### PR TITLE
Reduce memory usage on initial sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Moves from `pkg_resources` to locate entry points and other metadata to the faster and
   more light-weight `importlib.metadata`.
 - Update scripts are no longer run after a fresh install or for a new config.
+- Significantly reduces memory usage during the initial sync of a Dropbox folder with many
+  (> 10,000) items and when downloading a large set of changes.
+- The returned sync history is now limited to the last 1,000 sync events.
 
 ## v1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Update scripts are no longer run after a fresh install or for a new config.
 - Significantly reduces memory usage during the initial sync of a Dropbox folder with many
   (> 10,000) items and when downloading a large set of changes.
+- Fixes an issue with the macOS GUI becoming unresponsive when opening the selective sync
+  dialog if one of the folders contains a large number (> 2k) of items.
+- Fixes an issue with the Qt GUI crashing when opening the selective sync dialog if one of
+  the folders contains a large number (> 2k) of items.
 - The returned sync history is now limited to the last 1,000 sync events.
 
 ## v1.2.1

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -891,7 +891,9 @@ class DropboxClient:
     ) -> Iterator[files.ListFolderResult]:
         """
         Lists the contents of a folder on Dropbox. Does the same as :meth:`list_folder`
-        but returns an iterator yielding :class:`files.ListFolderResult` instances.
+        but returns an iterator yielding :class:`files.ListFolderResult` instances. The
+        number of entries returned in each iteration corresponds to the number of
+        entries returned by a single Dropbox API call and will be typically around 500.
         This is useful to save memory when indexing a large number of items.
 
         :param dbx_path: Path of folder on Dropbox.
@@ -1010,9 +1012,11 @@ class DropboxClient:
         self, last_cursor: str
     ) -> Iterator[files.ListFolderResult]:
         """
-        Lists changes to remote Dropbox since ``last_cursor``. Does the same as
+        Lists changes to the remote Dropbox since ``last_cursor``. Does the same as
         :meth:`list_remote_changes` but returns an iterator yielding
-        :class:`files.ListFolderResult` instances. This is useful to save memory when
+        :class:`files.ListFolderResult` instances. The number of entries returned in
+        each iteration corresponds to the number of entries returned by a single Dropbox
+        API call and will be typically around 500. This is useful to save memory when
         indexing a large number of items.
 
         :param last_cursor: Last to cursor to compare for changes.

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -25,6 +25,7 @@ from typing import (
     Type,
     Tuple,
     List,
+    Iterator,
     TypeVar,
     Optional,
     TYPE_CHECKING,
@@ -880,6 +881,60 @@ class DropboxClient:
 
         return self.flatten_results(results)
 
+    @to_maestral_error(dbx_path_arg=1)
+    def list_folder_iterator(
+        self,
+        dbx_path: str,
+        max_retries_on_timeout: int = 4,
+        include_non_downloadable_files: bool = False,
+        **kwargs,
+    ) -> Iterator[files.ListFolderResult]:
+        """
+        Lists the contents of a folder on Dropbox. Does the same as :meth:`list_folder`
+        but returns an iterator yielding :class:`files.ListFolderResult` instances.
+        This is useful to save memory when indexing a large number of items.
+
+        :param dbx_path: Path of folder on Dropbox.
+        :param max_retries_on_timeout: Number of times to try again if Dropbox servers
+            do not respond within the timeout. Occasional timeouts may occur for very
+            large Dropbox folders.
+        :param include_non_downloadable_files: If ``True``, files that cannot be
+            downloaded (at the moment only G-suite files on Dropbox) will be included.
+        :param kwargs: Other keyword arguments for Dropbox SDK files_list_folder.
+        :returns: Iterator over content of given folder.
+        """
+
+        dbx_path = "" if dbx_path == "/" else dbx_path
+
+        res = self.dbx.files_list_folder(
+            dbx_path,
+            include_non_downloadable_files=include_non_downloadable_files,
+            **kwargs,
+        )
+
+        yield res
+
+        idx = 0
+
+        while res.has_more:
+
+            idx += len(res.entries)
+            logger.info(f"Indexing {idx}...")
+
+            attempt = 0
+
+            while True:
+                try:
+                    res = self.dbx.files_list_folder_continue(res.cursor)
+                    yield res
+                    break
+                except requests.exceptions.ReadTimeout:
+                    attempt += 1
+                    if attempt <= max_retries_on_timeout:
+                        time.sleep(5.0)
+                    else:
+                        raise
+
     @staticmethod
     def flatten_results(
         results: List[files.ListFolderResult],
@@ -949,6 +1004,28 @@ class DropboxClient:
         results = self.flatten_results(results)
 
         return results
+
+    @to_maestral_error()
+    def list_remote_changes_iterator(
+        self, last_cursor: str
+    ) -> Iterator[files.ListFolderResult]:
+        """
+        Lists changes to remote Dropbox since ``last_cursor``. Does the same as
+        :meth:`list_remote_changes` but returns an iterator yielding
+        :class:`files.ListFolderResult` instances. This is useful to save memory when
+        indexing a large number of items.
+
+        :param last_cursor: Last to cursor to compare for changes.
+        :returns: Iterator over remote changes since given cursor.
+        """
+
+        result = self.dbx.files_list_folder_continue(last_cursor)
+
+        yield result
+
+        while result.has_more:
+            result = self.dbx.files_list_folder_continue(result.cursor)
+            yield result
 
 
 # ==== conversion functions to generate error messages and types =======================

--- a/maestral/client.py
+++ b/maestral/client.py
@@ -76,7 +76,7 @@ from maestral.errors import (
     InvalidDbidError,
 )
 from maestral.config import MaestralState
-from maestral.constants import DROPBOX_APP_KEY
+from maestral.constants import DROPBOX_APP_KEY, IDLE
 from maestral.utils import natural_size, chunks, clamp
 
 if TYPE_CHECKING:
@@ -888,6 +888,9 @@ class DropboxClient:
                     else:
                         raise
 
+        if idx > 0:
+            logger.info(IDLE)
+
         return self.flatten_results(results)
 
     def list_folder_iterator(
@@ -946,6 +949,9 @@ class DropboxClient:
                             time.sleep(5.0)
                         else:
                             raise
+
+            if idx > 0:
+                logger.info(IDLE)
 
     @staticmethod
     def flatten_results(

--- a/maestral/daemon.py
+++ b/maestral/daemon.py
@@ -522,8 +522,6 @@ def start_maestral_daemon(
             # notify systemd that we are shutting down
             sd_notifier.notify("STOPPING=1")
 
-        sys.exit(0)
-
 
 def _subprocess_launcher(
     config_name: str, log_to_stdout: bool, start_sync: bool

--- a/maestral/main.py
+++ b/maestral/main.py
@@ -675,11 +675,11 @@ class Maestral:
         else:
             return FileStatus.Unwatched.value
 
-    def get_activity(self, max_len: Optional[int] = 100) -> List[StoneType]:
+    def get_activity(self, limit: Optional[int] = 100) -> List[StoneType]:
         """
         Returns the current upload / download activity.
 
-        :param max_len: Maximum number of items to return. If None, all entries will be
+        :param limit: Maximum number of items to return. If None, all entries will be
             returned.
         :returns: A lists of all sync events currently queued for or being uploaded or
             downloaded with the events furthest up in the queue coming first.
@@ -687,15 +687,17 @@ class Maestral:
         """
 
         self._check_linked()
-        if max_len:
-            activity = [sync_event_to_dict(e) for e in self.monitor.activity[:max_len]]
+        if limit:
+            activity = [sync_event_to_dict(e) for e in self.monitor.activity[:limit]]
         else:
             activity = [sync_event_to_dict(e) for e in self.monitor.activity]
         return activity
 
     def get_history(self) -> List[StoneType]:
         """
-        Returns the historic upload / download activity.
+        Returns the historic upload / download activity. Up to 1,000 sync events can be
+        returned. Any events which occurred before the interval sepecified by the
+        ``keep_history`` config value are discarded.
 
         :returns: A lists of all sync events from the last week.
         :raises: :class:`errors.NotLinkedError` if no Dropbox account is linked

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -1033,8 +1033,8 @@ class SyncEngine:
     @property
     def history(self) -> List[SyncEvent]:
         """A list of the last SyncEvents in our history. History will be kept for the
-         interval specified by the config value``keep_history`` (defaults to two weeks)
-         and at most ``_max_history`` events will be returned (defaults to 1,000)."""
+        interval specified by the config value``keep_history`` (defaults to two weeks)
+        and at most ``_max_history`` events will be returned (defaults to 1,000)."""
         with self._database_access():
             query = self._db_session.query(SyncEvent)
             ordered_query = query.order_by(SyncEvent.change_time_or_sync_time)
@@ -3967,8 +3967,8 @@ class SyncMonitor:
     @property
     def history(self) -> List[SyncEvent]:
         """A list of the last SyncEvents in our history. History will be kept for the
-         interval specified by the config value``keep_history`` (defaults to two weeks)
-         and at most ``_max_history`` events will be returned (defaults to 1,000)."""
+        interval specified by the config value``keep_history`` (defaults to two weeks)
+        and at most ``_max_history`` events will be returned (defaults to 1,000)."""
         return self.sync.history
 
     @_with_lock

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -134,7 +134,7 @@ db_naming_convention = {
     "pk": "pk_%(table_name)s",
 }
 Base = declarative_base(metadata=MetaData(naming_convention=db_naming_convention))
-Session = sessionmaker()
+Session = sessionmaker(expire_on_commit=False)
 
 ExecInfoType = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
 FT = TypeVar("FT", bound=Callable[..., Any])

--- a/maestral/sync.py
+++ b/maestral/sync.py
@@ -2730,13 +2730,14 @@ class SyncEngine:
             ]
 
             # download in batches of 5,000 to reduce memory usage
-            for chunk in chunks(sync_events, 5000):
+            for chunk in chunks(sync_events, 5000, consume=True):
                 res = self.apply_remote_changes(chunk, cursor=None)
 
                 s = all(e.status in (SyncStatus.Done, SyncStatus.Skipped) for e in res)
                 success = s and success
 
                 # free memory
+                del chunk
                 del res
                 gc.collect()
 

--- a/maestral/utils/__init__.py
+++ b/maestral/utils/__init__.py
@@ -26,16 +26,25 @@ def natural_size(num: float, unit: str = "B", sep: bool = True) -> str:
     return f"{num:.1f}{sep_char}{prefix}{unit}"
 
 
-def chunks(lst: List, n: int) -> Iterator[List]:
+def chunks(lst: List, n: int, consume: bool = False) -> Iterator[List]:
     """
     Partitions an iterable into chunks of length ``n``.
 
     :param lst: Iterable to partition.
     :param n: Chunk size.
+    :param consume: If True, the list will be consumed (emptied) during the iteration.
+        This can be used to free memory in case of large lists.
     :returns: Iterator over chunks.
     """
-    for i in range(0, len(lst), n):
-        yield lst[i : i + n]
+
+    if consume:
+        while lst:
+            chunk = lst[0:n]
+            del lst[0:n]
+            yield chunk
+    else:
+        for i in range(0, len(lst), n):
+            yield lst[i : i + n]
 
 
 def clamp(n: _N, minn: _N, maxn: _N) -> _N:


### PR DESCRIPTION
This PR reduces the memory usage during an initial download and when syncing remote changes if the number of items to sync exceeds 5000. See issue #205.