### PR TITLE
Keep rev index in SQLite database

### DIFF
--- a/maestral/daemon.py
+++ b/maestral/daemon.py
@@ -74,7 +74,7 @@ def freeze_support() -> None:
 class Stop(enum.Enum):
     """
     Enumeration of daemon exit results.
-    
+
     :cvar Ok: Daemon quit successfully.
     :cvar Killed: Daemon process was killed.
     :cvar NotRunning: Daemon was not running.

--- a/maestral/daemon.py
+++ b/maestral/daemon.py
@@ -28,7 +28,7 @@ from typing import Optional, Union, Tuple, Dict, Type, TYPE_CHECKING
 from types import TracebackType, FrameType
 
 # external imports
-import Pyro5
+import Pyro5  # type: ignore
 from Pyro5.errors import CommunicationError  # type: ignore
 from Pyro5.api import Daemon, Proxy, expose, oneway, register_dict_to_class  # type: ignore
 from fasteners import InterProcessLock  # type: ignore

--- a/maestral/errors.py
+++ b/maestral/errors.py
@@ -173,7 +173,7 @@ class OutOfMemoryError(MaestralApiError):
     pass
 
 
-class RevFileError(MaestralApiError):
+class DatabaseError(MaestralApiError):
     """Raised when reading or saving the rev file fails."""
     pass
 
@@ -234,7 +234,7 @@ FATAL_ERRORS = (
     NoDropboxDirError,
     InotifyError,
     RestrictedContentError,
-    RevFileError,
+    DatabaseError,
     DropboxAuthError,
     TokenExpiredError,
     TokenRevokedError,

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -321,7 +321,7 @@ class Maestral:
 
         # clean up config + state
         self.sync.clear_rev_index()
-        self.sync.clear_database()
+        self.sync.clear_sync_history()
         self._conf.cleanup()
         self._state.cleanup()
 

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -1015,7 +1015,7 @@ class Maestral:
 
         # book keeping
         self.sync.clear_sync_error(dbx_path=dbx_path)
-        self.sync.set_local_rev(dbx_path, None)
+        self.sync._remove_from_index(dbx_path)
 
         # remove folder from local drive
         local_path = self.sync.to_local_path(dbx_path)

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -1015,7 +1015,7 @@ class Maestral:
 
         # book keeping
         self.sync.clear_sync_error(dbx_path=dbx_path)
-        self.sync._remove_from_index(dbx_path)
+        self.sync.remove_path_from_index(dbx_path)
 
         # remove folder from local drive
         local_path = self.sync.to_local_path(dbx_path)

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -1011,7 +1011,7 @@ class Maestral:
         self.sync.remove_path_from_index(dbx_path)
 
         # remove folder from local drive
-        local_path = self.sync.to_local_path(dbx_path)
+        local_path = self.sync.to_local_path_from_cased(dbx_path)
         # dbx_path will be lower-case, we there explicitly run `to_cased_path`
         local_path = to_cased_path(local_path)
         if local_path:
@@ -1237,7 +1237,7 @@ class Maestral:
         self._check_linked()
         self._check_dropbox_dir()
 
-        return self.sync.to_local_path(dbx_path)
+        return self.sync.to_local_path_from_cased(dbx_path)
 
     def check_for_updates(self) -> Dict[str, Union[str, bool, None]]:
         """

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -47,7 +47,7 @@ from maestral.errors import (
 from maestral.config import MaestralConfig, MaestralState
 from maestral.utils import get_newer_version
 from maestral.utils.housekeeping import validate_config_name
-from maestral.utils.path import is_child, to_cased_path, delete
+from maestral.utils.path import is_child, to_existing_cased_path, delete
 from maestral.utils.notify import MaestralDesktopNotifier
 from maestral.utils.serializer import (
     error_to_dict, dropbox_stone_to_dict, sync_event_to_dict, StoneType, ErrorType
@@ -1012,9 +1012,12 @@ class Maestral:
 
         # remove folder from local drive
         local_path = self.sync.to_local_path_from_cased(dbx_path)
-        # dbx_path will be lower-case, we there explicitly run `to_cased_path`
-        local_path = to_cased_path(local_path)
-        if local_path:
+        # dbx_path will be lower-case, we there explicitly run `to_existing_cased_path`
+        try:
+            local_path = to_existing_cased_path(local_path)
+        except FileNotFoundError:
+            pass
+        else:
             event_cls = DirDeletedEvent if osp.isdir(local_path) else FileDeletedEvent
             with self.monitor.fs_event_handler.ignore(event_cls(local_path)):
                 delete(local_path)

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -314,19 +314,12 @@ class Maestral:
         except (ConnectionError, MaestralApiError):
             pass
 
-        state_files = [
-            self.sync.rev_file_path,
-            self.sync.database_path,
-        ]
-
         # clean up config + state
-        self.sync.clear_rev_index()
+        self.sync.clear_index()
         self.sync.clear_sync_history()
         self._conf.cleanup()
         self._state.cleanup()
-
-        for file in state_files:
-            delete(file)
+        delete(self.sync.database_path)
 
         # delete auth token
         try:

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -415,11 +415,11 @@ class SyncEvent(Base):  # type: ignore
     :param direction: Direction of the sync: upload or download.
     :param item_type: The item type: file or folder.
     :param sync_time: The time the sync event was registered.
-    :param dbx_path: Dropbox path of the item to sync. If the sync represents a move
-        operation, this will be the destination path. The path does not need to be
-        correctly cased apart from the basename.
     :param dbx_id: A unique dropbox ID for the file or folder. Will only be set for
         download events which are not deletions.
+    :param dbx_path: Dropbox path of the item to sync. If the sync represents a move
+        operation, this will be the destination path. The basename must always be
+        correctly cased but the full path may not be.
     :param dbx_path_from: Dropbox path that this item was moved from. Will only be set if
         ``change_type`` is ``ChangeType.Moved``. The same rules for casing as for
         ``dbx_path`` apply.
@@ -448,7 +448,7 @@ class SyncEvent(Base):  # type: ignore
     :param completed: File size in bytes which has already been uploaded or downloaded.
         Always zero for folders.
 
-    :ivar id: A unique identifier of the sync item.
+    :ivar id: A unique identifier of the sync event.
     :ivar change_time_or_sync_time: Change time when available, otherwise sync time. This
         can be used for sorting or user information purposes.
     """
@@ -528,6 +528,25 @@ class SyncEvent(Base):  # type: ignore
 
 
 class IndexEntry(Base):  # type: ignore
+    """
+    Represents an entry in our local sync index.
+
+    :param dbx_path: Dropbox path of the item. The basename must always be correctly cased
+        but the full path may not be.
+    :param dbx_path_lower: Dropbox path of the item in lower case. This acts as a primary
+        key for the SQL database since there can only be one entry per case-insensitive
+        Dropbox path.
+    :param dbx_id: A unique dropbox ID for the file or folder.
+    :param item_type: The item type: file or folder.
+    :param last_sync: The last time a local change was uploaded. Should be the ctime of
+        the local file or folder.
+    :param rev: The file revision. Will be 'folder' for folders.
+    :param content_hash: A hash representing the file content. Will be 'folder' for
+        folders. May be None if not yet calculated.
+    :param content_hash_ctime: The ctime for which the content_hash was calculated. If
+        this is older than the current ctime, the content_hash will be invalid and has to
+        recalculated.
+    """
 
     __tablename__ = 'index'
 

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -17,7 +17,6 @@ import logging
 import time
 import tempfile
 import random
-import json
 from threading import Thread, Event, RLock, current_thread
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from queue import Queue, Empty

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -51,7 +51,6 @@ from watchdog.events import (
     DirDeletedEvent, FileDeletedEvent, DirMovedEvent, FileMovedEvent, FileSystemEvent
 )
 from watchdog.utils.dirsnapshot import DirectorySnapshot  # type: ignore
-from atomicwrites import atomic_write
 
 # local imports
 from maestral.config import MaestralConfig, MaestralState

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -864,10 +864,12 @@ class SyncEngine:
             return query.order_by(SyncEvent.change_time_or_sync_time).all()
 
     def clear_sync_history(self):
-        SyncEvent.metadata.drop_all(self._db_engine)
-        Base.metadata.create_all(self._db_engine)
+        with self._db_lock:
+            SyncEvent.metadata.drop_all(self._db_engine)
+            Base.metadata.create_all(self._db_engine)
+            self._db_session.expunge_all()
 
-    # ==== rev file management ===========================================================
+    # ==== index management ==============================================================
 
     def get_index(self) -> List[IndexEntry]:
         """
@@ -1006,6 +1008,7 @@ class SyncEngine:
         with self._db_lock:
             IndexEntry.metadata.drop_all(self._db_engine)
             Base.metadata.create_all(self._db_engine)
+            self._db_session.expunge_all()
 
     # ==== mignore management ============================================================
 

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -2358,7 +2358,7 @@ class SyncEngine:
                 logger.debug('Skipping deletion: remote item "%s" has been modified '
                              'since last sync', md.path_display)
                 # mark local folder as untracked
-                self._remove_from_index(dbx_path)
+                self._remove_from_index(event.dbx_path)
                 return None
 
         if event.is_file and isinstance(md, FolderMetadata):
@@ -2369,7 +2369,7 @@ class SyncEngine:
             logger.debug('Skipping deletion: expected file at "%s" but found a '
                          'folder instead', md.path_display)
             # mark local file as untracked
-            self._remove_from_index(dbx_path)
+            self._remove_from_index(event.dbx_path)
             return None
 
         try:
@@ -3192,7 +3192,6 @@ def download_worker(sync: SyncEngine, syncing: Event,
                     logger.info(IDLE)
 
                     sync.client.get_space_usage()
-
 
         except ConnectionError:
             syncing.clear()

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -67,7 +67,7 @@ from maestral.client import DropboxClient, os_to_maestral_error, fswatch_to_maes
 from maestral.utils.content_hasher import DropboxContentHasher
 from maestral.utils.notify import MaestralDesktopNotifier
 from maestral.utils.path import (
-    generate_cc_name, cased_path_candidates, to_cased_path, is_fs_case_sensitive,
+    generate_cc_name, cased_path_candidates, is_fs_case_sensitive,
     move, delete, is_child, is_equal_or_child
 )
 from maestral.utils.appdirs import get_data_path, get_home_dir

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -60,8 +60,8 @@ from maestral.constants import (
     EXCLUDED_DIR_NAMES, MIGNORE_FILE, FILE_CACHE
 )
 from maestral.errors import (
-    SyncError, RevFileError, NoDropboxDirError, CacheDirError, InvalidDbidError,
-    PathError, NotFoundError, FileConflictError, FolderConflictError, IsAFolderError
+    SyncError, NoDropboxDirError, CacheDirError, InvalidDbidError, PathError,
+    NotFoundError, FileConflictError, FolderConflictError, IsAFolderError
 )
 from maestral.client import DropboxClient, os_to_maestral_error, fswatch_to_maestral_error
 from maestral.utils.content_hasher import DropboxContentHasher

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -529,7 +529,7 @@ class SyncEvent(Base):  # type: ignore
                f"change_type={self.change_type.name}, dbx_path='{self.dbx_path}')>"
 
 
-class IndexEntry(Base):
+class IndexEntry(Base):  # type: ignore
 
     __tablename__ = 'index'
 

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -1165,7 +1165,6 @@ class SyncEngine:
                                 'Please check if you have write permissions for '
                                 f'{self._file_cache_path}.')
 
-    # TODO: test this
     def correct_case(self, dbx_path: str) -> str:
         """
         Converts a Dropbox path with correctly cased basename to a fully cased path.

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -1621,15 +1621,15 @@ class SyncEngine:
 
                 # always upload untracked items, check ctime of tracked items
                 local_entry = self.get_local_entry(dbx_path_lower)
-                is_new = not local_entry
                 is_modified = local_entry and ctime_check
 
-                if is_new:
+                if not local_entry:
                     if snapshot.isdir(path):
                         event = DirCreatedEvent(path)
                     else:
                         event = FileCreatedEvent(path)
                     changes.append(event)
+
                 elif is_modified:
                     if snapshot.isdir(path) and local_entry.is_directory:
                         event = DirModifiedEvent(path)
@@ -2315,12 +2315,12 @@ class SyncEngine:
 
         local_entry = self.get_local_entry(event.dbx_path)
 
-        if local_entry.is_directory:
-            mode = dropbox.files.WriteMode.overwrite
-        elif not local_entry:
+        if not local_entry:
             logger.debug('"%s" appears to have been modified but cannot '
                          'find old revision', event.dbx_path)
             mode = dropbox.files.WriteMode.add
+        elif local_entry.is_directory:
+            mode = dropbox.files.WriteMode.overwrite
         else:
             mode = dropbox.files.WriteMode.update(local_entry.rev)
 

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -539,6 +539,10 @@ class IndexEntry(Base):  # type: ignore
     content_hash = Column(String)
     content_hash_ctime = Column(Float)
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(item_type={self.item_type.name}, " \
+               f"dbx_path='{self.dbx_path}')>"
+
 
 class SyncEngine:
     """

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -1194,14 +1194,13 @@ class SyncEngine:
 
                     else:
                         # fall back to querying from server
-                        try:
-                            md_parent = self.client.get_metadata(dirname_lower)
-                        except LookupError:
-                            # give up
-                            parent_path_cased = osp.dirname(dbx_path)
-                        else:
+                        md_parent = self.client.get_metadata(dirname_lower)
+                        if md_parent:
                             # recurse over parent directories
                             parent_path_cased = self.correct_case(md_parent.path_display)
+                        else:
+                            # give up
+                            parent_path_cased = osp.dirname(dbx_path)
 
                 path_cased = f'{parent_path_cased}/{basename_cased}'
             else:

--- a/maestral/utils/notify.py
+++ b/maestral/utils/notify.py
@@ -182,7 +182,7 @@ class MaestralDesktopNotifier(logging.Handler):
 
     def notify(self, message: str, level: int = FILECHANGE,
                on_click: Optional[Callable] = None,
-               buttons: Optional[Dict[str, Callable]] = None) -> None:
+               buttons: Optional[Dict[str, Optional[Callable]]] = None) -> None:
         """
         Sends a desktop notification from maestral. The title defaults to 'Maestral'.
 
@@ -206,7 +206,7 @@ class MaestralDesktopNotifier(logging.Handler):
                 icon=APP_ICON_PATH,
                 urgency=urgency,
                 action=on_click,
-                buttons=buttons or dict(),
+                buttons=buttons,
             )
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/maestral/utils/notify_base.py
+++ b/maestral/utils/notify_base.py
@@ -4,7 +4,7 @@
 
 (c) Sam Schott; This work is licensed under the MIT licence.
 
-This module defines base classes for desktop notifications. 
+This module defines base classes for desktop notifications.
 
 """
 
@@ -17,7 +17,7 @@ class NotificationLevel(Enum):
     """
     Enumeration of notification levels. The interpretation and visuals will depend
     on the platform.
-    
+
     :cvar Critical: For critical errors.
     :cvar Normal: Default platform notification level.
     :cvar Low: Low priority notification.

--- a/maestral/utils/path.py
+++ b/maestral/utils/path.py
@@ -166,7 +166,6 @@ def to_cased_path(path: str, root: str = osp.sep,
     :param bool is_fs_case_sensitive: Bool indicating if the file system is case
         sensitive. If ``False``, we know that there can be at most one match and choose a
         faster algorithm.
-    :returns: Candidates for c
     :returns: Absolute and cased version of given path.
     """
 

--- a/maestral/utils/path.py
+++ b/maestral/utils/path.py
@@ -155,10 +155,10 @@ def cased_path_candidates(path: str, root: str = osp.sep,
 def to_cased_path(path: str, root: str = osp.sep,
                   is_fs_case_sensitive: bool = True) -> str:
     """
-    Returns a cased version of the given path as far as corresponding nodes exist in the
-    given root directory. If multiple matches are found, only one is returned. If ``path``
-    does not exist in root ``root`` or ``root`` does not exist, the return value will be
-    ``os.path.join(root, path)``.
+    Returns a cased version of the given path as far as corresponding nodes (with
+    arbitrary casing) exist in the given root directory. If multiple matches are found,
+    only one is returned. If ``path`` does not exist in root ``root`` or ``root`` does not
+    exist, the return value will be ``os.path.join(root, path)``.
 
     :param str path: Original path relative to ``root``.
     :param str root: Parent directory to search in. There are significant performance
@@ -171,6 +171,33 @@ def to_cased_path(path: str, root: str = osp.sep,
 
     candidates = cased_path_candidates(path, root, is_fs_case_sensitive)
     return candidates[0]
+
+
+def to_existing_cased_path(path: str, root: str = osp.sep,
+                           is_fs_case_sensitive: bool = True) -> str:
+    """
+    Returns a cased version of the given path if corresponding nodes (with arbitrary
+    casing) exist in the given root directory. If multiple matches are found, only one is
+    returned.
+
+    :param str path: Original path relative to ``root``.
+    :param str root: Parent directory to search in. There are significant performance
+        improvements if a root directory with a small tree is given.
+    :param bool is_fs_case_sensitive: Bool indicating if the file system is case
+        sensitive. If ``False``, we know that there can be at most one match and choose a
+        faster algorithm.
+    :returns: Absolute and cased version of given path.
+    :raises: :class:`FileNotFoundError` if ``path`` does not exist in root ``root`` or
+        ``root`` itself does not exist.
+    """
+
+    candidates = cased_path_candidates(path, root, is_fs_case_sensitive)
+
+    for candidate in candidates:
+        if osp.exists(candidate):
+            return candidate
+
+    raise FileNotFoundError(f'No matches with different casing found in "{root}"')
 
 
 def path_exists_case_insensitive(path: str, root: str = osp.sep,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from maestral import __version__, __author__, __url__
 
 # proceed with actual install
 install_requires = [
-    'atomicwrites>=1.0.0',
     'bugsnag>=3.4.0',
     'click>=7.1.1',
     'dropbox>=10.0.0',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,7 +77,7 @@ class TestAPI(TestCase):
             pass
 
         delete(cls.m.dropbox_path)
-        delete(cls.m.sync.rev_file_path)
+        delete(cls.m.sync.database_path)
         delete(cls.m.account_profile_pic_path)
         cls.m._conf.cleanup()
         cls.m._state.cleanup()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -523,10 +523,10 @@ class TestSync(TestCase):
                              f'different revs for "{dbx_path}"')
 
         for entry in entries:
-            if is_child(entry.dbx_path, remote_folder):
-                matching_items = list(r for r in remote_items if r['path_lower'] == entry.dbx_path)
+            if is_child(entry.dbx_path_lower, remote_folder):
+                matching_items = list(r for r in remote_items if r['path_lower'] == entry.dbx_path_lower)
                 self.assertEqual(len(matching_items), 1,
-                                 f'indexed item "{entry.dbx_path}" does not exist on dbx')
+                                 f'indexed item "{entry.dbx_path_lower}" does not exist on dbx')
 
         for path in local_snapshot.paths:
             if not self.m.sync.is_excluded(path) and is_child(path, local_folder):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -516,7 +516,7 @@ class TestSync(TestCase):
         # assert that all items from server are present locally with the same content hash
         for r in remote_items:
             dbx_path = r['path_display']
-            local_path = self.m.to_local_path(dbx_path)
+            local_path = to_existing_cased_path(dbx_path, root=self.m.dropbox_path)
 
             remote_hash = r['content_hash'] if r['type'] == 'FileMetadata' else 'folder'
             self.assertEqual(self.m.sync.get_local_hash(local_path), remote_hash,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -455,7 +455,7 @@ class TestSync(TestCase):
             pass
 
         delete(cls.m.dropbox_path)
-        delete(cls.m.sync.rev_file_path)
+        delete(cls.m.sync.database_path)
         delete(cls.m.account_profile_pic_path)
         cls.m._conf.cleanup()
         cls.m._state.cleanup()
@@ -508,7 +508,7 @@ class TestSync(TestCase):
         """Asserts that the `local_folder` and `remote_folder` are synced."""
         remote_items = self.m.list_folder(remote_folder, recursive=True)
         local_snapshot = DirectorySnapshot(local_folder)
-        rev_index = self.m.sync.get_rev_index()
+        entries = self.m.sync.get_index()
 
         for r in remote_items:
             dbx_path = r['path_display']
@@ -522,11 +522,11 @@ class TestSync(TestCase):
             self.assertEqual(self.m.sync.get_local_rev(dbx_path), remote_rev,
                              f'different revs for "{dbx_path}"')
 
-        for path in rev_index:
-            if is_child(path, remote_folder):
-                matching_items = list(r for r in remote_items if r['path_lower'] == path)
+        for entry in entries:
+            if is_child(entry.dbx_path, remote_folder):
+                matching_items = list(r for r in remote_items if r['path_lower'] == entry.dbx_path)
                 self.assertEqual(len(matching_items), 1,
-                                 f'indexed item "{path}" does not exist on dbx')
+                                 f'indexed item "{entry.dbx_path}" does not exist on dbx')
 
         for path in local_snapshot.paths:
             if not self.m.sync.is_excluded(path) and is_child(path, local_folder):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -515,7 +515,7 @@ class TestSync(TestCase):
             local_path = self.m.to_local_path(dbx_path)
 
             remote_hash = r['content_hash'] if r['type'] == 'FileMetadata' else 'folder'
-            remote_rev = r['rev'] if r['type'] == 'FileMetadata' else 'folder'
+            remote_rev = r['rev'] if r['type'] == 'FileMetadata' else f'folder:{r["name"]}'
 
             self.assertEqual(self.m.sync.get_local_hash(local_path), remote_hash,
                              f'different file content for "{dbx_path}"')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -20,7 +20,7 @@ from maestral.sync import (
 )
 from maestral.sync import delete, move
 from maestral.sync import is_child, is_fs_case_sensitive
-from maestral.sync import get_local_hash, DirectorySnapshot
+from maestral.sync import DirectorySnapshot
 from maestral.sync import SyncEngine, Observer, FSEventHandler
 from maestral.sync import SyncDirection, ItemType, ChangeType
 from maestral.errors import NotFoundError, FolderConflictError
@@ -517,7 +517,7 @@ class TestSync(TestCase):
             remote_hash = r['content_hash'] if r['type'] == 'FileMetadata' else 'folder'
             remote_rev = r['rev'] if r['type'] == 'FileMetadata' else 'folder'
 
-            self.assertEqual(get_local_hash(local_path), remote_hash,
+            self.assertEqual(self.m.sync.get_local_hash(local_path), remote_hash,
                              f'different file content for "{dbx_path}"')
             self.assertEqual(self.m.sync.get_local_rev(dbx_path), remote_rev,
                              f'different revs for "{dbx_path}"')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -540,7 +540,7 @@ class TestSync(TestCase):
                                  f'indexed item "{entry.dbx_path_lower}" does not exist on dbx')
 
                 r = matching_items[0]
-                remote_rev = r['rev'] if r['type'] == 'FileMetadata' else f'folder:{r["name"]}'
+                remote_rev = r['rev'] if r['type'] == 'FileMetadata' else 'folder'
 
                 # check if revs are equal on server and locally
                 self.assertEqual(entry.rev, remote_rev,
@@ -551,8 +551,7 @@ class TestSync(TestCase):
                 local_path_actual_casing = to_existing_cased_path(local_path_expected_casing)
 
                 self.assertEqual(local_path_expected_casing, local_path_actual_casing,
-                                 f'expected local casing "{local_path_expected_casing}" '
-                                 f'but found "{local_path_expected_casing}"')
+                                 'casing on drive does not match index')
 
     @staticmethod
     def _count_conflicts(entries, name):
@@ -1047,7 +1046,7 @@ class TestSync(TestCase):
 
         # start with nested folders
         os.mkdir(self.test_folder_local + '/folder')
-        os.mkdir(self.test_folder_local + '/Subfolder')
+        os.mkdir(self.test_folder_local + '/folder/Subfolder')
         self.wait_for_idle()
 
         self.assert_synced(self.test_folder_local, self.test_folder_dbx)
@@ -1067,13 +1066,16 @@ class TestSync(TestCase):
 
         # start with nested folders
         os.mkdir(self.test_folder_local + '/folder')
-        os.mkdir(self.test_folder_local + '/Subfolder')
+        os.mkdir(self.test_folder_local + '/folder/Subfolder')
         self.wait_for_idle()
 
         self.assert_synced(self.test_folder_local, self.test_folder_dbx)
 
         # rename remote folder
-        self.m.client.move(self.test_folder_dbx + '/folder', self.test_folder_dbx + '/FOLDER')
+        self.m.client.move(self.test_folder_dbx + '/folder',
+                           self.test_folder_dbx + '/FOLDER',
+                           autorename=True)
+
         self.wait_for_idle()
 
         self.assertTrue(osp.isdir(self.test_folder_local + '/FOLDER'))


### PR DESCRIPTION
Keep the revision index in our SQlite database and store addition information for every path in the index:

* The unique Dropbox ID
* The `last_sync` time for the last upload sync.
* The content hash (not yet used)
* The item type (file vs folder)

Other changes are:

* Optimise how we determine the correct casing of a path: Dropbox only provides correct casing for the basename and not any parent directories in `path_display`. We previously use the casing of any existing local folders for parent directories. This has been now changed to use the casing of basenames from previous sync events, if available, or from existing entries in our local index. If neither can be used, the Dropbox server is queries explicitly for the metadata of all parent directories.
* Rename a local file or folder if the casing changes. Previously, the casing from the first download would always be preserved.

