### PR TITLE
Move code for printing tables and grids to cli to separate module

### DIFF
--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -33,7 +33,7 @@ from .daemon import (
     is_running,
 )
 from .config import MaestralConfig, MaestralState, list_configs
-from .utils.cli import Column, Table, Align, Elide, Grid, TextField, DateField
+from .utils.cli import Column, Table, Align, Elide, Grid, TextField, DateField, Field
 from .utils.housekeeping import remove_configuration, validate_config_name
 
 
@@ -857,6 +857,8 @@ def ls(long: bool, dropbox_path: str, include_deleted: bool, config_name: str) -
                     size = natural_size(cast(float, entry["size"]))
                 else:
                     size = "-"
+
+                dt_field: Field
 
                 if "client_modified" in entry:
                     cm = cast(str, entry["client_modified"])

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -14,7 +14,7 @@ import os.path as osp
 import functools
 import textwrap
 import time
-from typing import Optional, List, Dict, Iterable, Callable, Union, TypeVar, cast
+from typing import Optional, List, Dict, Iterable, Callable, cast
 
 # external imports
 import click
@@ -33,16 +33,13 @@ from .daemon import (
     is_running,
 )
 from .config import MaestralConfig, MaestralState, list_configs
+from .utils.cli import Column, Table, Align, Elide, Grid, TextField
 from .utils.housekeeping import remove_configuration, validate_config_name
 
 
 OK = click.style("[OK]", fg="green")
 FAILED = click.style("[FAILED]", fg="red")
 KILLED = click.style("[KILLED]", fg="red")
-
-LEFT, CENTER, RIGHT = range(3)
-
-T = TypeVar("T")
 
 
 def stop_daemon_with_cli_feedback(config_name: str) -> None:
@@ -223,112 +220,6 @@ def catch_maestral_errors(func: Callable) -> Callable:
             raise click.ClickException("Could not connect to Dropbox.")
 
     return wrapper
-
-
-def _transpose(ll: List[List[T]]) -> List[List[T]]:
-    return list(map(list, zip(*ll)))
-
-
-def format_table(
-    rows: Optional[List[List[str]]] = None,
-    columns: Optional[List[List[str]]] = None,
-    headers: Optional[List[str]] = None,
-    padding: int = 2,
-    alignment: Optional[Union[int, List[int]]] = None,
-    wrap: bool = True,
-):
-    """
-    Prints given data as a pretty table. Either rows or columns must be given.
-
-    :param rows: List of strings for table rows.
-    :param columns: List of strings for table columns.
-    :param headers: List of strings for column titles.
-    :param padding: Padding between columns.
-    :param alignment: List of alignments for every column. Values can be ``LEFT``,
-        ``CENTER``, ``RIGHT``. If not given, defaults to left alignment.
-    :param wrap: If ``True``, wrap cell content to fit the terminal width.
-    :returns: Formatted multi-line string.
-    """
-
-    if rows and columns:
-        raise ValueError("Cannot give both rows and columns as input.")
-
-    if not columns:
-        if rows:
-            columns = list(columns) if columns else _transpose(rows)
-        else:
-            raise ValueError("Must give either rows or columns as input.")
-
-    if headers:
-        for i, col in enumerate(columns):
-            col.insert(0, headers[i])
-
-    # return early if all columns are empty (including headers)
-    if all(len(col) == 0 for col in columns):
-        return ""
-
-    # default to left alignment
-    if not alignment:
-        alignment = [LEFT] * len(columns)
-    elif isinstance(alignment, int):
-        alignment = [alignment] * len(columns)
-    elif len(alignment) != len(columns):
-        raise ValueError("Must give an alignment for every column.")
-
-    # determine column widths from terminal width and padding
-
-    col_widths = tuple(max(len(cell) for cell in col) for col in columns)
-
-    if wrap:
-
-        terminal_width, terminal_height = click.get_terminal_size()
-        available_width = terminal_width - padding * len(columns)
-
-        n = 3
-        sum_widths = sum(w ** n for w in col_widths)
-        subtract = max([sum(col_widths) - available_width, 0])
-        col_widths = tuple(
-            round(w - subtract * w ** n / sum_widths) for w in col_widths
-        )
-
-    # wrap strings to fit column
-
-    wrapped_columns: List[List[List[str]]] = []
-
-    for column, width in zip(columns, col_widths):
-        wrapped_columns.append([textwrap.wrap(cell, width=width) for cell in column])
-
-    wrapped_rows = _transpose(wrapped_columns)
-
-    # generate lines by filling columns
-
-    lines = []
-
-    for row in wrapped_rows:
-        n_lines = max(len(cell) for cell in row)
-        for cell in row:
-            cell += [""] * (n_lines - len(cell))
-
-        for i in range(n_lines):
-            line = ""
-            for cell, width, align in zip(row, col_widths, alignment):
-
-                if align == LEFT:
-                    line += cell[i].ljust(width)
-                elif align == RIGHT:
-                    line += cell[i].rjust(width)
-                elif align == CENTER:
-                    line += cell[i].center(width)
-                else:
-                    raise ValueError(
-                        "Alignment must be LEFT = 0, CENTER = 1, RIGHT = 2"
-                    )
-
-                line += " " * padding
-
-            lines.append(line)
-
-    return "\n".join(lines)
 
 
 # ======================================================================================
@@ -757,14 +648,20 @@ def status(config_name: str) -> None:
 
             check_for_fatal_errors(m)
 
-            sync_err_list = m.sync_errors
+            sync_errors = m.sync_errors
 
-            if len(sync_err_list) > 0:
-                headers = ["PATH", "ERROR"]
-                col0 = ["'{}'".format(err["dbx_path"]) for err in sync_err_list]
-                col1 = ["{title}. {message}".format(**err) for err in sync_err_list]
+            if len(sync_errors) > 0:
 
-                click.echo(format_table(columns=[col0, col1], headers=headers))
+                path_column = Column(title="Path")
+                message_column = Column(title="Error", wraps=True)
+
+                for error in sync_errors:
+                    path_column.append(error["dbx_path"])
+                    message_column.append("{title}. {message}".format(**error))
+
+                table = Table([path_column, message_column])
+
+                table.echo()
                 click.echo("")
 
     except Pyro5.errors.CommunicationError:
@@ -924,83 +821,60 @@ def ls(long: bool, dropbox_path: str, include_deleted: bool, config_name: str) -
 
         if long:
 
-            names = []
-            types = []
-            sizes = []
-            shared = []
-            last_modified = []
-            excluded = []
-
             to_short_type = {
                 "FileMetadata": "file",
                 "FolderMetadata": "folder",
                 "DeletedMetadata": "deleted",
             }
 
-            for e in entries:
+            table = Table(
+                columns=[
+                    Column("Name"),
+                    Column("Type"),
+                    Column("Size", align=Align.Right),
+                    Column("Shared"),
+                    Column("Syncing"),
+                    Column("Last Modified"),
+                ]
+            )
 
-                long_type = cast(str, e["type"])
-                name = cast(str, e["name"])
-                path_lower = cast(str, e["path_lower"])
+            for entry in entries:
 
-                types.append(to_short_type[long_type])
-                names.append(name)
+                item_type = to_short_type[cast(str, entry["type"])]
+                name = cast(str, entry["name"])
+                path_lower = cast(str, entry["path_lower"])
 
-                shared.append("shared" if "sharing_info" in e else "private")
-                excluded.append(m.excluded_status(path_lower))
+                shared = "shared" if "sharing_info" in entry else "private"
+                excluded = m.excluded_status(path_lower)
 
-                if "size" in e:
-                    size = cast(float, e["size"])
-                    sizes.append(natural_size(size))
+                if "size" in entry:
+                    size = natural_size(cast(float, entry["size"]))
                 else:
-                    sizes.append("-")
+                    size = "-"
 
-                if "client_modified" in e:
-                    cm = cast(str, e["client_modified"])
+                if "client_modified" in entry:
+                    cm = cast(str, entry["client_modified"])
                     dt = datetime.strptime(cm, "%Y-%m-%dT%H:%M:%S%z").astimezone()
-                    last_modified.append(dt.strftime("%d %b %Y %H:%M"))
                 else:
-                    last_modified.append("-")
+                    dt = "-"
+
+                table.append([name, item_type, size, shared, excluded, dt])
 
             click.echo("")
-            click.echo(
-                format_table(
-                    headers=["Name", "Type", "Size", "Shared", "Syncing", "Modified"],
-                    columns=[names, types, sizes, shared, excluded, last_modified],
-                    alignment=[LEFT, LEFT, RIGHT, LEFT, LEFT, LEFT],
-                    wrap=False,
-                ),
-            )
+            table.echo()
             click.echo("")
 
         else:
 
-            from .utils import chunks
+            grid = Grid()
 
-            names = []
-            colors = []
-            formatted_names = []
-            max_len = 0
+            for entry in entries:
+                name = cast(str, entry["name"])
+                color = "blue" if entry["type"] == "DeletedMetadata" else None
 
-            for e in entries:
-                name = cast(str, e["name"])
+                grid.append(TextField(name, fg=color))
 
-                max_len = max(max_len, len(name))
-                names.append(name)
-                colors.append("blue" if e["type"] == "DeletedMetadata" else None)
-
-            max_len += 2  # add 2 spaces padding
-
-            for name, color in zip(names, colors):
-                formatted_names.append(click.style(name.ljust(max_len), fg=color))
-
-            width, height = click.get_terminal_size()
-            n_columns = max(width // max_len, 1)
-
-            rows = chunks(formatted_names, n_columns)
-
-            for row in rows:
-                click.echo("".join(row))
+            grid.echo()
 
 
 @main.command(help_priority=11, help="Links Maestral with your Dropbox account.")
@@ -1117,20 +991,19 @@ def revs(dropbox_path: str, config_name: str) -> None:
 
         entries = m.list_revisions(dropbox_path)
 
-    revs = []
-    last_modified = []
+    table = Table(["Revision", "Last Modified"])
 
-    for e in entries:
+    for entry in entries:
 
-        rev = cast(str, e["rev"])
-        cm = cast(str, e["client_modified"])
-
-        revs.append(rev)
+        rev = cast(str, entry["rev"])
+        cm = cast(str, entry["client_modified"])
 
         dt = datetime.strptime(cm, "%Y-%m-%dT%H:%M:%S%z").astimezone()
-        last_modified.append(dt.strftime("%d %b %Y %H:%M"))
+        table.append([rev, dt])
 
-    click.echo(format_table(columns=[revs, last_modified]))
+    click.echo("")
+    table.echo()
+    click.echo("")
 
 
 @main.command(
@@ -1157,9 +1030,9 @@ def history(config_name: str) -> None:
     with MaestralProxy(config_name, fallback=True) as m:
         history = m.get_history()
 
-    paths = []
-    change_times = []
-    change_types = []
+    table = Table(
+        [Column("Path", elide=Elide.Leading), Column("Change"), Column("Time")]
+    )
 
     for event in history:
 
@@ -1168,11 +1041,11 @@ def history(config_name: str) -> None:
         change_time_or_sync_time = cast(float, event["change_time_or_sync_time"])
         dt = datetime.fromtimestamp(change_time_or_sync_time)
 
-        paths.append(dbx_path)
-        change_times.append(dt.strftime("%d %b %Y %H:%M"))
-        change_types.append(change_type)
+        table.append([dbx_path, change_type, dt])
 
-    click.echo(format_table(columns=[paths, change_types, change_times], wrap=False))
+    click.echo("")
+    table.echo()
+    click.echo("")
 
 
 @main.command(help_priority=19, help="Lists all configured Dropbox accounts.")
@@ -1190,10 +1063,10 @@ def configs() -> None:
     names = list_configs()
     emails = [MaestralState(c).get("account", "email") for c in names]
 
+    table = Table([Column("Config name", names), Column("Account", emails)])
+
     click.echo("")
-    click.echo(
-        format_table(columns=[names, emails], headers=["Config name", "Account"])
-    )
+    table.echo()
     click.echo("")
 
 

--- a/src/maestral/utils/cli.py
+++ b/src/maestral/utils/cli.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+
+import enum
+import textwrap
+from datetime import datetime
+from typing import Optional, List, Union, TypeVar, Iterator, Sequence, Any
+
+import click
+
+
+_T = TypeVar("_T")
+
+
+def _transpose(ll: List[List[_T]]) -> List[List[_T]]:
+    return list(map(list, zip(*ll)))
+
+
+class Align(enum.Enum):
+    Left = 0
+    Right = 1
+
+
+class Elide(enum.Enum):
+    Leading = 0
+    Center = 1
+    Trailing = 2
+
+
+def elide(
+    text: str, width: int, placeholder: str = "...", elide: Elide = Elide.Trailing
+) -> str:
+
+    if len(text) <= width:
+        return text
+
+    available = width - len(placeholder)
+
+    if elide is Elide.Trailing:
+        return text[:available] + placeholder
+    elif elide is Elide.Leading:
+        return placeholder + text[-available:]
+    else:
+        half_available = available // 2
+        return text[:half_available] + placeholder + text[-half_available:]
+
+
+def adjust(text: str, width: int, align: Align = Align.Left) -> str:
+
+    needed = width - len(click.unstyle(text))
+
+    if needed > 0:
+        if align == Align.Left:
+            return text + " " * needed
+        else:
+            return " " * needed + text
+    else:
+        return text
+
+
+class Field:
+    @property
+    def display_width(self) -> int:
+        raise NotImplementedError()
+
+    def format(self, width: int) -> List[str]:
+        raise NotImplementedError()
+
+
+class TextField(Field):
+    def __init__(
+        self,
+        text: str,
+        align: Align = Align.Left,
+        wraps: bool = False,
+        elide: Elide = Elide.Trailing,
+        **style,
+    ) -> None:
+        self.text = text
+        self.align = align
+        self.wraps = wraps
+        self.elide = elide
+        self.style = style
+
+    @property
+    def display_width(self) -> int:
+        return len(self.text)
+
+    def format(self, width: int) -> List[str]:
+
+        if self.wraps:
+            lines = textwrap.wrap(self.text, width=width)
+        else:
+            lines = [elide(self.text, width, elide=self.elide)]
+
+        # apply style first, adjust later
+
+        if self.style:
+            lines = [click.style(line, **self.style) for line in lines]
+
+        return [adjust(line, width, self.align) for line in lines]
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}('{self.text}')>"
+
+
+class DateField(Field):
+    def __init__(self, dt: datetime) -> None:
+        self.dt = dt
+
+    @property
+    def display_width(self) -> int:
+        return 20
+
+    def format(self, width: int) -> List[str]:
+        if width >= 20:
+            return [self.dt.strftime("%d %b %Y at %H:%M")]
+        elif width >= 17:
+            return [self.dt.strftime("%x, %H:%M")]
+        else:
+            return [self.dt.strftime("%x")]
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}('{self.format(17)}')>"
+
+
+class Column:
+    def __init__(
+        self,
+        title: str,
+        fields: Sequence = (),
+        align: Align = Align.Left,
+        wraps: bool = False,
+        elide: Elide = Elide.Trailing,
+    ) -> None:
+        self.fields = [TextField(title, align=align, bold=True)]
+        self.align = align
+        self.wraps = wraps
+        self.elide = elide
+
+        for field in fields:
+            self.fields.append(self._to_field(field))
+
+    @property
+    def display_width(self) -> int:
+        return max(field.display_width for field in self.fields)
+
+    def append(self, field: Any) -> None:
+        self.fields.append(self._to_field(field))
+
+    def insert(self, index: int, field: Any) -> None:
+        self.fields.insert(index, self._to_field(field))
+
+    def __getitem__(self, item: int) -> Field:
+        return self.fields[item]
+
+    def __setitem__(self, key: int, value: Any) -> None:
+        self.fields[key] = self._to_field(value)
+
+    def __iter__(self) -> Iterator[Field]:
+        return iter(self.fields)
+
+    def __len__(self) -> int:
+        return len(self.fields)
+
+    def _to_field(self, field: Any) -> Field:
+        if isinstance(field, Field):
+            return field
+        elif isinstance(field, datetime):
+            return DateField(field)
+        else:
+            return TextField(
+                str(field), align=self.align, wraps=self.wraps, elide=self.elide
+            )
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(title='{self.fields[0].text}')>"
+
+
+class Table:
+
+    columns: List[Column]
+
+    def __init__(self, columns: List[Union[Column, str]], padding: int = 2) -> None:
+        self.columns = []
+        self.padding = padding
+
+        for col in columns:
+            if isinstance(col, Column):
+                self.columns.append(col)
+            else:
+                self.columns.append(Column(col))
+
+    def append(self, row: Sequence) -> None:
+        for i, col in enumerate(self.columns):
+            col.append(row[i])
+
+    def insert(self, index: int, row: Sequence) -> None:
+        for i, col in enumerate(self.columns):
+            col.insert(index, row[i])
+
+    def __getitem__(self, item: int) -> List[Field]:
+        return [col[item] for col in self.columns]
+
+    def __setitem__(self, key: int, value: Sequence):
+        for i, col in enumerate(self.columns):
+            col[key] = value[i]
+
+    def __iter__(self) -> Iterator[List[Field]]:
+        return iter([col[i] for col in self.columns] for i in range(len(self)))
+
+    def __len__(self) -> int:
+        return max(len(col) for col in self.columns)
+
+    def format_lines(self, width: Optional[int] = None) -> Iterator[str]:
+
+        # get terminal width if no width is given
+        if not width:
+            width, height = click.get_terminal_size()
+
+        available_width = width - self.padding * len(self.columns)
+        raw_col_widths = [col.display_width for col in self.columns]
+
+        # Allocate column width from available width,
+        # weighted by the raw width of each column.
+        n = 3
+        sum_widths = sum(w ** n for w in raw_col_widths)
+        subtract = max([sum(raw_col_widths) - available_width, 0])
+        allocated_col_widths = tuple(
+            round(w - subtract * w ** n / sum_widths) for w in raw_col_widths
+        )
+
+        # generate lines
+        spacer = " " * self.padding
+
+        for row in self:
+            cells = []
+
+            for field, alloc_width in zip(row, allocated_col_widths):
+                cells.append(field.format(alloc_width))
+
+            n_lines = max(len(cell) for cell in cells)
+
+            for i in range(n_lines):
+
+                line_parts = []
+
+                for cell_lines, alloc_width in zip(cells, allocated_col_widths):
+                    try:
+                        line_parts.append(cell_lines[i])
+                    except IndexError:
+                        line_parts.append(adjust("", width=alloc_width))
+
+                line = spacer.join(line_parts)
+                yield line.rstrip()
+
+    def format(self, width: Optional[int] = None) -> str:
+        return "\n".join(self.format_lines(width))
+
+    def echo(self):
+        for line in self.format_lines():
+            click.echo(line)
+
+
+class Grid:
+
+    fields: List[Field]
+
+    def __init__(
+        self, fields: Sequence = (), padding: int = 2, align: Align = Align.Left
+    ):
+
+        self.fields = []
+        self.padding = padding
+        self.align = align
+
+        for field in fields:
+            self.fields.append(self._to_field(field))
+
+    def append(self, field) -> None:
+        self.fields.append(self._to_field(field))
+
+    def insert(self, index: int, field: Any) -> None:
+        self.fields.insert(index, self._to_field(field))
+
+    def __getitem__(self, item) -> Field:
+        return self.fields[item]
+
+    def __setitem__(self, key: int, value: Field):
+        self.fields[key] = self._to_field(value)
+
+    def __iter__(self) -> Iterator:
+        return iter(self.fields)
+
+    def __len__(self) -> int:
+        return len(self.fields)
+
+    def _to_field(self, field: Any) -> Field:
+        if isinstance(field, Field):
+            return field
+        elif isinstance(field, datetime):
+            return DateField(field)
+        else:
+            return TextField(str(field), align=self.align)
+
+    def format_lines(self, width: Optional[int] = None) -> Iterator[str]:
+
+        from . import chunks
+
+        # get terminal width if no width is given
+        if not width:
+            width, height = click.get_terminal_size()
+
+        field_width = max(field.display_width for field in self.fields)
+        field_width = min(field_width, width)  # cap at terminal / total width
+        field_texts = [field.format(field_width)[0] for field in self.fields]
+
+        n_columns = max(width // (field_width + self.padding), 1)
+
+        rows = chunks(field_texts, n_columns)
+        spacer = " " * self.padding
+
+        for row in rows:
+            line = spacer.join(row)
+            yield line.rstrip()
+
+    def format(self, width: Optional[int] = None) -> str:
+        return "\n".join(self.format_lines(width))
+
+    def echo(self):
+        for line in self.format_lines():
+            click.echo(line)

--- a/src/maestral/utils/cli.py
+++ b/src/maestral/utils/cli.py
@@ -424,24 +424,29 @@ class Grid:
         :returns: Iterator over lines which can be printed to the terminal.
         """
 
-        from . import chunks
+        if len(self.fields) > 0:
 
-        # get terminal width if no width is given
-        if not width:
-            width, height = click.get_terminal_size()
+            from . import chunks
 
-        field_width = max(field.display_width for field in self.fields)
-        field_width = min(field_width, width)  # cap at terminal / total width
-        field_texts = [field.format(field_width)[0] for field in self.fields]
+            # get terminal width if no width is given
+            if not width:
+                width, height = click.get_terminal_size()
 
-        n_columns = max(width // (field_width + self.padding), 1)
+            field_width = max(field.display_width for field in self.fields)
+            field_width = min(field_width, width)  # cap at terminal / total width
+            field_texts = [field.format(field_width)[0] for field in self.fields]
 
-        rows = chunks(field_texts, n_columns)
-        spacer = " " * self.padding
+            n_columns = max(width // (field_width + self.padding), 1)
 
-        for row in rows:
-            line = spacer.join(row)
-            yield line.rstrip()
+            rows = chunks(field_texts, n_columns)
+            spacer = " " * self.padding
+
+            for row in rows:
+                line = spacer.join(row)
+                yield line.rstrip()
+
+        else:
+            yield ""
 
     def format(self, width: Optional[int] = None) -> str:
         """


### PR DESCRIPTION
This PR moves the code for printing formatted tables and grids to a new utils module `utils.cli`. It also adds some color and style to terminal output.