### PR TITLE
Use short-lived oauth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added an option `--external` to `maestral log show` to open the log in the platform's
   default program instead of showing it in the console.
+  
+#### Changed:
+
+- Transition to short-lived auth tokens for newly linked accounts.
 
 ## v1.1.0
 

--- a/maestral/cli.py
+++ b/maestral/cli.py
@@ -620,10 +620,11 @@ def status(config_name: str):
             color = 'red' if n_errors > 0 else 'green'
             n_errors_str = click.style(str(n_errors), fg=color)
             click.echo('')
-            click.echo('Account:       {}'.format(m.get_state('account', 'email')))
-            click.echo('Usage:         {}'.format(m.get_state('account', 'usage')))
-            click.echo('Status:        {}'.format(m.status))
-            click.echo('Sync errors:   {}'.format(n_errors_str))
+            click.echo('Account:      {}'.format(m.get_state('account', 'email')))
+            click.echo('Usage:        {}'.format(m.get_state('account', 'usage')))
+            click.echo('Status:       {}'.format(m.status))
+            click.echo('Sync threads: {}'.format('Running' if m.running else 'Stopped'))
+            click.echo('Sync errors:  {}'.format(n_errors_str))
             click.echo('')
 
             check_for_fatal_errors(m)

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -144,7 +144,8 @@ class DropboxClient:
 
     SDK_VERSION = '2.0'
 
-    def __init__(self, config_name, refresh_token, timeout=100):
+    def __init__(self, config_name, refresh_token=None, access_token=None,
+                 access_token_expiration=None, timeout=100):
 
         self.config_name = config_name
 
@@ -153,26 +154,32 @@ class DropboxClient:
         self._state = MaestralState(config_name)
 
         # initialize API client
-        self.dbx = Dropbox(
-            app_key=DROPBOX_APP_KEY,
-            oauth2_refresh_token=refresh_token,
-            session=SESSION,
-            user_agent=USER_AGENT,
-            timeout=self._timeout
-        )
+        self.set_token(refresh_token, access_token, access_token_expiration)
 
     def set_token(self, refresh_token=None, access_token=None,
                   access_token_expiration=None):
+        """
+        Sets the access tokens for the Dropbox API. This will create a new SDK instance
+        with new tokens.
 
-        self.dbx = Dropbox(
-            oauth2_refresh_token=refresh_token,
-            oauth2_access_token=access_token,
-            oauth2_access_token_expiration=access_token_expiration,
-            app_key=DROPBOX_APP_KEY,
-            session=SESSION,
-            user_agent=USER_AGENT,
-            timeout=self._timeout
-        )
+        :param str refresh_token: Long-lived refresh token to generate new access tokens.
+        :param str access_token: Short-lived auth token.
+        :param datetime | int access_token_expiration: Expiry time of auth token.
+        """
+
+        if refresh_token or access_token:
+
+            self.dbx = Dropbox(
+                oauth2_refresh_token=refresh_token,
+                oauth2_access_token=access_token,
+                oauth2_access_token_expiration=access_token_expiration,
+                app_key=DROPBOX_APP_KEY,
+                session=SESSION,
+                user_agent=USER_AGENT,
+                timeout=self._timeout
+            )
+        else:
+            self.dbx = None
 
     @to_maestral_error()
     def get_account_info(self, dbid=None):

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -148,8 +148,9 @@ class DropboxClient:
 
         self.config_name = config_name
 
-        self._state = MaestralState(config_name)
+        self._timeout = timeout
         self._backoff_until = 0
+        self._state = MaestralState(config_name)
 
         # initialize API client
         self.dbx = Dropbox(
@@ -157,17 +158,21 @@ class DropboxClient:
             oauth2_refresh_token=refresh_token,
             session=SESSION,
             user_agent=USER_AGENT,
-            timeout=timeout
+            timeout=self._timeout
         )
 
-    def set_token(self, refresh_token=None, access_token=None, expires_at=None):
+    def set_token(self, refresh_token=None, access_token=None,
+                  access_token_expiration=None):
 
-        if not (access_token or refresh_token):
-            raise BadInputException('OAuth2 access token or refresh token must be set')
-
-        self.dbx._oauth2_access_token = access_token
-        self.dbx._oauth2_refresh_token = refresh_token
-        self.dbx._oauth2_access_token_expiration = expires_at
+        self.dbx = Dropbox(
+            oauth2_refresh_token=refresh_token,
+            oauth2_access_token=access_token,
+            oauth2_access_token_expiration=access_token_expiration,
+            app_key=DROPBOX_APP_KEY,
+            session=SESSION,
+            user_agent=USER_AGENT,
+            timeout=self._timeout
+        )
 
     @to_maestral_error()
     def get_account_info(self, dbid=None):

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -21,7 +21,6 @@ from datetime import datetime, timezone
 # external imports
 import requests
 from dropbox import Dropbox, dropbox, files, users, exceptions
-from dropbox.dropbox import BadInputException
 
 # local imports
 from maestral import __version__

--- a/maestral/config/main.py
+++ b/maestral/config/main.py
@@ -61,7 +61,8 @@ DEFAULTS_STATE = [
          'abbreviated_name': '',
          'type': '',
          'usage': '',
-         'usage_type': '',
+         'usage_type': '',  # private vs business
+         'token_access_type': 'legacy',  # this will be updated on completed OAuth
      }
      ),
     ('app',  # app state

--- a/maestral/config/main.py
+++ b/maestral/config/main.py
@@ -62,7 +62,7 @@ DEFAULTS_STATE = [
          'type': '',
          'usage': '',
          'usage_type': '',  # private vs business
-         'token_access_type': 'legacy',  # this will be updated on completed OAuth
+         'token_access_type': 'legacy',  # will be updated on completed OAuth
      }
      ),
     ('app',  # app state

--- a/maestral/config/main.py
+++ b/maestral/config/main.py
@@ -34,6 +34,7 @@ DEFAULTS = [
     ('account',
      {
          'account_id': '',  # dropbox account id, must match the saved account key
+         'token_access_type': 'legacy',  # will be updated on completed OAuth
      }
      ),
     ('app',
@@ -62,7 +63,6 @@ DEFAULTS_STATE = [
          'type': '',
          'usage': '',
          'usage_type': '',  # private vs business
-         'token_access_type': 'legacy',  # will be updated on completed OAuth
      }
      ),
     ('app',  # app state

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -1259,7 +1259,8 @@ class Maestral:
 
     def _periodic_refresh(self):
         while True:
-            if not self.pending_link:
+            # update account info
+            if self.client.dbx:
                 self.get_account_info()
                 self.get_profile_pic()
             # check for maestral updates

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -262,7 +262,7 @@ class Maestral:
             self.client.set_token(
                 refresh_token=self._auth.refresh_token,
                 access_token=self._auth.access_token,
-                expires_at=self._auth.expires_at,
+                access_token_expiration=self._auth.access_token_expiration,
             )
 
             try:

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -569,23 +569,15 @@ class Maestral:
         Bool indicating if Maestral is syncing (read only). It will be ``True`` if syncing
         is not paused by the user *and* Maestral is connected to the internet.
         """
-
-        if self.pending_link:
-            return False
-        else:
-            return (self.monitor.syncing.is_set()
-                    or self.monitor.startup.is_set()
-                    or self.sync.busy())
+        return (self.monitor.syncing.is_set()
+                or self.monitor.startup.is_set()
+                or self.sync.busy())
 
     @property
     def paused(self):
         """Bool indicating if syncing is paused by the user (read only). This is set by
         calling :meth:`pause`."""
-
-        if self.pending_link:
-            return False
-        else:
-            return self.monitor.paused_by_user.is_set() and not self.sync.busy()
+        return self.monitor.paused_by_user.is_set() and not self.sync.busy()
 
     @property
     def running(self):
@@ -593,11 +585,7 @@ class Maestral:
         Bool indicating if sync threads are running (read only). They will be stopped
         before :meth:`start_sync` is called, when shutting down or because of an exception.
         """
-
-        if self.pending_link:
-            return False
-        else:
-            return self.monitor.running.is_set() or self.sync.busy()
+        return self.monitor.running.is_set() or self.sync.busy()
 
     @property
     def connected(self):

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -9,7 +9,6 @@ This module defines the main API which is exposed to the CLI or GUI.
 """
 
 # system imports
-import functools
 import sys
 import os
 import os.path as osp

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -194,7 +194,7 @@ class Maestral:
         self._setup_logging()
 
         self._auth = OAuth2Session(config_name)
-        self.client = DropboxClient(config_name=self.config_name, refresh_token='none')
+        self.client = DropboxClient(config_name=self.config_name)
         self.monitor = SyncMonitor(self.client)
         self.sync = self.monitor.sync
 
@@ -540,14 +540,14 @@ class Maestral:
 
         if self._auth.token_access_type == 'legacy':
             access_token = self._auth.access_token  # triggers keyring access
-            if access_token:
+            if not self.client.dbx and access_token:
                 self.client.set_token(access_token=access_token)
 
             return not access_token
 
         else:
             refresh_token = self._auth.refresh_token  # triggers keyring access
-            if refresh_token:
+            if not self.client.dbx and refresh_token:
                 self.client.set_token(refresh_token=refresh_token)
 
             return not refresh_token

--- a/maestral/oauth.py
+++ b/maestral/oauth.py
@@ -174,7 +174,7 @@ class OAuth2Session:
             return self._refresh_token
 
     @property
-    def expires_at(self):
+    def access_token_expiration(self):
         """Returns the expiry time for the short-lived access token. This will only be
         set for an 'offline' token and if we completed the flow during the current
         session."""

--- a/maestral/oauth.py
+++ b/maestral/oauth.py
@@ -127,7 +127,7 @@ class OAuth2Session:
 
     @token_access_type.setter
     def token_access_type(self, value):
-        self._state.get('account', 'token_access_type', value)
+        self._state.set('account', 'token_access_type', value)
 
     @property
     def account_id(self):

--- a/maestral/oauth.py
+++ b/maestral/oauth.py
@@ -106,6 +106,7 @@ class OAuth2Session:
     ConnectionFailed = 2
 
     default_token_access_type = 'offline'
+    _supported_token_access_types = ('offline', 'legacy')
 
     _lock = RLock()
 
@@ -140,6 +141,10 @@ class OAuth2Session:
 
     @token_access_type.setter
     def token_access_type(self, value):
+
+        if value not in self._supported_token_access_types:
+            raise ValueError('Token type must be "offline" or "legacy"')
+
         self._conf.set('account', 'token_access_type', value)
 
     @property

--- a/maestral/oauth.py
+++ b/maestral/oauth.py
@@ -201,10 +201,11 @@ class OAuth2Session:
 
             self._loaded = True
         except KeyringLocked:
-            info = f'Could not load token. {self.keyring.name} is locked.'
-            logger.error(info)
-            raise KeyringAccessError('Could not load token',
-                                     f'{self.keyring.name} is locked.')
+            title = f'Could not load auth token, {self.keyring.name} is locked'
+            msg = 'Please unlock the keyring and try again.'
+            exc = KeyringAccessError(title, msg)
+            logger.error(title, exc_info=_exc_info(exc))
+            raise exc
 
     def get_auth_url(self):
         """
@@ -278,11 +279,16 @@ class OAuth2Session:
                 self.keyring.delete_password('Maestral', self._account_id)
                 click.echo(' > Credentials removed.')
             except KeyringLocked:
-                info = f'Could not delete token. {self.keyring.name} is locked.'
-                logger.error(info)
-                raise KeyringAccessError('Could not delete token',
-                                         f'{self.keyring.name} is locked.')
+                title = f'Could not delete auth token, {self.keyring.name} is locked'
+                msg = 'Please unlock the keyring and try again.'
+                exc = KeyringAccessError(title, msg)
+                logger.error(title, exc_info=_exc_info(exc))
+                raise exc
             finally:
                 self._account_id = None
                 self._access_token = None
                 self._refresh_token = None
+
+
+def _exc_info(exc):
+    return type(exc), exc, exc.__traceback__

--- a/maestral/oauth.py
+++ b/maestral/oauth.py
@@ -22,7 +22,7 @@ import requests
 from dropbox.oauth import DropboxOAuth2FlowNoRedirect
 
 # local imports
-from maestral.config import MaestralConfig, MaestralState
+from maestral.config import MaestralConfig
 from maestral.constants import DROPBOX_APP_KEY
 from maestral.client import CONNECTION_ERRORS
 from maestral.errors import KeyringAccessError
@@ -115,7 +115,6 @@ class OAuth2Session:
 
         self.keyring = get_keyring_backend(config_name)
         self._conf = MaestralConfig(config_name)
-        self._state = MaestralState(config_name)
 
         self._auth_flow = DropboxOAuth2FlowNoRedirect(
             self._app_key,
@@ -137,11 +136,11 @@ class OAuth2Session:
         """Returns the type of access token. If 'legacy', we have a long-lived access
         token. If 'offline', we have a short-lived access token with an expiry time and
         a long-lived refresh token to generate new access tokens."""
-        return self._state.get('account', 'token_access_type')
+        return self._conf.get('account', 'token_access_type')
 
     @token_access_type.setter
     def token_access_type(self, value):
-        self._state.set('account', 'token_access_type', value)
+        self._conf.set('account', 'token_access_type', value)
 
     @property
     def account_id(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,6 +30,8 @@ class TestAPI(TestCase):
         cls.m = Maestral('test-config')
         cls.m._auth._account_id = os.environ.get('DROPBOX_ID', '')
         cls.m._auth._access_token = os.environ.get('DROPBOX_TOKEN', '')
+        cls.m._auth._loaded = True
+        cls.m._auth.token_access_type = 'legacy'
         cls.m.create_dropbox_directory('~/Dropbox_Test')
 
         # all our tests will be carried out within this folder

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -385,6 +385,8 @@ class TestSync(TestCase):
         cls.m = Maestral('test-config')
         cls.m._auth._account_id = os.environ.get('DROPBOX_ID', '')
         cls.m._auth._access_token = os.environ.get('DROPBOX_TOKEN', '')
+        cls.m._auth._loaded = True
+        cls.m._auth.token_access_type = 'legacy'
         cls.m.create_dropbox_directory('~/Dropbox_Test')
 
         # all our tests will be carried out within this folder


### PR DESCRIPTION
Dropbox recently introduced short-lived oauth tokens to replace the previously long-lived tokens and will deprecate the old auth tokens in mid 2021. This PR introduces support in Maestral for short-lived tokens which are always used to link new accounts. Previously linked accounts will continue to use long-lived tokens until a future update.