### PR TITLE
Selective sync updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,21 @@
 * Increased timeout for all event queues.
 * Decreased the frequency of Pyro daemon housekeeping tasks.
 * Improved performance when syncing a large number of remote deletions.
+* The `Maestral.exclude_item()` API now accepts paths which lie inside an excluded 
+  folder. When called with such a path, all immediate parents will be included as well.
+* The `Maestral.excluded_items` property is no longer read-only.
 
 #### Fixes:
 
 * Fixes an issue where `maestral ls` would fail when run with the `-l, --long` flag.
 * Fixes an `IndexError` during a download sync when trying to query past versions of a
   deleted item.
+* Fixes an issue which could case a segfault of the selective sync dialog on macOS.
+
+#### Deprecated:
+
+* Deprecated the `Maestral.set_excluded_items` API. Use the setter for
+  `Maestral.excluded_items` instead.
 
 ## v1.2.2
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -24,7 +24,7 @@ try:
     from concurrent.futures import InvalidStateError  # type: ignore
 except ImportError:
     # Python 3.7 and lower
-    InvalidStateError = RuntimeError
+    InvalidStateError = RuntimeError  # type: ignore
 
 # external imports
 import requests

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1118,12 +1118,16 @@ class Maestral:
         to call this method with items which have already been included, they will not
         be downloaded again.
 
+        If the path lies inside an excluded folder, all its immediate parents will be
+        included. Other children of the excluded folder will remain excluded.
+
+        If any children of dbx_path were excluded, they will now be included.
+
         Any downloads will be carried out by the sync threads. Errors during the
         download can be accessed through :attr:`sync_errors` or :attr:`maestral_errors`.
 
         :param dbx_path: Dropbox path of item to include.
         :raises: :class:`errors.NotFoundError` if there is nothing at the given path
-        :raises: :class:`errors.PathError` if the path lies inside an excluded folder
         :raises: :class:`errors.DropboxAuthError` in case of an invalid access token
         :raises: :class:`errors.DropboxServerError` for internal Dropbox errors
         :raises: :class:`ConnectionError` if connection to Dropbox fails
@@ -1134,87 +1138,56 @@ class Maestral:
         self._check_linked()
         self._check_dropbox_dir()
 
-        # input validation
+        # ---- input validation --------------------------------------------------------
         md = self.client.get_metadata(dbx_path)
 
         if not md:
             raise NotFoundError(
-                "Cannot include item", f'"{dbx_path}" does not exist on Dropbox'
+                "Cannot include item",
+                f'"{dbx_path}" does not exist on Dropbox',
             )
 
         dbx_path = dbx_path.lower().rstrip("/")
 
-        old_excluded_items = self.sync.excluded_items
+        # ---- update excluded items list ----------------------------------------------
 
-        for folder in old_excluded_items:
+        excluded_items = set(self.sync.excluded_items)
+
+        # remove dbx_path from list
+        try:
+            excluded_items.remove(dbx_path)
+        except KeyError:
+            pass
+
+        excluded_parent: Optional[str] = None
+
+        for folder in excluded_items.copy():
+
+            # include all parents which are required to download dbx_path
             if is_child(dbx_path, folder):
-                raise PathError(
-                    "Cannot include item",
-                    f'"{dbx_path}" lies inside the excluded folder '
-                    f'"{folder}". Please include "{folder}" first.',
-                )
+                # remove parent folder from excluded list
+                excluded_items.remove(folder)
+                # add all children of parent folder which do not lead to dbx_path
+                for res in self.client.list_folder_iterator(folder):
+                    for entry in res.entries:
+                        if not is_equal_or_child(dbx_path, entry.path_lower):
+                            excluded_items.add(entry.path_lower)
 
-        # Get items which will need to be downloaded, do not attempt to download
-        # children of `dbx_path` which were already included.
-        # `new_included_items` will either be empty (`dbx_path` was already
-        # included), just contain `dbx_path` itself (the item was fully excluded) or
-        # only contain children of `dbx_path` (`dbx_path` was partially included).
-        new_included_items = tuple(
-            x for x in old_excluded_items if x == dbx_path or is_child(x, dbx_path)
-        )
+                excluded_parent = folder
 
-        if new_included_items:
-            # remove `dbx_path` or all excluded children from the excluded list
-            excluded_items = list(set(old_excluded_items) - set(new_included_items))
+            # include all children of dbx_path
+            if is_child(folder, dbx_path):
+                excluded_items.remove(folder)
+
+        self.sync.excluded_items = list(excluded_items)
+
+        # download item from Dropbox
+        if excluded_parent:
+            logger.info("Included %s and parent directories", dbx_path)
+            self.monitor.added_item_queue.put(excluded_parent)
         else:
-            logger.info("%s was already included", dbx_path)
-            return
-
-        self.sync.excluded_items = excluded_items
-
-        logger.info("Included %s", dbx_path)
-
-        # download items from Dropbox
-        for folder in new_included_items:
-            self.monitor.added_item_queue.put(folder)
-
-    def set_excluded_items(self, items: List[str]) -> None:
-        """
-        Sets the list of excluded files or folders. Items which are not in ``items`` but
-        were previously excluded will be downloaded.
-
-        Any downloads will be carried out by the sync threads. Errors during the
-        download can be accessed through :attr:`sync_errors` or :attr:`maestral_errors`.
-
-        On initial sync, this does not trigger any downloads.
-
-        :param items: List of excluded files or folders to set.
-        :raises: :class:`errors.NotLinkedError` if no Dropbox account is linked
-        :raises: :class:`errors.NoDropboxDirError` if local Dropbox folder is not set up
-        """
-
-        self._check_linked()
-        self._check_dropbox_dir()
-
-        excluded_items = self.sync.clean_excluded_items_list(items)
-        old_excluded_items = self.sync.excluded_items
-
-        added_excluded_items = set(excluded_items) - set(old_excluded_items)
-        added_included_items = set(old_excluded_items) - set(excluded_items)
-
-        self.sync.excluded_items = excluded_items
-
-        if not self.pending_first_download:
-            # apply changes
-            for path in added_excluded_items:
-                logger.info("Excluded %s", path)
-                self._remove_after_excluded(path)
-            for path in added_included_items:
-                if not self.sync.is_excluded_by_user(path):
-                    logger.info("Included %s", path)
-                    self.monitor.added_item_queue.put(path)
-
-        logger.info(IDLE)
+            logger.info("Included %s", dbx_path)
+            self.monitor.added_item_queue.put(dbx_path)
 
     def excluded_status(self, dbx_path: str) -> str:
         """

--- a/tests/linked/test_main.py
+++ b/tests/linked/test_main.py
@@ -116,19 +116,19 @@ class TestAPI(TestCase):
         self.assertEqual(FileStatus.Error.value, file_status)
 
     def test_selective_sync_api(self):
-        """Test `Maestral.exclude_item` and  Maestral.include_item`."""
+        """Test `Maestral.exclude_item` and Maestral.include_item`."""
 
         test_path_local = self.test_folder_local + "/selective_sync_test_folder"
         test_path_local_sub = test_path_local + "/subfolder"
         test_path_dbx = self.test_folder_dbx + "/selective_sync_test_folder"
         test_path_dbx_sub = test_path_dbx + "/subfolder"
 
-        # create a local folder 'folder'
+        # create a local folder test_path_local
         os.mkdir(test_path_local)
         os.mkdir(test_path_local_sub)
         self.wait_for_idle()
 
-        # exclude 'folder' from sync
+        # exclude test_path_dbx from sync
         self.m.exclude_item(test_path_dbx)
         self.wait_for_idle()
 
@@ -140,7 +140,7 @@ class TestAPI(TestCase):
             self.m.excluded_status(self.test_folder_dbx), "partially excluded"
         )
 
-        # include 'folder' in sync
+        # include test_path_dbx in sync, check that it worked
         self.m.include_item(test_path_dbx)
         self.wait_for_idle()
 
@@ -149,13 +149,18 @@ class TestAPI(TestCase):
         self.assertEqual(self.m.excluded_status(self.test_folder_dbx), "included")
         self.assertEqual(self.m.excluded_status(test_path_dbx_sub), "included")
 
-        # exclude 'folder' again for further tests
+        # exclude test_path_dbx again for further tests
         self.m.exclude_item(test_path_dbx)
         self.wait_for_idle()
 
-        # test including a folder inside 'folder'
-        with self.assertRaises(PathError):
-            self.m.include_item(test_path_dbx + "/subfolder")
+        # test including a folder inside test_path_dbx,
+        # test_path_dbx should become included itself
+        self.m.include_item(test_path_dbx + "/subfolder")
+        self.assertNotIn(
+            test_path_dbx,
+            self.m.excluded_items,
+            'test_path_dbx still in "excluded_items" list',
+        )
 
         # test that 'folder' is removed from excluded_list on deletion
         self.m.client.remove(test_path_dbx)


### PR DESCRIPTION
* Allow setting `Maestral.excluded_items` directly
* Allow including items that lie within excluded folders through `Maestral.include_item()`
* Deprecate `Maestral.set_excluded_items()`
