### PR TITLE
CLI "recent-changes" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added an option `--external` to `maestral log show` to open the log in the platform's
   default program instead of showing it in the console.
+- Added a CLI command `recent-changes` to list recently added or modified files. Deletions
+  or added folders will not be shown.
 
 ## v1.1.0
 

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -952,7 +952,7 @@ def recent_changes(config_name: str):
     """Shows a list of recent file changes."""
 
     from maestral.daemon import MaestralProxy
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     with MaestralProxy(config_name, fallback=True) as m:
 
@@ -960,13 +960,12 @@ def recent_changes(config_name: str):
         paths = []
         last_modified = []
         for e in changes_dict:
-            paths.append(m.to_local_path(e['path_display']))
+            paths.append(e['path_display'])
 
-            dt = datetime.strptime(e['client_modified'], '%Y-%m-%dT%H:%M:%SZ')
-            dt = dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
+            dt = datetime.fromtimestamp(e['client_modified'])  # convert to local time
             last_modified.append(dt.strftime('%d %b %Y %H:%M'))
 
-        click.echo('\n' + format_table(columns=[paths, last_modified]) + '\n')
+        click.echo(format_table(columns=[paths, last_modified]))
 
 
 @main.command(help_priority=19)

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -910,6 +910,7 @@ def rebuild_index(config_name: str):
 @catch_maestral_errors
 def revs(dropbox_path: str, config_name: str):
     """Lists old revisions of a file."""
+
     from datetime import datetime, timezone
     from maestral.daemon import MaestralProxy
 
@@ -946,6 +947,29 @@ def restore(dropbox_path: str, rev: str, config_name: str):
 
 
 @main.command(help_priority=18)
+@existing_config_option
+def recent_changes(config_name: str):
+    """Shows a list of recent file changes."""
+
+    from maestral.daemon import MaestralProxy
+    from datetime import datetime, timezone
+
+    with MaestralProxy(config_name, fallback=True) as m:
+
+        changes_dict = m.get_state('sync', 'recent_changes')
+        paths = []
+        last_modified = []
+        for e in changes_dict:
+            paths.append(m.to_local_path(e['path_display']))
+
+            dt = datetime.strptime(e['client_modified'], '%Y-%m-%dT%H:%M:%SZ')
+            dt = dt.replace(tzinfo=timezone.utc).astimezone(tz=None)
+            last_modified.append(dt.strftime('%d %b %Y %H:%M'))
+
+        click.echo('\n' + format_table(columns=[paths, last_modified]) + '\n')
+
+
+@main.command(help_priority=19)
 def configs():
     """Lists all configured Dropbox accounts."""
     from maestral.daemon import is_running
@@ -967,7 +991,7 @@ def configs():
     click.echo('')
 
 
-@main.command(help_priority=20)
+@main.command(help_priority=21)
 @click.option('--yes', '-Y', is_flag=True, default=False)
 @click.option('--no', '-N', is_flag=True, default=False)
 @existing_config_option
@@ -1001,7 +1025,7 @@ def analytics(yes: bool, no: bool, config_name: str):
         click.echo(f'Automatic error reports are {enabled_str}.')
 
 
-@main.command(help_priority=22)
+@main.command(help_priority=23)
 @existing_config_option
 def account_info(config_name: str):
     """Shows your Dropbox account information."""
@@ -1023,7 +1047,7 @@ def account_info(config_name: str):
         click.echo('')
 
 
-@main.command(help_priority=23)
+@main.command(help_priority=24)
 def about():
     """Returns the version number and other information."""
     import time

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -949,7 +949,7 @@ def restore(dropbox_path: str, rev: str, config_name: str):
 @main.command(help_priority=18)
 @existing_config_option
 def recent_changes(config_name: str):
-    """Shows a list of recent file changes."""
+    """Shows a list of recently changed or added files."""
 
     from maestral.daemon import MaestralProxy
     from datetime import datetime

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -911,7 +911,7 @@ def rebuild_index(config_name: str):
 def revs(dropbox_path: str, config_name: str):
     """Lists old revisions of a file."""
 
-    from datetime import datetime, timezone
+    from datetime import datetime
     from maestral.daemon import MaestralProxy
 
     with MaestralProxy(config_name, fallback=True) as m:
@@ -1150,9 +1150,9 @@ def log_show(external: bool, config_name: str):
     from maestral.utils.appdirs import get_log_path
 
     log_file = get_log_path('maestral', config_name + '.log')
- 
+
     if external:
-         res = click.launch(log_file)
+        res = click.launch(log_file)
     else:
         try:
             with open(log_file) as f:

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -29,7 +29,7 @@ import functools
 from enum import IntEnum
 import pprint
 import socket
-from datetime import datetime, timezone
+from datetime import timezone
 
 # external imports
 import pathspec


### PR DESCRIPTION
This PR introduces a CLI command "recent-changes" to display the last 30 file changes with server modified times. It also includes the necessary backend modifications to store server modified times in the file history.