### PR TITLE
Migrate daemon locks from lock file to fcntl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@
   has been paused.
 - Fixes an issue where download errors would show a rev number instead of the Dropbox
   path.
+- Fixes a race condition when two processes try to start a sync daemon at the same time.
 - Fixes an issue in the macOS GUI where updating the displayed sync issues could fail.
+
+#### Removed:
+
+- Removed `lockfile` dependency.
 
 ## v1.0.2
 

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -1129,4 +1129,4 @@ def notify_snooze(config_name: str, minutes: int):
             click.echo(f'Notifications snoozed for {minutes} min. '
                        'Set snooze to 0 to reset.')
         else:
-            click.echo(f'Notifications enabled.')
+            click.echo('Notifications enabled.')

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -838,14 +838,14 @@ def rebuild_index(config_name: str):
 @main.command(help_priority=16)
 def configs():
     """Lists all configured Dropbox accounts."""
-    from maestral.daemon import get_maestral_pid
+    from maestral.daemon import is_running
 
     # clean up stale configs
     config_names = list_configs()
 
     for name in config_names:
         dbid = MaestralConfig(name).get('account', 'account_id')
-        if dbid == '' and not get_maestral_pid(name):
+        if dbid == '' and not is_running(name):
             remove_configuration(name)
 
     # display remaining configs

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -445,16 +445,10 @@ def gui(config_name):
 def start(config_name: str, foreground: bool, verbose: bool):
     """Starts the Maestral daemon."""
 
-    from maestral.daemon import get_maestral_pid, get_maestral_proxy
+    from maestral.daemon import get_maestral_proxy
     from maestral.daemon import (start_maestral_daemon_thread, threads,
                                  start_maestral_daemon_process, Start)
 
-    # do nothing if already running
-    if get_maestral_pid(config_name):
-        click.echo('Maestral daemon is already running.')
-        return
-
-    # start daemon
     click.echo('Starting Maestral...', nl=False)
 
     if foreground:
@@ -464,6 +458,9 @@ def start(config_name: str, foreground: bool, verbose: bool):
 
     if res == Start.Ok:
         click.echo('\rStarting Maestral...        ' + OK)
+    elif res == Start.AlreadyRunning:
+        click.echo('\rStarting Maestral...        Already running.')
+        return
     else:
         click.echo('\rStarting Maestral...        ' + FAILED)
         click.echo('Please check logs for more information.')

--- a/maestral/daemon.py
+++ b/maestral/daemon.py
@@ -105,18 +105,20 @@ def _get_lockdata():
         fmt = off_t + off_t + pid_t + 'hh'
         pid_index = 2
         lockdata = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0)
-    elif sys.platform.startswith('gnukfreebsd'):
-        fmt = 'qqihhi'
-        pid_index = 2
-        lockdata = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0, 0)
-    elif sys.platform in ('hp-uxB', 'unixware7'):
-        fmt = 'hhlllii'
-        pid_index = 2
-        lockdata = struct.pack(fmt, fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)
-    else:
+    # elif sys.platform.startswith('gnukfreebsd'):
+    #     fmt = 'qqihhi'
+    #     pid_index = 2
+    #     lockdata = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0, 0)
+    # elif sys.platform in ('hp-uxB', 'unixware7'):
+    #     fmt = 'hhlllii'
+    #     pid_index = 2
+    #     lockdata = struct.pack(fmt, fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)
+    elif sys.platform.startswith('linux'):
         fmt = 'hh' + start_len + 'ih'
         pid_index = 4
         lockdata = struct.pack(fmt, fcntl.F_WRLCK, 0, 0, 0, 0, 0)
+    else:
+        raise RuntimeError(f'Unsupported platform {sys.platform}')
 
     return lockdata, fmt, pid_index
 

--- a/maestral/daemon.py
+++ b/maestral/daemon.py
@@ -264,7 +264,7 @@ def sockpath_for_config(config_name):
 
 
 def lockpath_for_config(config_name):
-    return get_runtime_path('maestral',  f'{config_name}.lock')
+    return get_runtime_path('maestral', f'{config_name}.lock')
 
 
 def get_maestral_pid(config_name):

--- a/setup.py
+++ b/setup.py
@@ -1,35 +1,11 @@
 # -*- coding: utf-8 -*-
 
 # system imports
-import sys
-import os.path as osp
 from setuptools import setup, find_packages
 import importlib.util
 
 # local imports (must not depend on 3rd party packages)
 from maestral import __version__, __author__, __url__
-from maestral.utils.appdirs import get_runtime_path
-from maestral.config.base import list_configs
-
-
-# abort install if there are running daemons
-running_daemons = []
-
-for config in list_configs():
-    pid_file = get_runtime_path('maestral', config + '.pid')
-    if osp.exists(pid_file):
-        running_daemons.append(config)
-
-if running_daemons:
-    sys.stderr.write(f"""
-Maestral daemons with the following configs are running:
-
-{', '.join(running_daemons)}
-
-Please stop the daemons before updating to ensure a clean upgrade
-of config files and compatibility been the CLI and daemon.
-    """)
-    sys.exit(1)
 
 
 # proceed with actual install
@@ -42,7 +18,7 @@ install_requires = [
     'jeepney;sys_platform=="linux"',
     'keyring>=19.0.0',
     'keyrings.alt>=3.1.0',
-    'lockfile>=0.12.0',
+    'fasteners',
     'packaging',
     'pathspec>=0.5.8',
     'Pyro5>=5.7',


### PR DESCRIPTION
Migrate from lockfile to fasteners which use POSIX fcntl locks. This has the following advantages:

- Locks are always released when the process quits, even on segfaults.
- PID of locking process can be retrieved from kernel instead of reading from lockfile.
- No race conditions on startup or quit.