### PR TITLE
Use mignore when creating directorysnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 #### Changed:
 
 * Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
+* Performance has been improved by avoiding scanning of objects matching an 
+  `.mignore` pattern (file watches will still be added however). A resulting behavioral change
+  is that **maestral will remove existing matching files from Dropbox as well**. After this change
+  it will be immaterial if an `.mignore` pattern is added before or after having matching files 
+  in Dropbox.
   
 #### Fixes:
 


### PR DESCRIPTION
This PR uses a custom `listdir` function in `DirectorySnapshot` to take into account the `mignore` rules.

Using this PR, there is no need to snapshot ignored folders which can save considerable time and memory.

Fixes #216

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Note: there are no new features, just performance improvements
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
