### PR TITLE
Refactor autostart

### DIFF
--- a/src/maestral/utils/autostart.py
+++ b/src/maestral/utils/autostart.py
@@ -249,11 +249,12 @@ def _get_available_implementation() -> Optional[SupportedImplementations]:
     if system == "Darwin":
         return SupportedImplementations.launchd
     else:
-        res = subprocess.check_output(["ps", "-p", "1"]).decode()
-        if "systemd" in res:
-            return SupportedImplementations.systemd
-        else:
+        try:
+            res = subprocess.check_output(["ps", "-p", "1"]).decode()
+        except (FileNotFoundError, subprocess.CalledProcessError):
             return None
+        else:
+            return SupportedImplementations.systemd if "systemd" in res else None
 
 
 class AutoStart:

--- a/src/maestral/utils/autostart.py
+++ b/src/maestral/utils/autostart.py
@@ -4,8 +4,8 @@
 
 (c) Sam Schott; This work is licensed under the MIT licence.
 
-This module handles starting Maestral on user login and supports multiple platform
-specific backends such as launchd or systemd.
+This module handles starting the maestral daemon on user login and supports multiple
+platform specific backends such as launchd or systemd.
 
 Note that launchd agents will not show as "login items" in macOS system preferences. As
 a result, the user does not have a convenient UI to remove Maestral autostart entries

--- a/src/maestral/utils/autostart.py
+++ b/src/maestral/utils/autostart.py
@@ -5,22 +5,17 @@
 (c) Sam Schott; This work is licensed under the MIT licence.
 
 This module handles starting Maestral on user login and supports multiple platform
-specific backends such as launchd or systemd. Additionally, this module also provides
-support for GUIs via launchd or xdg-desktop entries by passing the ``gui`` option to the
-``maestral`` command or executable. Therefore, only GUIs which are explicitly supported
-by the CLI with the `maestral gui` command or frozen executables which provide their own
-GUI are supported.
+specific backends such as launchd or systemd.
 
 Note that launchd agents will not show as "login items" in macOS system preferences. As
 a result, the user does not have a convenient UI to remove Maestral autostart entries
 manually outside of Maestral itself. Login items however only support app bundles and
 provide no option to pass command line arguments to the app. They would therefore
-neither support pip installs or multiple configurations.
+neither support pip installed packages or multiple configurations.
 
 """
 
 # system imports
-import sys
 import os
 import os.path as osp
 import re
@@ -246,25 +241,35 @@ class AutoStartXDGDesktop(AutoStartBase):
         return os.path.isfile(self.destination)
 
 
+def _get_available_implementation() -> Optional[SupportedImplementations]:
+    """Returns the supported implementation depending on the platform."""
+
+    system = platform.system()
+
+    if system == "Darwin":
+        return SupportedImplementations.launchd
+    else:
+        res = subprocess.check_output(["ps", "-p", "1"]).decode()
+        if "systemd" in res:
+            return SupportedImplementations.systemd
+        else:
+            return None
+
+
 class AutoStart:
     """Creates auto-start files in the appropriate system location to automatically
     start Maestral when the user logs in. Different backends are used depending on the
-    platform and if we want to start a GUI or a daemon / service."""
+    platform."""
 
     _impl: AutoStartBase
 
-    def __init__(self, config_name: str, gui: bool = False) -> None:
+    def __init__(self, config_name: str) -> None:
 
-        self._gui = gui
         self.maestral_path = self.get_maestral_command_path()
-        self.implementation = self._get_available_implementation()
+        self.implementation = _get_available_implementation()
 
-        if gui:
-            start_cmd = f"{self.maestral_path} gui -c {config_name}"
-            bundle_id = "{}.{}".format(BUNDLE_ID, config_name)
-        else:
-            start_cmd = f"{self.maestral_path} start -f -c {config_name}"
-            bundle_id = "{}-{}.{}".format(BUNDLE_ID, "daemon", config_name)
+        start_cmd = f"{self.maestral_path} start -f -c {config_name}"
+        bundle_id = f"{BUNDLE_ID}-daemon.{config_name}"
 
         if self.implementation == SupportedImplementations.launchd:
             self._impl = AutoStartLaunchd(bundle_id, start_cmd)
@@ -349,9 +354,6 @@ class AutoStart:
             executable cannot be found.
         """
 
-        if self._gui and getattr(sys, "frozen", False):
-            return sys.executable
-
         try:
             dist_files = files("maestral")
         except PackageNotFoundError:
@@ -377,19 +379,3 @@ class AutoStart:
             return str(path)
         else:
             return shutil.which("maestral") or ""
-
-    def _get_available_implementation(self) -> Optional[SupportedImplementations]:
-        """Returns the supported implementation depending on the platform."""
-
-        system = platform.system()
-
-        if system == "Darwin":
-            return SupportedImplementations.launchd
-        elif system == "Linux" and self._gui:
-            return SupportedImplementations.xdg_desktop
-        else:
-            res = subprocess.check_output(["ps", "-p", "1"]).decode()
-            if "systemd" in res:
-                return SupportedImplementations.systemd
-            else:
-                return None


### PR DESCRIPTION
This PR simplifies the autostart module by removing all support for GUIs and frozen applications. The reasoning is:

* Providing a "start-on-login" option for a GUI fundamentally is the job of the GUI itself. Removing this from the `maestral` module results in a clearer separation of responsibilities. As a tradeoff, there may be some code-duplication in the GUI, depending on its autostart mechanism and if it aims to be cross-platform.
* We will move away from PyInstaller to briefcase for bundling. The latter provides an almost unmodified Python runtime and pip-installed Python packages, reducing the need to specially accommodate "frozen" executables.

The autostart module itself is still retained for the CLI which is bundled together with the daemon instead of a separate package.

This PR also fixes an issue with detecting `systemd` on Linux if the `ps` command is not available or does not have a `-p` option, as reported in #199.