### PR TITLE
Refactor threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+#### Added:
+
+* Added a public API `Maetral.status_change_longpoll` for frontends to wait for status
+  changes without frequent polling. `status_change_longpoll` blocks until there is a
+  change in status and then returns ``True``. The default timeout iss 60 sec.
+* Added `utils.networkstatus` module which uses platform APIs to subscribe to changes in
+  network status if available and falls back to polling of the connection otherwise.
+
+#### Changes:
+
+* Increased timeout for all event queues.
+* Decreased the frequeny of Pyro daemon housekeeping tasks.
+
 ## v1.2.2
 
 This release focuses on bug fixes and performance improvements. In particular, memory

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -688,7 +688,7 @@ class MaestralProxy:
 
                 self._m = Maestral(config_name)
             else:
-                raise CommunicationError("Could not get proxy")
+                raise CommunicationError(f"Could not get proxy for '{config_name}'")
 
         self._is_fallback = not isinstance(self._m, Proxy)
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -102,7 +102,8 @@ def serpent_deserialize_api_error(class_name: str, d: dict) -> MaestralApiError:
     :returns: Class instance.
     """
     # import maestral errors for evaluation
-    from . import errors  # noqa: F401
+    # this import needs to be absolute to reconstruct the Exception class
+    import maestral.errors  # noqa: F401
 
     cls = eval(class_name)
     err = cls(*d["args"])

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor, Future, wait
 from typing import Union, List, Iterator, Dict, Set, Deque, Awaitable, Optional, Any
 
 try:
-    from concurrent.futures import InvalidStateError
+    from concurrent.futures import InvalidStateError  # type: ignore
 except ImportError:
     # Python 3.7 and lower
     InvalidStateError = RuntimeError

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -16,8 +16,14 @@ import logging.handlers
 from collections import deque
 import asyncio
 import random
-from concurrent.futures import ThreadPoolExecutor, Future, InvalidStateError, wait
+from concurrent.futures import ThreadPoolExecutor, Future, wait
 from typing import Union, List, Iterator, Dict, Set, Deque, Awaitable, Optional, Any
+
+try:
+    from concurrent.futures import InvalidStateError
+except ImportError:
+    # Python 3.7 and lower
+    InvalidStateError = RuntimeError
 
 # external imports
 import requests

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -14,6 +14,7 @@ import shutil
 import logging.handlers
 from collections import deque
 import asyncio
+import random
 from concurrent.futures import ThreadPoolExecutor
 from typing import Union, List, Iterator, Dict, Optional, Deque, Any
 
@@ -237,9 +238,8 @@ class Maestral:
             thread_name_prefix="maestral-thread-pool",
             max_workers=2,
         )
-        self._refresh_task = self._loop.create_task(
-            self._periodic_refresh(),
-        )
+        self._refresh_info_task = self._loop.create_task(self._periodic_refresh_info())
+        self._update_task = self._loop.create_task(self._period_update_check())
 
         # create a future which will return once `shutdown_daemon` is called
         # can be used by an event loop wait until maestral has been stopped
@@ -1324,7 +1324,8 @@ class Maestral:
 
         self.stop_sync()
 
-        self._refresh_task.cancel()
+        self._refresh_info_task.cancel()
+        self._update_task.cancel()
         self._thread_pool.shutdown(wait=False)
 
         if self._loop.is_running():
@@ -1412,7 +1413,9 @@ class Maestral:
 
                         batch_op.drop_constraint(constraint_name=name, type_="unique")
 
-    async def _periodic_refresh(self) -> None:
+    async def _periodic_refresh_info(self) -> None:
+
+        await asyncio.sleep(60 * 5)
 
         while True:
             # update account info
@@ -1427,6 +1430,13 @@ class Maestral:
                         self._thread_pool, self.get_profile_pic
                     )
 
+            await asyncio.sleep(60 * (44.5 + random.random()))  # (45 +/- 1) min
+
+    async def _period_update_check(self) -> None:
+
+        await asyncio.sleep(60 * 3)
+
+        while True:
             # check for maestral updates
             res = await self._loop.run_in_executor(
                 self._thread_pool, self.check_for_updates
@@ -1435,7 +1445,7 @@ class Maestral:
             if not res["error"]:
                 self._state.set("app", "latest_release", res["latest_release"])
 
-            await asyncio.sleep(60 * 60)  # 60 min
+            await asyncio.sleep(60 * (59.5 + random.random()))  # (60 +/- 1) min
 
     def __repr__(self) -> str:
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -116,6 +116,7 @@ class CachedHandler(logging.Handler):
     """
 
     cached_records: Deque[logging.LogRecord]
+    _emit_future: Future
 
     def __init__(
         self, level: int = logging.NOTSET, maxlen: Optional[int] = None

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -135,11 +135,17 @@ class CachedHandler(logging.Handler):
 
         # notify any waiting coroutines that we have a status change
         try:
-            self._emit_future.set_result(record)
+            self._emit_future.set_result(True)
         except InvalidStateError:
             pass
 
     def wait_for_emit(self, timeout: Optional[float]) -> bool:
+        """
+        Blocks until a new record is emitted.
+
+        :param timeout: Maximum time to block before returning.
+        :returns: ``True``if there was a status change, ``False`` in case of a timeout.
+        """
         done, not_done = wait([self._emit_future], timeout=timeout)
         self._emit_future = Future()  # reset future
         return len(done) == 1
@@ -550,6 +556,14 @@ class Maestral:
     # ==== state information  ==========================================================
 
     def status_change_longpoll(self, timeout: Optional[float] = 60) -> bool:
+        """
+        Blocks until there is a change in status or until a timeout occurs. This method
+        can be used by frontends to wait for status changes without constant polling.
+
+        :param timeout: Maximum time to block before returning, even if there is no
+            status change.
+        :returns: ``True``if there was a status change, ``False`` in case of a timeout.
+        """
         return self._log_handler_info_cache.wait_for_emit(timeout)
 
     @property

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -570,6 +570,8 @@ class Maestral:
         :param timeout: Maximum time to block before returning, even if there is no
             status change.
         :returns: ``True``if there was a status change, ``False`` in case of a timeout.
+
+        .. versionadded:: 1.3.0
         """
         return self._log_handler_info_cache.wait_for_emit(timeout)
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -17,7 +17,7 @@ from collections import deque
 import asyncio
 import random
 from concurrent.futures import ThreadPoolExecutor
-from typing import Union, List, Iterator, Dict, Optional, Deque, Any
+from typing import Union, List, Iterator, Dict, Set, Deque, Awaitable, Optional, Any
 
 # external imports
 import requests
@@ -235,13 +235,15 @@ class Maestral:
 
         # schedule background tasks
         self._loop = asyncio.get_event_loop()
+        self._tasks: Set[asyncio.Task] = set()
         self._thread_pool = ThreadPoolExecutor(
             thread_name_prefix="maestral-thread-pool",
             max_workers=2,
         )
-        self._refresh_info_task = self._loop.create_task(self._periodic_refresh_info())
-        self._update_task = self._loop.create_task(self._period_update_check())
-        self._reindex_task = self._loop.create_task(self._period_reindexing())
+
+        self._schedule_task(self._periodic_refresh_info())
+        self._schedule_task(self._period_update_check())
+        self._schedule_task(self._period_reindexing())
 
         # create a future which will return once `shutdown_daemon` is called
         # can be used by an event loop wait until maestral has been stopped
@@ -1326,14 +1328,15 @@ class Maestral:
 
         self.stop_sync()
 
-        self._refresh_info_task.cancel()
-        self._update_task.cancel()
+        for task in self._tasks:
+            task.cancel()
+
         self._thread_pool.shutdown(wait=False)
 
         if self._loop.is_running():
             self._loop.call_soon_threadsafe(self.shutdown_complete.set_result, True)
 
-    # ==== private methods =============================================================
+    # ==== verifiers ===================================================================
 
     def _check_linked(self) -> None:
 
@@ -1349,6 +1352,8 @@ class Maestral:
                 "No local Dropbox directory",
                 'Call "create_dropbox_directory" to set up.',
             )
+
+    # ==== housekeeping on update  =====================================================
 
     def _check_and_run_post_update_scripts(self) -> None:
         """
@@ -1414,6 +1419,13 @@ class Maestral:
                             }
 
                         batch_op.drop_constraint(constraint_name=name, type_="unique")
+
+    # ==== period async jobs ===========================================================
+
+    def _schedule_task(self, coro: Awaitable) -> None:
+
+        task = self._loop.create_task(coro)
+        self._tasks.add(task)
 
     async def _periodic_refresh_info(self) -> None:
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -21,7 +21,6 @@ from collections import abc
 from contextlib import contextmanager
 import enum
 import pprint
-import socket
 import gc
 from datetime import timezone
 from functools import wraps
@@ -123,6 +122,7 @@ from .utils.path import (
     content_hash,
 )
 from .utils.appdirs import get_data_path, get_home_dir
+from .utils.networkstate import NetworkConnectionNotifier
 
 
 logger = logging.getLogger(__name__)
@@ -3643,35 +3643,21 @@ def helper(mm: "SyncMonitor") -> None:
     """
     A worker for periodic maintenance:
 
-     1) Checks for a connection to Dropbox servers.
-     2) Pauses syncing when the connection is lost and resumes syncing when reconnected
-        and syncing has not been paused by the user.
-     3) Triggers weekly reindexing.
+     1) Triggers periodic / weekly reindexing.
 
     :param mm: MaestralMonitor instance.
     """
 
     while mm.running.is_set():
 
-        if check_connection("www.dropbox.com"):
-            if not mm.connected.is_set() and not mm.paused_by_user.is_set():
-                mm.startup.set()
-            # rebuild the index periodically
-            elif (
-                time.time() - mm.sync.last_reindex > mm.reindex_interval
-                and mm.idle_time > 20 * 60
-            ):
-                mm.rebuild_index()
-            mm.connected.set()
-            time.sleep(mm.connection_check_interval)
+        # rebuild the index periodically
+        if (
+            time.time() - mm.sync.last_reindex > mm.reindex_interval
+            and mm.idle_time > 20 * 60
+        ):
+            mm.rebuild_index()
 
-        else:
-            if mm.connected.is_set():
-                logger.info(DISCONNECTED)
-            mm.syncing.clear()
-            mm.connected.clear()
-            mm.startup.clear()
-            time.sleep(mm.connection_check_interval)
+        time.sleep(60*10)  # check every 10 min
 
 
 def download_worker(
@@ -3932,7 +3918,6 @@ class SyncMonitor:
     """
 
     added_item_queue: "Queue[str]"
-    connection_check_interval: float = 2.0
 
     def __init__(self, client: DropboxClient):
 
@@ -3956,6 +3941,12 @@ class SyncMonitor:
         self.sync = SyncEngine(self.client, self.fs_event_handler)
 
         self._startup_time = -1.0
+
+        self.connection_manager = NetworkConnectionNotifier(
+            host="www.dropbox.com",
+            on_connect=self.on_connected,
+            on_disconnect=self.on_disconnected,
+        )
 
     def _with_lock(fn: FT) -> FT:  # type: ignore
         @wraps(fn)
@@ -3985,6 +3976,17 @@ class SyncMonitor:
         and at most ``_max_history`` events will be returned (defaults to 1,000)."""
         return self.sync.history
 
+    @property
+    def idle_time(self) -> float:
+        """Returns the idle time in seconds since the last file change or since startup
+        if there haven't been any changes in our current session."""
+
+        now = time.time()
+        time_since_startup = now - self._startup_time
+        time_since_last_sync = now - self.sync.last_change
+
+        return min(time_since_startup, time_since_last_sync)
+
     @_with_lock
     def start(self) -> None:
         """Creates observer threads and starts syncing."""
@@ -3995,7 +3997,7 @@ class SyncMonitor:
 
         self.running = Event()  # create new event to let old threads shut down
 
-        self.local_observer_thread = Observer()
+        self.local_observer_thread = Observer(timeout=5)
         self.local_observer_thread.setName("maestral-fsobserver")
         self._watch = self.local_observer_thread.schedule(
             self.fs_event_handler, self.sync.dropbox_path, recursive=True
@@ -4128,16 +4130,23 @@ class SyncMonitor:
 
         logger.info(STOPPED)
 
-    @property
-    def idle_time(self) -> float:
-        """Returns the idle time in seconds since the last file change or since startup
-        if there haven't been any changes in our current session."""
+    @_with_lock
+    def on_connected(self) -> None:
 
-        now = time.time()
-        time_since_startup = now - self._startup_time
-        time_since_last_sync = now - self.sync.last_change
+        if self.running.is_set():
+            if not self.connected.is_set() and not self.paused_by_user.is_set():
+                self.startup.set()
+            self.connected.set()
 
-        return min(time_since_startup, time_since_last_sync)
+    @_with_lock
+    def on_disconnected(self) -> None:
+
+        if self.running.is_set():
+            if self.connected.is_set():
+                logger.info(DISCONNECTED)
+            self.syncing.clear()
+            self.connected.clear()
+            self.startup.clear()
 
     def reset_sync_state(self) -> None:
         """Resets all saved sync state."""
@@ -4308,19 +4317,3 @@ def cpu_usage_percent(interval: float = 0.1) -> float:
     else:
         single_cpu_percent = overall_cpus_percent * _cpu_count
         return round(single_cpu_percent, 1)
-
-
-def check_connection(hostname: str) -> bool:
-    """
-    A low latency check for an internet connection.
-
-    :param hostname: Hostname to use for connection check.
-    :returns: Connection availability.
-    """
-    try:
-        host = socket.gethostbyname(hostname)
-        s = socket.create_connection((host, 80), 2)
-        s.close()
-        return True
-    except Exception:
-        return False

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1887,7 +1887,7 @@ class SyncEngine:
         return changes, now
 
     def wait_for_local_changes(
-        self, timeout: float = 5, delay: float = 1
+        self, timeout: float = 40, delay: float = 1
     ) -> Tuple[List[SyncEvent], float]:
         """
         Waits for local file changes. Returns a list of local changes with at most one
@@ -3997,13 +3997,13 @@ class SyncMonitor:
 
         self.running = Event()  # create new event to let old threads shut down
 
-        self.local_observer_thread = Observer(timeout=5)
+        self.local_observer_thread = Observer(timeout=40)
         self.local_observer_thread.setName("maestral-fsobserver")
         self._watch = self.local_observer_thread.schedule(
             self.fs_event_handler, self.sync.dropbox_path, recursive=True
         )
-        for emitter in self.local_observer_thread.emitters:
-            emitter.setName("maestral-fsemitter")
+        for i, emitter in enumerate(self.local_observer_thread.emitters):
+            emitter.setName(f"maestral-fsemitter-{i}")
 
         self.helper_thread = Thread(
             target=helper, daemon=True, args=(self,), name="maestral-helper"
@@ -4124,9 +4124,9 @@ class SyncMonitor:
         self.sync.cancel_pending.clear()
 
         self.local_observer_thread.stop()
-        self.local_observer_thread.join()
-        self.helper_thread.join()
-        self.upload_thread.join()
+        # self.local_observer_thread.join()
+        # self.helper_thread.join()
+        # self.upload_thread.join()
 
         logger.info(STOPPED)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3638,6 +3638,7 @@ class SyncEngine:
 # Workers for upload, download and connection monitoring threads
 # ======================================================================================
 
+
 def download_worker(
     sync: SyncEngine, syncing: Event, running: Event, connected: Event
 ) -> None:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3995,7 +3995,7 @@ class SyncMonitor:
 
         self.running = Event()  # create new event to let old threads shut down
 
-        self.local_observer_thread = Observer(timeout=0.3)
+        self.local_observer_thread = Observer()
         self.local_observer_thread.setName("maestral-fsobserver")
         self._watch = self.local_observer_thread.schedule(
             self.fs_event_handler, self.sync.dropbox_path, recursive=True

--- a/src/maestral/utils/networkstate.py
+++ b/src/maestral/utils/networkstate.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+
+A module to receive notifications on network status changes. This will aim to use non-
+polling implementations (SCNetworkReachability on macOS and the
+org.freedesktop.NetworkManager Dbus services on Linux) and fall back to polling
+otherwise.
+
+"""
+import logging
+from typing import Callable, Optional
+import platform
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["NetworkConnectionNotifier"]
+
+
+class NetworkConnectionNotifier:
+    """
+    :param host: Host address to check connection.
+    :param on_connect: Callback to invoke when connection is lost.
+    :param on_disconnect: Callback to invoke when connection is established.
+    """
+
+    def __init__(
+        self,
+        host: str = "www.google.com",
+        on_connect: Optional[Callable] = None,
+        on_disconnect: Optional[Callable] = None,
+    ) -> None:
+
+        self.host = host
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+
+        if platform.system() == "Darwin":
+            from .networkstate_macos import NetworkConnectionNotifierMacOS
+
+            self._impl = NetworkConnectionNotifierMacOS(self.host, self._callback)
+
+        elif platform.system() == "Linux":
+            from .networkstate_linux import (
+                NetworkConnectionNotifierDbus,
+                NetworkConnectionNotifierPolling,
+            )
+
+            self._impl = NetworkConnectionNotifierDbus(self.host, self._callback)
+
+            if not self._impl.interface:
+                self._impl = NetworkConnectionNotifierPolling(self.host, self._callback)
+
+        else:
+            raise RuntimeError(f"Unsupported platform {platform.platform()}")
+
+    @property
+    def connected(self) -> bool:
+        return self._impl.connected
+
+    def _callback(self, connected):
+
+        if connected and self.on_connect:
+            self.on_connect()
+        elif self.on_disconnect:
+            self.on_disconnect()

--- a/src/maestral/utils/networkstate.py
+++ b/src/maestral/utils/networkstate.py
@@ -11,6 +11,8 @@ import logging
 from typing import Callable, Optional
 import platform
 
+from .networkstate_base import NetworkConnectionNotifierBase
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +25,8 @@ class NetworkConnectionNotifier:
     :param on_connect: Callback to invoke when connection is lost.
     :param on_disconnect: Callback to invoke when connection is established.
     """
+
+    _impl: NetworkConnectionNotifierBase
 
     def __init__(
         self,

--- a/src/maestral/utils/networkstate_base.py
+++ b/src/maestral/utils/networkstate_base.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from typing import Callable
+
+
+class NetworkConnectionNotifierBase:
+    def __init__(self, host: str, callback: Callable) -> None:
+        self.host = host
+        self.callback = callback
+
+    @property
+    def connected(self) -> bool:
+        raise NotImplementedError()

--- a/src/maestral/utils/networkstate_linux.py
+++ b/src/maestral/utils/networkstate_linux.py
@@ -3,10 +3,10 @@ import logging
 import socket
 import threading
 import time
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, Optional
 
-from dbus_next import BusType
-from dbus_next.aio import MessageBus
+from dbus_next import BusType  # type: ignore
+from dbus_next.aio import MessageBus, ProxyInterface  # type: ignore
 
 from .networkstate_base import NetworkConnectionNotifierBase
 
@@ -21,6 +21,7 @@ class NetworkConnectionNotifierDbus(NetworkConnectionNotifierBase):
     def __init__(self, host: str, callback: Callable) -> None:
         super().__init__(host, callback)
         self._loop = asyncio.get_event_loop()
+        self.interface: Optional[ProxyInterface] = None
         self._force_run_in_loop(self._init_dbus())
 
     def _force_run_in_loop(self, coro: Coroutine) -> None:
@@ -65,7 +66,7 @@ class NetworkConnectionNotifierPolling(NetworkConnectionNotifierBase):
         super().__init__(host, callback)
 
         self.interval = interval
-        self._old_state = None
+        self._old_state: Optional[bool] = None
 
         self._thread = threading.Thread(
             target=self._polling_worker,

--- a/src/maestral/utils/networkstate_linux.py
+++ b/src/maestral/utils/networkstate_linux.py
@@ -1,0 +1,96 @@
+import asyncio
+import logging
+import socket
+import threading
+import time
+from typing import Callable, Coroutine
+
+from dbus_next import BusType
+from dbus_next.aio import MessageBus
+
+from .networkstate_base import NetworkConnectionNotifierBase
+
+
+logger = logging.getLogger(__name__)
+
+NM_CONNECTIVITY_FULL = 4
+
+
+class NetworkConnectionNotifierDbus(NetworkConnectionNotifierBase):
+
+    def __init__(self, host: str, callback: Callable) -> None:
+        super().__init__(host, callback)
+        self._loop = asyncio.get_event_loop()
+        self._force_run_in_loop(self._init_dbus())
+
+    def _force_run_in_loop(self, coro: Coroutine) -> None:
+
+        if self._loop.is_running():
+            asyncio.run_coroutine_threadsafe(coro, self._loop)
+        else:
+            self._loop.run_until_complete(coro)
+
+    async def _init_dbus(self) -> None:
+
+        try:
+            self.bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+            introspection = await self.bus.introspect(
+                "org.freedesktop.NetworkManager", "/org/freedesktop/NetworkManager"
+            )
+            self.proxy_object = self.bus.get_proxy_object(
+                "org.freedesktop.NetworkManager",
+                "/org/freedesktop/NetworkManager",
+                introspection,
+            )
+            self.interface = self.proxy_object.get_interface(
+                "org.freedesktop.NetworkManager"
+            )
+            self.interface.on_state_changed(self._on_state_changed)
+        except Exception:
+            self.interface = None
+            logger.warning("Could not connect to DBUS interface", exc_info=True)
+
+    def _on_state_changed(self, state) -> None:
+        self.callback(state == NM_CONNECTIVITY_FULL)
+
+    @property
+    def connected(self) -> bool:
+        res = self.interface.check_connectivity()
+        return res == NM_CONNECTIVITY_FULL
+
+
+class NetworkConnectionNotifierPolling(NetworkConnectionNotifierBase):
+
+    def __init__(self, host: str, callback: Callable, interval: float = 2.0) -> None:
+        super().__init__(host, callback)
+
+        self.interval = interval
+        self._old_state = None
+
+        self._thread = threading.Thread(
+            target=self._polling_worker,
+            name="maestral-networkstatus-polling",
+            daemon=True,
+        )
+
+    def _polling_worker(self) -> None:
+
+        while True:
+
+            state = self.connected
+
+            if state is not self._old_state:
+                self.callback(state)
+
+            self._old_state = state
+            time.sleep(self.interval)
+
+    @property
+    def connected(self) -> bool:
+        try:
+            host = socket.gethostbyname(self.host)
+            s = socket.create_connection((host, 80), 2)
+            s.close()
+            return True
+        except Exception:
+            return False

--- a/src/maestral/utils/networkstate_linux.py
+++ b/src/maestral/utils/networkstate_linux.py
@@ -17,7 +17,6 @@ NM_CONNECTIVITY_FULL = 4
 
 
 class NetworkConnectionNotifierDbus(NetworkConnectionNotifierBase):
-
     def __init__(self, host: str, callback: Callable) -> None:
         super().__init__(host, callback)
         self._loop = asyncio.get_event_loop()
@@ -64,7 +63,6 @@ class NetworkConnectionNotifierDbus(NetworkConnectionNotifierBase):
 
 
 class NetworkConnectionNotifierPolling(NetworkConnectionNotifierBase):
-
     def __init__(self, host: str, callback: Callable, interval: float = 2.0) -> None:
         super().__init__(host, callback)
 

--- a/src/maestral/utils/networkstate_linux.py
+++ b/src/maestral/utils/networkstate_linux.py
@@ -56,8 +56,11 @@ class NetworkConnectionNotifierDbus(NetworkConnectionNotifierBase):
 
     @property
     def connected(self) -> bool:
-        res = self.interface.check_connectivity()
-        return res == NM_CONNECTIVITY_FULL
+        if self.interface:
+            res = self.interface.check_connectivity()
+            return res == NM_CONNECTIVITY_FULL
+        else:
+            raise RuntimeError("Could not connect to DBUS interface")
 
 
 class NetworkConnectionNotifierPolling(NetworkConnectionNotifierBase):

--- a/src/maestral/utils/networkstate_macos.py
+++ b/src/maestral/utils/networkstate_macos.py
@@ -32,7 +32,7 @@ from ctypes import (
     c_uint32,
 )
 
-from rubicon.objc.runtime import load_library
+from rubicon.objc.runtime import load_library  # type: ignore
 
 from .networkstate_base import NetworkConnectionNotifierBase
 

--- a/src/maestral/utils/networkstate_macos.py
+++ b/src/maestral/utils/networkstate_macos.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2012 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Network state detection on OS X.
+
+NetworkManagerState: class with listening thread, calls back with state changes
+
+TODO: This is taken from the Ubuntu Single Sign-On Python library and can likely be
+  simplified using NWPathMonitor
+
+"""
+from ctypes import (
+    POINTER,
+    CFUNCTYPE,
+    Structure,
+    pointer,
+    c_bool,
+    c_long,
+    c_void_p,
+    c_uint32,
+)
+
+from rubicon.objc.runtime import load_library
+
+from .networkstate_base import NetworkConnectionNotifierBase
+
+
+libsc = load_library("SystemConfiguration")
+libcf = load_library("CoreFoundation")
+
+CFRunLoopGetCurrent = libcf.CFRunLoopGetCurrent
+CFRunLoopGetCurrent.restype = c_void_p
+CFRunLoopGetCurrent.argtypes = []
+
+kCFRunLoopCommonModes = c_void_p.in_dll(libcf, "kCFRunLoopCommonModes")
+
+CFRelease = libcf.CFRelease
+CFRelease.restype = None
+CFRelease.argtypes = [c_void_p]
+
+SCNRCreateWithName = libsc.SCNetworkReachabilityCreateWithName
+SCNRCreateWithName.restype = c_void_p
+
+SCNRGetFlags = libsc.SCNetworkReachabilityGetFlags
+SCNRGetFlags.restype = c_bool
+SCNRGetFlags.argtypes = [c_void_p, POINTER(c_uint32)]
+
+SCNRScheduleWithRunLoop = libsc.SCNetworkReachabilityScheduleWithRunLoop
+SCNRScheduleWithRunLoop.restype = c_bool
+SCNRScheduleWithRunLoop.argtypes = [c_void_p, c_void_p, c_void_p]
+
+SCNRCallbackType = CFUNCTYPE(None, c_void_p, c_uint32, c_void_p)
+# NOTE: need to keep this reference alive as long as a callback might occur.
+
+SCNRSetCallback = libsc.SCNetworkReachabilitySetCallback
+SCNRSetCallback.restype = c_bool
+SCNRSetCallback.argtypes = [c_void_p, SCNRCallbackType, c_void_p]
+
+
+def check_connected_state(hostname):
+    """Calls Synchronous SCNR API, returns bool."""
+    target = SCNRCreateWithName(None, hostname)
+    if target is None:
+        raise RuntimeError("Error creating network reachability reference")
+
+    flags = c_uint32(0)
+    ok = SCNRGetFlags(target, pointer(flags))
+    CFRelease(target)
+
+    if not ok:
+        raise RuntimeError(f"Error getting reachability status of '{hostname}'")
+
+    return flags_say_reachable(flags.value)
+
+
+def flags_say_reachable(flags):
+    """Check flags returned from SCNetworkReachability API. Returns bool.
+
+    Requires some logic:
+    reachable_flag isn't enough on its own.
+
+    A down wifi will return flags = 7, or reachable_flag and
+    connection_required_flag, meaning that the host *would be*
+    reachable, but you need a connection first.  (And then you'd
+    presumably be best off checking again.)
+    """
+    # values from SCNetworkReachability.h
+    reachable_flag = 1 << 1
+    connection_required_flag = 1 << 2
+
+    reachable = flags & reachable_flag
+    connection_required = flags & connection_required_flag
+
+    return reachable and not connection_required
+
+
+class SCNRContext(Structure):
+    """A struct to send as SCNetworkReachabilityContext to SCNRSetCallback.
+
+    We don't use the fields currently.
+    """
+
+    _fields_ = [
+        ("version", c_long),
+        ("info", c_void_p),
+        ("retain", c_void_p),  # func ptr
+        ("release", c_void_p),  # func ptr
+        ("copyDescription", c_void_p),
+    ]  # func ptr
+
+
+class NetworkConnectionNotifierMacOS(NetworkConnectionNotifierBase):
+    def __init__(self, host: str, callback) -> None:
+        super().__init__(host, callback)
+        self.result_cb = callback
+        self.hostname = host
+        self.start_listening()
+
+    def start_listening(self) -> None:
+        """Setup callback and listen for changes."""
+
+        def reachability_state_changed_cb(targetref, flags, info):
+            """Callback for SCNetworkReachability API
+
+            This callback is passed to the SCNetworkReachability API,
+            so its method signature has to be exactly this. Therefore,
+            we declare it here and just call _state_changed with
+            flags."""
+            state = check_connected_state(self.hostname)
+            self.result_cb(state)
+
+        self._c_callback = SCNRCallbackType(reachability_state_changed_cb)
+        self._context = SCNRContext(0, None, None, None, None)
+
+        self._target = SCNRCreateWithName(None, self.hostname)
+        if self._target is None:
+            raise RuntimeError("Error creating SCNetworkReachability target")
+
+        ok = SCNRSetCallback(self._target, self._c_callback, pointer(self._context))
+        if not ok:
+            CFRelease(self._target)
+            raise RuntimeError("Error setting SCNetworkReachability callback")
+
+        ok = SCNRScheduleWithRunLoop(
+            self._target, CFRunLoopGetCurrent(), kCFRunLoopCommonModes
+        )
+        if not ok:
+            CFRelease(self._target)
+            raise RuntimeError("Error scheduling on runloop: SCNetworkReachability")
+
+    @property
+    def connected(self) -> bool:
+        return check_connected_state(self.hostname)

--- a/src/maestral/utils/notify.py
+++ b/src/maestral/utils/notify.py
@@ -22,6 +22,15 @@ from ..constants import APP_NAME, BUNDLE_ID, APP_ICON_PATH
 from .notify_base import DesktopNotifierBase, NotificationLevel, Notification
 
 
+__all__ = [
+    "DesktopNotifier",
+    "DesktopNotifierBase",
+    "MaestralDesktopNotifier",
+    "NotificationLevel",
+    "Notification",
+]
+
+
 class DesktopNotifier:
     """
     Cross-platform desktop notifications for macOS and Linux. Uses different backends

--- a/src/maestral/utils/notify_linux.py
+++ b/src/maestral/utils/notify_linux.py
@@ -13,7 +13,7 @@ from typing import Optional, Type, Coroutine
 
 # external imports
 from dbus_next import Variant  # type: ignore
-from dbus_next.aio import MessageBus  # type: ignore
+from dbus_next.aio import MessageBus, ProxyInterface  # type: ignore
 
 # local imports
 from .notify_base import Notification, DesktopNotifierBase, NotificationLevel
@@ -38,6 +38,7 @@ class DBusDesktopNotifier(DesktopNotifierBase):
     def __init__(self, app_name: str, app_id: str) -> None:
         super().__init__(app_name, app_id)
         self._loop = asyncio.get_event_loop()
+        self.interface: Optional[ProxyInterface] = None
         self._force_run_in_loop(self._init_dbus())
 
     def _force_run_in_loop(self, coro: Coroutine) -> None:


### PR DESCRIPTION
This PR refactors threading and minimises tasks that require frequent polling. As a result, the daemon now comes very close to 0% CPU usage when idle. Changes are:

* Checking for network connection has now been moved to a separate module `.utils.networkstate` which subscribes to updates from the operating system on network status changes:
   - On macOS, this uses `SCNetworkReachability` from the `System Configuration` framework which directly checks for the reachability of a host (www.dropbox.com in our case) and runs a callback when its reachability changes. This requires a running `CFRunLoop` which is already set up by the daemon by default.
   - On Linux, this attempts to use the Dbus service `org.freedesktop.NetworkManager`. This requires a running asyncio event loop which is already set up by the daemon by default. If we cannot connect to the DBus service, we fall back to manually polling the connection. 


* Periodic reindexing is now triggered by an asyncio task.

* Timeouts to wait for local file changes have been increased from 5 sec / 0.3 sec to 40 sec.

* Housekeeping tasks of the Pyro daemon are no longer run every 2 sec but every 20 sec.

* Added a public API `Maestral.status_change_longpoll` to block until a status changes occcurs. This can be used by frontends to check for status changes without frequent polling.

The above changes mean that threads may be blocking to for > 20 sec before they can be cleanly shut down, as was already the case with the download sync thread (the Dropbox API endpoint `files/list_folder/longpoll` may be blocking for up to 60 sec). All threads therefore must be daemons and should not be joined when shutting down. Since all sync operations are already safe with respect to killing the entire process, this is not  problem.