### PR TITLE
Optimise case conversion cache

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1450,6 +1450,25 @@ class SyncEngine:
     def correct_case(self, dbx_path: str) -> str:
         """
         Converts a Dropbox path with correctly cased basename to a fully cased path.
+        This is because Dropbox metadata guarantees the correct casing for the basename
+        only. In practice, casing of parent directories is often incorrect.
+        This is done by retrieving the correct casing of the dirname, either from our
+        cache, our database or from Dropbox servers.
+
+        Performance may vary significantly with the number of parent folders:
+
+        1) If the parent directory is already in our cache, performance is O(1).
+        2) If the parent directory is already in our sync index, performance is O(1) but
+           slower than the first case because it requires a SQLAlchemy query.
+        3) If the parent directory is unknown to us, its metadata (including the correct
+           casing of directory's basename) is queried from Dropbox. This is used to
+           construct a correctly cased path by calling :meth:`correct_case` again. At
+           best, performance will be of O(2) if the parent directory is known to us, at
+           worst if will be of order O(n) involving queries to Dropbox servers for each
+           parent directory.
+
+        When running :meth:`correct_case` on a large tree of paths, it is therefore best
+        to do so in hierarchical order.
 
         :param dbx_path: Dropbox path with correctly cased basename, as provided by
             ``Metadata.path_display`` or ``Metadata.name``.
@@ -1470,7 +1489,7 @@ class SyncEngine:
             parent_path_cased = self._case_conversion_cache.get(dirname_lower)
 
             if not parent_path_cased:
-                # try to get dirname casing from our index
+                # try to get dirname casing from our index, this is slower
                 with self._database_access():
                     parent_entry = self.get_index_entry(dirname_lower)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1504,7 +1504,7 @@ class SyncEngine:
                         parent_path_cased = self.correct_case(md_parent.path_display)
                     else:
                         # give up
-                        parent_path_cased = osp.dirname(dbx_path)
+                        parent_path_cased = dirname
 
             path_cased = f"{parent_path_cased}/{basename}"
 

--- a/src/maestral/utils/caches.py
+++ b/src/maestral/utils/caches.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+from threading import RLock
+from typing import Any
+
+
+class LRUCache:
+    """
+    A simple LRU cache implementation from Sachin Negi.
+
+    :param capacity: Maximum number of of entries to keep.
+    """
+
+    _cache: OrderedDict
+
+    def __init__(self, capacity: int) -> None:
+        self._lock = RLock()
+        self._cache = OrderedDict()
+        self.capacity = capacity
+
+    def get(self, key: Any) -> Any:
+        """
+        Get the cached value for a key. Mark as most recently used.
+
+        :param key: Key to query.
+        :returns: Cached value or None.
+        """
+        with self._lock:
+            try:
+                self._cache.move_to_end(key)
+                return self._cache[key]
+            except KeyError:
+                return None
+
+    def put(self, key: Any, value: Any) -> None:
+        """
+        Set the cached value for a key. Mark as most recently used.
+
+        :param key: Key to use. Must be hashable.
+        :param value: Value to cache.
+        """
+        with self._lock:
+            self._cache[key] = value
+            self._cache.move_to_end(key)
+            if len(self._cache) > self.capacity:
+                self._cache.popitem(last=False)
+
+    def clear(self) -> None:
+        """
+        Clears the cache.
+        """
+
+        with self._lock:
+            self._cache.clear()


### PR DESCRIPTION
Instead of keeping a bare dictionary as cache for past case conversions and manually clearing it, this PR uses a (very simple) least-recently-used (LRU) cache which keeps the last 5,000 case conversions in memory.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct (Code of conduct? This project doesn't have a code of conduct!)
