### PR TITLE
Fix conflict resolution

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2989,7 +2989,8 @@ class SyncEngine:
         # apply deleted items
         if deleted:
             logger.info("Applying deletions...")
-        for items in deleted.values():
+        for level in sorted(deleted):
+            items = deleted[level]
             with ThreadPoolExecutor(
                 max_workers=self._num_threads,
                 thread_name_prefix="maestral-download-pool",
@@ -3004,7 +3005,8 @@ class SyncEngine:
         # create local folders, start with top-level and work your way down
         if folders:
             logger.info("Creating folders...")
-        for items in folders.values():
+        for level in sorted(folders):
+            items = folders[level]
             with ThreadPoolExecutor(
                 max_workers=self._num_threads,
                 thread_name_prefix="maestral-download-pool",

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2974,12 +2974,12 @@ class SyncEngine:
 
             level = event.dbx_path.count("/")
 
-            if event.is_file:
+            if event.is_deleted:
+                add_to_bin(deleted, level, event)
+            elif event.is_file:
                 files.append(event)
             elif event.is_directory:
                 add_to_bin(folders, level, event)
-            elif event.is_deleted:
-                add_to_bin(deleted, level, event)
 
             # housekeeping
             self.syncing.append(event)

--- a/tests/linked/fixtures.py
+++ b/tests/linked/fixtures.py
@@ -85,7 +85,7 @@ def cleanup_test_config(m: Maestral, test_folder_dbx: Optional[str] = None) -> N
 
     # remove local files and folders
     delete(m.dropbox_path)
-    remove_configuration("test-config")
+    remove_configuration(m.config_name)
 
 
 class DropboxTestLock:

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -356,6 +356,7 @@ class TestSync(TestCase):
 
     def test_local_deletion_during_upload(self):
 
+        # we mimic a deletion during upload by queueing a fake FileCreatedEvent
         fake_created_event = FileCreatedEvent(self.test_folder_local + "/file.txt")
         self.m.monitor.fs_event_handler.local_file_event_queue.put(fake_created_event)
 


### PR DESCRIPTION
This PR fixes errors in conflict resolution which were introduced in #221. Those occur because a download sync is no longer always followed by an upload sync and the local cursor is therefore no longer incremented after every download sync. We can therefore no longer compare a file's ctime to the local cursor to check for conflicts. Instead, a new API `SyncEngine.has_unsynced_changes` is introduced which recurses over the subtree from the given path and compares it to our index.

Two related errors are also fixed:

1.  An issue where remote deleted events where incorrectly classified, leading to some deletions being incorrectly applied after other sync events. This did not lead to any known issues.

2. An issue where remote deletions and folder creations where applied in the order provided by Dropbox instead of hierarchically. This could lead to a performance impact when resolving folder casing.