### PR TITLE
ISSUE-187: Docker image for headless service

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,8 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=aries1980/maestral
-          # This doesn't work for some reason.
-          # MAESTRAL_VERSION=$(git describe --abbrev=0)
-          MAESTRAL_VERSION=1.2.0
+          LAST_GIT_TAG=$(git describe --tags --abbrev=0)
+          MAESTRAL_VERSION=${LAST_GIT_TAG:1}
           VERSION=noop
           GIT_BRANCH=${GITHUB_REF##*/}
           if [ "${{ github.event_name }}" = "schedule" ]; then
@@ -46,9 +45,6 @@ jobs:
             MINOR=${MAESTRAL_VERSION%.*}
             MAJOR=${MINOR%.*}
             TAGS="${DOCKER_IMAGE}:${MAESTRAL_VERSION},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=maestral_version::${MAESTRAL_VERSION}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,6 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
         name: Update repo description
         uses: peter-evans/dockerhub-description@v2
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=aries1980/maestral
+          DOCKER_IMAGE=maestraldbx/maestral
           LAST_GIT_TAG=$(git describe --tags --abbrev=0)
           MAESTRAL_VERSION=${LAST_GIT_TAG:1}
           VERSION=noop

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,7 +98,7 @@ jobs:
             org.opencontainers.image.title="Maestral" 
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-          platforms: linux/amd64,linux/arm64,linux/arm32
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ on:
     - cron: "19 4 * * *" # everyday at 04:19
 
 jobs:
-  github-cache:
+  docker-build:
     runs-on: ubuntu-latest
     steps:
       -
@@ -101,6 +101,10 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
+  
+  dockerhub-repo-description:
+    runs-on: ubuntu-latest
+    steps:
       -
         name: Update repo description
         uses: peter-evans/dockerhub-description@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,100 @@
+name: Uploads Maestral Docker image and pushes to hub.docker.com
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+
+jobs:
+  github-cache:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=aries1980/maestral
+          MAESTRAL_VERSION=$(git describe --abbrev=0)
+          VERSION=noop
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MAESTRAL_VERSION=${VERSION:1}
+            MINOR=${MAESTRAL_VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="${DOCKER_IMAGE}:${MAESTRAL_VERSION},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=maestral_version::${MAESTRAL_VERSION}
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VERSION=${{ steps.prep.outputs.maestral_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          context: .
+          file: ./Dockerfile
+          # See https://github.com/opencontainers/image-spec/blob/master/annotations.md
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.docker.cmd="docker run -d -v /home/dropbox:/dropbox maestral" \
+            org.opencontainers.image.documentation="https://maestral.readthedocs.io/en/latest"
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+            org.opencontainers.image.ref.name=${{ github.branch }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.title="Maestral" 
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+          platforms: linux/amd64,linux/arm64,linux/arm32
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+      -
+        name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: ${{ steps.prep.outputs.docker_image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
           DOCKER_IMAGE=aries1980/maestral
           MAESTRAL_VERSION=$(git describe --abbrev=0)
           VERSION=noop
+          GIT_BRANCH=${GITHUB_REF##*/}
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly
           elif [[ $GITHUB_REF == refs/tags/* ]]; then
@@ -43,6 +44,7 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=maestral_version::${MAESTRAL_VERSION}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=git_branch::${GIT_BRANCH}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       -
@@ -82,7 +84,7 @@ jobs:
             org.opencontainers.image.docker.cmd="docker run -d -v /home/dropbox:/dropbox maestral" \
             org.opencontainers.image.documentation="https://maestral.readthedocs.io/en/latest"
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-            org.opencontainers.image.ref.name=${{ github.branch }}
+            org.opencontainers.image.ref.name=${{ steps.prep.outputs.git_branch }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.title="Maestral" 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,10 +8,16 @@ on:
       - 'v*.*.*'
   pull_request:
 
+  schedule:
+    - cron: "19 4 * * *" # everyday at 04:19
+
 jobs:
   github-cache:
     runs-on: ubuntu-latest
     steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
       -
         name: Prepare
         id: prep

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,14 +20,12 @@ jobs:
         # Needed for getting the latest Git tag in the "Prepare" step.
         
       - name: Fetching tags 
-        #run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
         run: git fetch --prune --unshallow --tags
 
       - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=aries1980/maestral
-          #LAST_GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
           LAST_GIT_TAG=$(git describe --tags --abbrev=0)
           MAESTRAL_VERSION=${LAST_GIT_TAG:1}
           VERSION=noop
@@ -50,12 +48,15 @@ jobs:
             MINOR=${MAESTRAL_VERSION%.*}
             MAJOR=${MINOR%.*}
             TAGS="${DOCKER_IMAGE}:${MAESTRAL_VERSION},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          fi
+ 
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=maestral_version::${MAESTRAL_VERSION}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=git_branch::${GIT_BRANCH}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -101,16 +102,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
-  
-  dockerhub-repo-description:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
 
-      - name: Update repo description
-        uses: peter-evans/dockerhub-description@v2
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          DOCKERHUB_REPOSITORY: ${{ steps.prep.outputs.docker_image }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,9 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=aries1980/maestral
-          MAESTRAL_VERSION=$(git describe --abbrev=0)
+          # This doesn't work for some reason.
+          # MAESTRAL_VERSION=$(git describe --abbrev=0)
+          MAESTRAL_VERSION=1.2.0
           VERSION=noop
           GIT_BRANCH=${GITHUB_REF##*/}
           if [ "${{ github.event_name }}" = "schedule" ]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,13 +90,13 @@ jobs:
           labels: |
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.docker.cmd="docker run -d -v /home/dropbox:/dropbox maestral" \
-            org.opencontainers.image.documentation="https://maestral.readthedocs.io/en/latest"
+            org.opencontainers.image.docker.cmd=docker run -d --rm --name maestral -v /home/dropbox:/dropbox maestral
+            org.opencontainers.image.documentation=https://maestral.readthedocs.io/en/latest
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
             org.opencontainers.image.ref.name=${{ steps.prep.outputs.git_branch }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.title="Maestral" 
+            org.opencontainers.image.title=Maestral
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.version=${{ steps.prep.outputs.version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,14 +15,19 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Prepare
+        # Needed for getting the latest Git tag in the "Prepare" step.
+        
+      - name: Fetching tags 
+        #run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        run: git fetch --prune --unshallow --tags
+
+      - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=aries1980/maestral
+          #LAST_GIT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
           LAST_GIT_TAG=$(git describe --tags --abbrev=0)
           MAESTRAL_VERSION=${LAST_GIT_TAG:1}
           VERSION=noop
@@ -51,28 +56,27 @@ jobs:
           echo ::set-output name=git_branch::${GIT_BRANCH}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Cache Docker layers
+
+      - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           build-args: |
@@ -101,11 +105,10 @@ jobs:
   dockerhub-repo-description:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Update repo description
+
+      - name: Update repo description
         uses: peter-evans/dockerhub-description@v2
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dockerhub-repo-description.yml
+++ b/.github/workflows/dockerhub-repo-description.yml
@@ -1,0 +1,19 @@
+name: Uploads Maestral Docker image and pushes to hub.docker.com
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  
+  dockerhub-repo-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: ${{ steps.prep.outputs.docker_image }}

--- a/.github/workflows/dockerhub-repo-description.yml
+++ b/.github/workflows/dockerhub-repo-description.yml
@@ -16,4 +16,4 @@ on:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          DOCKERHUB_REPOSITORY: ${{ steps.prep.outputs.docker_image }}
+          DOCKERHUB_REPOSITORY: maestraldbx/maestral

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.8.6-alpine3.12
+
+ARG UID=1000
+ARG VERSION
+
+RUN set -eux ; \
+  adduser -D -u ${UID} -h /dropbox dropbox ; \
+  apk add --no-cache --virtual .build-deps \
+    gcc \
+    musl-dev \
+    python3-dev \
+    libffi-dev \
+    openssl-dev ; \
+  pip install maestral==${VERSION} ; \
+  pip cache purge ; \
+  apk del --no-network .build-deps
+
+USER dropbox
+VOLUME ["/dropbox"]
+WORKDIR /dropbox
+
+CMD ["maestral", "-f", "start"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ USER dropbox
 VOLUME ["/dropbox"]
 WORKDIR /dropbox
 
-CMD ["maestral", "-f", "start"] 
+CMD ["maestral", "start", "-f"] 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ everything that you supposed to do in the command line, except running the GUI.
 For the first run, get access to the shell within the Docker container 
 
 ```console
-$ docker run -it -v /mnt/dropbox:/dropbox aries1980/maestral:latest ash
+$ docker run -it -v /mnt/dropbox:/dropbox maestraldbx/maestral:latest ash
 ```
 
 where `/mnt/dropbox` is the directory that which contains the `Dropbox` directory.
@@ -128,7 +128,7 @@ $ docker run \
   --name maestral \
   --rm \
   -v /mnt/dropbox:/dropbox \
-  aries1980/maestral:latest
+  maestraldbx/maestral:latest
 ```
 
 - To step into the Maestral container: `docker exec -it maestral ash`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ through linking and configuring your Dropbox and will then start syncing.
 ![screenshot macOS](https://raw.githubusercontent.com/SamSchott/maestral-dropbox/master/screenshots/macOS_light.png)
 ![screenshot Fedora](https://raw.githubusercontent.com/SamSchott/maestral-dropbox/master/screenshots/Ubuntu.png)
 
-## Command line usage
+### Command line usage
 
 After installation, Maestral will be available as a command line script by typing
 `maestral` in the command prompt. Type `maestral --help` to get a full list of available
@@ -104,6 +104,27 @@ work         user@mycorp.org
 
 By default, the Dropbox folder names will contain the capitalised config-name in braces.
 In the above case, this will be "Dropbox (Personal)" and "Dropbox (Work)".
+
+### Docker usage
+
+The Docker image is available for x86, arm/v7 (32bit) and arm64 platforms. You can do
+everything that you supposed to do in the command line, except running the GUI.
+
+For the first run, get access to the shell within the Docker container 
+
+```console
+$ docker run -it -v /mnt/dropbox:/dropbox aries1980/maestral:latest ash
+```
+
+where `/mnt/dropbox` is the directory that which contains the `Dropbox` directory.
+Maestral runs with `UID` 1000, make sure that the user owns `/mnt/dropbox` and the
+contents within (`chown -R 1000 /mnt/dropbox`).
+
+Later, if you want just a `maestral start`, just execute
+
+```console
+$ docker run -v /mnt/dropbox:/dropbox aries1980/maestral:latest
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,18 @@ contents within (`chown -R 1000 /mnt/dropbox`).
 Later, if you want just a `maestral start`, just execute
 
 ```console
-$ docker run -v /mnt/dropbox:/dropbox aries1980/maestral:latest
+$ docker run \
+  -d \
+  --name maestral \
+  --rm \
+  -v /mnt/dropbox:/dropbox \
+  aries1980/maestral:latest
 ```
+
+- To step into the Maestral container: `docker exec -it maestral ash`
+- List the logs of the container: `docker logs maestral`
+- Get the build info of a running container: `docker inspect maestral | jq ".[].Config.Labels"`
+
 
 ## Contribute
 


### PR DESCRIPTION
This PR contains the following:

- Dockerfile that creates a minimal image of 36MB (based on python:3.8-alpine).
- Github Action workflow, that builds, caches, pushes the image to Docker Hub.
- A 2nd Github Action job that pushes the content of the README.md as the description to the Docker Hub repo. This happens on newly tagged release.
- The build creates Docker image for amd64, arm/v7 (32bit) and arm64 (aka arm/v8) architectures, so you can use it on your Raspberry Pi, OSMC box, Synology NAS, etc.

## Proof for the successful build

- https://hub.docker.com/r/aries1980/maestral/tags
- https://github.com/aries1980/maestral/runs/1203608714?check_suite_focus=true
- https://github.com/aries1980/maestral/runs/1203483095?check_suite_focus=true (For the repo description update)
- https://hub.docker.com/r/aries1980/maestral (For the repo description update)

## TODO

- ATM it pushes to my personal registry: https://hub.docker.com/r/aries1980/maestral . If you are happy with that, we can keep it there, just make it official. I tried to create a "maestral" organization on Docker Hub, but it is already claimed. If you change the repo name, don't forget to change it in the README and in the Github Action workflows. Also, on repo change, don't forget to add the DOCKERHUB_USERNAME, DOCKERHUB_PASSWORD, DOCKERHUB_TOKEN !

Any feedback are welcome!