### PR TITLE
Refactor notifications

### DIFF
--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -1436,19 +1436,19 @@ def log_level(level_name: str, config_name: str) -> None:
 @click.argument(
     "level_name",
     required=False,
-    type=click.Choice(["NONE", "ERROR", "SYNCISSUE", "FILECHANGE"]),
+    type=click.Choice(["ERROR", "SYNCISSUE", "FILECHANGE"]),
 )
 @existing_config_option
 def notify_level(level_name: str, config_name: str) -> None:
 
-    from .utils.notify import MaestralDesktopNotifier as MDN
+    from .utils.notify import MaestralDesktopNotifier as Notifier
 
     with MaestralProxy(config_name, fallback=True) as m:
         if level_name:
-            m.notification_level = MDN.level_name_to_number(level_name)
+            m.notification_level = Notifier.level_name_to_number(level_name)
             click.echo(f"Notification level set to {level_name}.")
         else:
-            level_name = MDN.level_number_to_name(m.notification_level)
+            level_name = Notifier.level_number_to_name(m.notification_level)
             click.echo(f"Notification level: {level_name}.")
 
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -834,7 +834,8 @@ class SyncEngine:
 
         self._conf = MaestralConfig(self.config_name)
         self._state = MaestralState(self.config_name)
-        self._notifier = MaestralDesktopNotifier.for_config(self.config_name)
+
+        self.notifier = MaestralDesktopNotifier(self.config_name)
 
         # upload_errors / download_errors: contains failed uploads / downloads
         # (from sync errors) to retry later
@@ -3099,7 +3100,7 @@ class SyncEngine:
         else:
             msg = f"{file_name} {change_type}"
 
-        self._notifier.notify("Items synced", msg, on_click=callback)
+        self.notifier.notify("Items synced", msg, on_click=callback)
 
     def _filter_excluded_changes_remote(
         self, changes: List[SyncEvent]

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1732,6 +1732,11 @@ class SyncEngine:
             # we have a file / folder associated with the sync error
             file_name = osp.basename(err.dbx_path)
             logger.warning("Could not sync %s", file_name, exc_info=True)
+            self.notifier.notify(
+                "Sync error",
+                f"Could not sync {file_name}",
+                level=self.notifier.SYNCISSUE,
+            )
             self.sync_errors.add(err)
 
             # save download errors to retry later


### PR DESCRIPTION
* Separate manual desktop notifier and logging handler into different classes.
* Keep the desktop notification logging handler always on level ERROR.
* Emit all other notifications (file changes, sync issues, etc) explicitly and not indirectly through logger. This reduces unintentional / hidden side effects of log messages.
* Remove the CLI option to completely disable desktop notifications. Error messages will now always trigger a notification.