### PR TITLE
Fix file path decoding on problematic bytes

### DIFF
--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -1,0 +1,483 @@
+# -*- coding: utf-8 -*-
+"""
+This module contains the definitions of our data base tables which store the index, sync
+history and cache of content hashes.
+"""
+
+# system imports
+import os
+import time
+import enum
+from datetime import timezone
+from typing import Optional, TYPE_CHECKING
+
+# external imports
+import sqlalchemy.types as sqltypes  # type: ignore
+from sqlalchemy.ext.declarative import declarative_base  # type: ignore
+from sqlalchemy.orm import sessionmaker  # type: ignore
+from sqlalchemy.sql import case  # type: ignore
+from sqlalchemy.sql.elements import Case  # type: ignore
+from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
+from sqlalchemy import Column, MetaData  # type: ignore
+from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata  # type: ignore
+from watchdog.events import (
+    FileSystemEvent,
+    EVENT_TYPE_CREATED,
+    EVENT_TYPE_DELETED,
+    EVENT_TYPE_MOVED,
+    EVENT_TYPE_MODIFIED,
+)
+
+if TYPE_CHECKING:
+    from .sync import SyncEngine
+
+
+__all__ = [
+    "SyncDirection",
+    "SyncStatus",
+    "ItemType",
+    "ChangeType",
+    "SyncEvent",
+    "IndexEntry",
+    "HashCacheEntry",
+    "Session",
+    "Base",
+    "db_naming_convention",
+]
+
+
+db_naming_convention = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(column_0_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+Base = declarative_base(metadata=MetaData(naming_convention=db_naming_convention))
+Session = sessionmaker(expire_on_commit=False)
+
+
+class SyncDirection(enum.Enum):
+    """Enumeration of sync directions"""
+
+    Up = "up"
+    Down = "down"
+
+
+class SyncStatus(enum.Enum):
+    """Enumeration of sync status"""
+
+    Queued = "queued"
+    Syncing = "syncing"
+    Done = "done"
+    Failed = "failed"
+    Skipped = "skipped"
+    Aborted = "aborted"
+
+
+class ItemType(enum.Enum):
+    """Enumeration of SyncEvent types"""
+
+    File = "file"
+    Folder = "folder"
+    Unknown = "unknown"  # This can occur for remote deleted events, see issue #198
+
+
+class ChangeType(enum.Enum):
+    """Enumeration of SyncEvent change types"""
+
+    Added = "added"
+    Removed = "removed"
+    Moved = "moved"
+    Modified = "modified"
+
+
+class SyncEvent(Base):  # type: ignore
+    """Represents a file or folder change in the sync queue
+
+    This is used to abstract the :class:`watchdog.events.FileSystemEvent` created for
+    local changes and the :class:`dropbox.files.Metadata` created for remote changes.
+    All arguments are used to construct instance attributes and some attributes may not
+    be set for all event types. Note that some instance attributes depend on the state
+    of the Maestral instance, e.g., :attr:`local_path` will depend on the current path
+    of the local Dropbox folder. They may therefore become invalid after sync sessions.
+
+    The convenience methods :meth:`from_dbx_metadata` and :meth:`from_file_system_event`
+    should be used to properly construct a SyncEvent from Dropbox Metadata or a local
+    FileSystemEvent, respectively.
+    """
+
+    __tablename__ = "history"
+
+    id = Column(sqltypes.Integer, primary_key=True)
+    """A unique identifier of the SyncEvent."""
+
+    direction = Column(sqltypes.Enum(SyncDirection), nullable=False)
+    """The :class:`SyncDirection`."""
+
+    item_type = Column(sqltypes.Enum(ItemType), nullable=False)
+    """
+    The :class:`ItemType`. May be undetermined for remote deletions.
+    """
+
+    sync_time = Column(sqltypes.Float, nullable=False)
+    """The time the SyncEvent was registered."""
+
+    dbx_id = Column(sqltypes.String)
+    """
+    A unique dropbox ID for the file or folder. Will only be set for download events
+    which are not deletions.
+    """
+
+    dbx_path = Column(sqltypes.String, nullable=False)
+    """
+    Dropbox path of the item to sync. If the sync represents a move operation, this will
+    be the destination path. Follows the casing from server.
+    """
+
+    local_path = Column(sqltypes.String, nullable=False)
+    """
+    Local path of the item to sync. If the sync represents a move operation, this will
+    be the destination path. Follows the casing from server.
+    """
+
+    dbx_path_from = Column(sqltypes.String)
+    """
+    Dropbox path that this item was moved from. Will only be set if :attr:`change_type`
+    is :attr:`ChangeType.Moved`. Follows the casing from server.
+    """
+
+    local_path_from = Column(sqltypes.String)
+    """
+    Local path of the item to sync. If the sync represents a move operation, this will
+    be the destination path. Follows the casing from server.
+    """
+
+    rev = Column(sqltypes.String)
+    """
+    The file revision. Will only be set for remote changes. Will be ``'folder'`` for
+    folders and ``None`` for deletions.
+    """
+
+    content_hash = Column(sqltypes.String)
+    """
+    A hash representing the file content. Will be ``'folder'`` for folders and ``None``
+    for deletions. Set for both local and remote changes.
+    """
+
+    change_type = Column(sqltypes.Enum(ChangeType), nullable=False)
+    """
+    The :class:`ChangeType`. Remote SyncEvents currently do not generate moved events
+    but are reported as deleted and added at the new location.
+    """
+
+    change_time = Column(sqltypes.Float)
+    """
+    Local ctime or remote ``client_modified`` time for files. ``None`` for folders or
+    for remote deletions. Note that ``client_modified`` may not be reliable as it is set
+    by other clients and not verified.
+    """
+
+    change_dbid = Column(sqltypes.String)
+    """
+    The Dropbox ID of the account which performed the changes. This may not be set for
+    added folders or deletions on the server.
+    """
+
+    change_user_name = Column(sqltypes.String)
+    """
+    The user name corresponding to :attr:`change_dbid`, if the account still exists.
+    This field may not be set for performance reasons.
+    """
+
+    status = Column(sqltypes.Enum(SyncStatus), nullable=False)
+    """The :class:`SyncStatus`."""
+
+    size = Column(sqltypes.Integer, nullable=False)
+    """Size of the item in bytes. Always zero for folders."""
+
+    completed = Column(sqltypes.Integer, default=0)
+    """
+    File size in bytes which has already been uploaded or downloaded. Always zero for
+    folders.
+    """
+
+    @hybrid_property
+    def change_time_or_sync_time(self) -> float:
+        """
+        Change time when available, otherwise sync time. This can be used for sorting or
+        user information purposes.
+        """
+        return self.change_time or self.sync_time
+
+    @change_time_or_sync_time.expression  # type: ignore
+    def change_time_or_sync_time(cls) -> Case:
+        return case(
+            [(cls.change_time != None, cls.change_time)],  # noqa: E711
+            else_=cls.sync_time,
+        )
+
+    @property
+    def is_file(self) -> bool:
+        """Returns True for file changes"""
+        return self.item_type == ItemType.File
+
+    @property
+    def is_directory(self) -> bool:
+        """Returns True for folder changes"""
+        return self.item_type == ItemType.Folder
+
+    @property
+    def is_added(self) -> bool:
+        """Returns True for added items"""
+        return self.change_type == ChangeType.Added
+
+    @property
+    def is_moved(self) -> bool:
+        """Returns True for moved items"""
+        return self.change_type == ChangeType.Moved
+
+    @property
+    def is_changed(self) -> bool:
+        """Returns True for changed file contents"""
+        return self.change_type == ChangeType.Modified
+
+    @property
+    def is_deleted(self) -> bool:
+        """Returns True for deleted items"""
+        return self.change_type == ChangeType.Removed
+
+    @property
+    def is_upload(self) -> bool:
+        """Returns True for changes to upload"""
+        return self.direction == SyncDirection.Up
+
+    @property
+    def is_download(self) -> bool:
+        """Returns True for changes to download"""
+        return self.direction == SyncDirection.Down
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__}(direction={self.direction.name}, "
+            f"change_type={self.change_type.name}, dbx_path='{self.dbx_path}')>"
+        )
+
+    @classmethod
+    def from_dbx_metadata(cls, md: Metadata, sync_engine: "SyncEngine") -> "SyncEvent":
+        """
+        Initializes a SyncEvent from the given Dropbox metadata.
+
+        :param md: Dropbox Metadata.
+        :param sync_engine: SyncEngine instance.
+        :returns: An instance of this class with attributes populated from the given
+            Dropbox Metadata.
+        """
+        if isinstance(md, DeletedMetadata):
+            # there is currently no API call to determine who deleted a file or folder
+            change_type = ChangeType.Removed
+            change_time = None
+            size = 0
+            rev = None
+            hash_str = None
+            dbx_id = None
+            change_dbid = None
+
+            local_rev = sync_engine.get_local_rev(md.path_lower)
+            if local_rev == "folder":
+                item_type = ItemType.Folder
+            elif local_rev is not None:
+                item_type = ItemType.File
+            else:
+                item_type = ItemType.Unknown
+
+        elif isinstance(md, FolderMetadata):
+            # there is currently no API call to determine who added a folder
+            change_type = ChangeType.Added
+            item_type = ItemType.Folder
+            size = 0
+            rev = "folder"
+            hash_str = "folder"
+            dbx_id = md.id
+            change_time = None
+            change_dbid = None
+
+        elif isinstance(md, FileMetadata):
+            item_type = ItemType.File
+            rev = md.rev
+            hash_str = md.content_hash
+            dbx_id = md.id
+            size = md.size
+            change_time = md.client_modified.replace(tzinfo=timezone.utc).timestamp()
+            if sync_engine.get_local_rev(md.path_lower):
+                change_type = ChangeType.Modified
+            else:
+                change_type = ChangeType.Added
+            if md.sharing_info:
+                change_dbid = md.sharing_info.modified_by
+            else:
+                # file is not a shared folder, therefore
+                # the current user must have added or modified it
+                change_dbid = sync_engine.client.account_id
+        else:
+            raise RuntimeError(f"Cannot convert {md} to SyncEvent")
+
+        dbx_path_cased = sync_engine.correct_case(md.path_display)
+
+        return cls(
+            direction=SyncDirection.Down,
+            item_type=item_type,
+            sync_time=time.time(),
+            dbx_path=dbx_path_cased,
+            dbx_id=dbx_id,
+            local_path=sync_engine.to_local_path_from_cased(dbx_path_cased),
+            rev=rev,
+            content_hash=hash_str,
+            change_type=change_type,
+            change_time=change_time,
+            change_dbid=change_dbid,
+            status=SyncStatus.Queued,
+            size=size,
+            completed=0,
+        )
+
+    @classmethod
+    def from_file_system_event(
+        cls, event: FileSystemEvent, sync_engine: "SyncEngine"
+    ) -> "SyncEvent":
+        """
+        Initializes a SyncEvent from the given local file system event.
+
+        :param event: Local file system event.
+        :param sync_engine: SyncEngine instance.
+        :returns: An instance of this class with attributes populated from the given
+            SyncEvent.
+        """
+
+        change_dbid = sync_engine.client.account_id
+        to_path = getattr(event, "dest_path", event.src_path)
+        from_path = None
+
+        if event.event_type == EVENT_TYPE_CREATED:
+            change_type = ChangeType.Added
+        elif event.event_type == EVENT_TYPE_DELETED:
+            change_type = ChangeType.Removed
+        elif event.event_type == EVENT_TYPE_MOVED:
+            change_type = ChangeType.Moved
+            from_path = event.src_path
+        elif event.event_type == EVENT_TYPE_MODIFIED:
+            change_type = ChangeType.Modified
+        else:
+            raise RuntimeError(f"Cannot convert {event} to SyncEvent")
+
+        change_time: Optional[float]
+        stat: Optional[os.stat_result]
+
+        try:
+            stat = os.stat(to_path)
+        except OSError:
+            stat = None
+
+        if event.is_directory:
+            item_type = ItemType.Folder
+            size = 0
+            try:
+                change_time = stat.st_birthtime  # type: ignore
+            except AttributeError:
+                change_time = None
+        else:
+            item_type = ItemType.File
+            change_time = stat.st_ctime if stat else None
+            size = stat.st_size if stat else 0
+
+        # Note: We get the content hash here instead of later, even though the
+        # calculation may be slow and :meth:`from_file_system_event` may be called
+        # serially and not from a thread pool. This is because hashing is CPU bound
+        # and parallelization would cause large multi-core CPU usage (or result in
+        # throttling of our thread-pool).
+
+        return cls(
+            direction=SyncDirection.Up,
+            item_type=item_type,
+            sync_time=time.time(),
+            dbx_path=sync_engine.to_dbx_path(to_path),
+            local_path=to_path,
+            dbx_path_from=sync_engine.to_dbx_path(from_path) if from_path else None,
+            local_path_from=from_path,
+            content_hash=sync_engine.get_local_hash(to_path),
+            change_type=change_type,
+            change_time=change_time,
+            change_dbid=change_dbid,
+            status=SyncStatus.Queued,
+            size=size,
+            completed=0,
+        )
+
+
+class IndexEntry(Base):  # type: ignore
+    """Represents an entry in our local sync index"""
+
+    __tablename__ = "index"
+
+    dbx_path_lower = Column(sqltypes.String, nullable=False, primary_key=True)
+    """
+    Dropbox path of the item in lower case. This acts as a primary key for the SQLites
+    database since there can only be one entry per case-insensitive Dropbox path.
+    """
+
+    dbx_path_cased = Column(sqltypes.String, nullable=False)
+    """Dropbox path of the item, correctly cased."""
+
+    dbx_id = Column(sqltypes.String, nullable=False)
+    """The unique dropbox ID for the item."""
+
+    item_type = Column(sqltypes.Enum(ItemType), nullable=False)
+    """The :class:`ItemType`."""
+
+    last_sync = Column(sqltypes.Float)
+    """
+    The last time a local change was uploaded. Should be the ctime of the local item.
+    """
+
+    rev = Column(sqltypes.String, nullable=False)
+    """The file revision. Will be ``'folder'`` for folders."""
+
+    content_hash = Column(sqltypes.String)
+    """
+    A hash representing the file content. Will be ``'folder'`` for folders. May be
+    ``None`` if not yet calculated.
+    """
+
+    @property
+    def is_file(self) -> bool:
+        """Returns True for file changes"""
+        return self.item_type == ItemType.File
+
+    @property
+    def is_directory(self) -> bool:
+        """Returns True for folder changes"""
+        return self.item_type == ItemType.Folder
+
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__}(item_type={self.item_type.name}, "
+            f"dbx_path='{self.dbx_path_cased}')>"
+        )
+
+
+class HashCacheEntry(Base):  # type: ignore
+    """Represents an entry in our cache of content hashes"""
+
+    __tablename__ = "hash_cache"
+
+    local_path = Column(sqltypes.String, nullable=False, primary_key=True)
+    """The local path of the item."""
+
+    hash_str = Column(sqltypes.String)
+    """The content hash of the item."""
+
+    mtime = Column(sqltypes.Float)
+    """
+    The mtime of the item just before the hash was computed. When the current ctime is
+    newer, the hash will need to be recalculated.
+    """

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -159,7 +159,7 @@ class SyncEvent(Base):  # type: ignore
     local_path = Column(StringPath, nullable=False)
     """
     Local path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. Follows the casing from server.
+    be the destination path. This will be correctly cased.
     """
 
     dbx_path_from = Column(StringPath)
@@ -170,8 +170,8 @@ class SyncEvent(Base):  # type: ignore
 
     local_path_from = Column(StringPath)
     """
-    Local path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. Follows the casing from server.
+    Local path that this item was moved from. Will only be set if :attr:`change_type`
+    is :attr:`ChangeType.Moved`. This will be correctly cased.
     """
 
     rev = Column(sqltypes.String)

--- a/src/maestral/fsevents/__init__.py
+++ b/src/maestral/fsevents/__init__.py
@@ -52,8 +52,13 @@ MovedEvents which are not unique (their paths appear in other events) will be sp
 into Deleted and Created events by Maestral.
 """
 
+import os
+from typing import Union
+
 from watchdog.utils import platform  # type: ignore
 from watchdog.utils import UnsupportedLibc
+from watchdog.utils import unicode_paths
+
 
 if platform.is_darwin():
     from .fsevents import OrderedFSEventsObserver as Observer
@@ -66,3 +71,22 @@ else:
     from watchdog.observers import Observer  # type: ignore
 
 __all__ = ["Observer"]
+
+
+# patch encoding / decoding of paths in watchdog
+
+
+def _patched_decode(path: Union[str, bytes]) -> str:
+    if isinstance(path, bytes):
+        return os.fsdecode(path)
+    return path
+
+
+def _patched_encode(path: Union[str, bytes]) -> bytes:
+    if isinstance(path, str):
+        return os.fsencode(path)
+    return path
+
+
+unicode_paths.decode = _patched_decode
+unicode_paths.encode = _patched_encode

--- a/src/maestral/logging.py
+++ b/src/maestral/logging.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""This module defines custom logging records and handlers."""
+
+import logging
+from collections import deque
+from concurrent.futures._base import Future, wait
+from typing import Deque, Optional, List
+
+try:
+    from concurrent.futures import InvalidStateError  # type: ignore
+except ImportError:
+    # Python 3.7 and lower
+    InvalidStateError = RuntimeError  # type: ignore
+
+import sdnotify  # type: ignore
+
+try:
+    from systemd import journal  # type: ignore
+except ImportError:
+    journal = None
+
+from .utils import sanitize_string
+
+
+if journal:
+
+    def safe_journal_sender(MESSAGE: str, **kwargs) -> None:
+
+        MESSAGE = sanitize_string(MESSAGE)
+
+        for key, value in kwargs.items():
+            if isinstance(value, str):
+                kwargs[key] = sanitize_string(value)
+
+        journal.send(MESSAGE, **kwargs)
+
+
+else:
+
+    def safe_journal_sender(MESSAGE: str, **kwargs) -> None:
+        pass
+
+
+class EncodingSafeLogRecord(logging.LogRecord):
+    """A log record which ensures that messages contain only unicode characters
+
+    This is useful when log messages may contain file paths generates by OS APIs. In
+    Python, such path strings may contain surrogate escapes and will therefore raise
+    :class:`UnicodeEncodingError`s under many circumstances (printing to stdout, etc).
+    """
+
+    def getMessage(self) -> str:
+        """
+        Formats the log message and replaces all surrogate escapes with "�".
+        """
+        msg = super().getMessage()
+        return sanitize_string(msg)
+
+
+logging.setLogRecordFactory(EncodingSafeLogRecord)
+
+
+class CachedHandler(logging.Handler):
+    """Handler which stores past records
+
+    This is used to populate Maestral's status and error interfaces. The method
+    :meth:`wait_for_emit` can be used from another thread to block until a new record is
+    emitted, for instance to react to state changes.
+
+    :param level: Initial log level. Defaults to NOTSET.
+    :param maxlen: Maximum number of records to store. If ``None``, all records will be
+        stored. Defaults to ``None``.
+    """
+
+    cached_records: Deque[logging.LogRecord]
+    _emit_future: Future
+
+    def __init__(
+        self, level: int = logging.NOTSET, maxlen: Optional[int] = None
+    ) -> None:
+        super().__init__(level=level)
+        self.cached_records = deque([], maxlen)
+        self._emit_future = Future()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Logs the specified log record and saves it to the cache.
+
+        :param record: Log record.
+        """
+        self.cached_records.append(record)
+
+        # notify any waiting coroutines that we have a status change
+        try:
+            self._emit_future.set_result(True)
+        except InvalidStateError:
+            pass
+
+    def wait_for_emit(self, timeout: Optional[float]) -> bool:
+        """
+        Blocks until a new record is emitted.
+
+        :param timeout: Maximum time to block before returning.
+        :returns: ``True``if there was a status change, ``False`` in case of a timeout.
+        """
+        done, not_done = wait([self._emit_future], timeout=timeout)
+        self._emit_future = Future()  # reset future
+        return len(done) == 1
+
+    def getLastMessage(self) -> str:
+        """
+        :returns: The log message of the last record or an empty string.
+        """
+        try:
+            last_record = self.cached_records[-1]
+            return last_record.getMessage()
+        except IndexError:
+            return ""
+
+    def getAllMessages(self) -> List[str]:
+        """
+        :returns: A list of all record messages.
+        """
+        return [r.getMessage() for r in self.cached_records]
+
+    def clear(self) -> None:
+        """
+        Clears all cached records.
+        """
+        self.cached_records.clear()
+
+
+class SdNotificationHandler(logging.Handler):
+    """Handler which emits messages as systemd notifications
+
+    This is useful when used from a systemd service and will do nothing when no
+    NOTIFY_SOCKET is provided.
+
+    :param level: Initial log level. Defaults to NOTSET.
+    """
+
+    notifier = sdnotify.SystemdNotifier()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Sends the record massage to systemd as service status.
+
+        :param record: Log record.
+        """
+        self.notifier.notify(f"STATUS={record.message}")

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1438,8 +1438,8 @@ class Maestral:
         from alembic.migration import MigrationContext  # type: ignore
         from alembic.operations import Operations  # type: ignore
         from sqlalchemy.engine import reflection  # type: ignore
-        from .sync import db_naming_convention as nc
-        from .sync import IndexEntry
+        from .database import db_naming_convention as nc
+        from .database import IndexEntry
 
         table_name = IndexEntry.__tablename__
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -382,9 +382,9 @@ class Maestral:
         else:
             self.log_handler_sd = None
 
-        # log to stdout (disabled by default)
+        # log to stderr (disabled by default)
         level = self.log_level if self._log_to_stdout else 100
-        self.log_handler_stream = logging.StreamHandler(sys.stdout)
+        self.log_handler_stream = logging.StreamHandler(sys.stderr)
         self.log_handler_stream.setFormatter(log_fmt_long)
         self.log_handler_stream.setLevel(level)
         self._logger.addHandler(self.log_handler_stream)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2207,7 +2207,9 @@ class SyncEngine:
                 else:
                     new_event = FileMovedEvent(src_path, dest_path)
 
-                # only recombine events if neither is in an excluded path
+                # Only recombine events if neither has an excluded path: We want to
+                # treat renaming from / to an excluded path as a creation / deletion,
+                # respectively.
                 if not self._should_split_excluded(new_event):
                     cleaned_events.difference_update(split_events)
                     cleaned_events.add(new_event)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -21,7 +21,6 @@ from contextlib import contextmanager
 import enum
 import pprint
 import gc
-from datetime import timezone
 from functools import wraps
 from typing import (
     Optional,
@@ -45,22 +44,12 @@ import click
 import sqlalchemy.exc  # type: ignore
 import sqlalchemy.engine.url  # type: ignore
 from sqlalchemy.sql import func  # type: ignore
-from sqlalchemy.ext.declarative import declarative_base  # type: ignore
-from sqlalchemy.orm import sessionmaker  # type: ignore
-from sqlalchemy.sql import case  # type: ignore
-from sqlalchemy.sql.elements import Case  # type: ignore
-from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
-from sqlalchemy import MetaData, Column, Integer, String, Enum, Float, create_engine  # type: ignore
+from sqlalchemy import create_engine  # type: ignore
 import pathspec  # type: ignore
 import dropbox  # type: ignore
 from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata  # type: ignore
 from watchdog.events import FileSystemEventHandler  # type: ignore
-from watchdog.events import (
-    EVENT_TYPE_CREATED,
-    EVENT_TYPE_DELETED,
-    EVENT_TYPE_MOVED,
-    EVENT_TYPE_MODIFIED,
-)
+from watchdog.events import EVENT_TYPE_CREATED, EVENT_TYPE_DELETED, EVENT_TYPE_MOVED
 from watchdog.events import (
     DirModifiedEvent,
     FileModifiedEvent,
@@ -107,6 +96,17 @@ from .client import (
     convert_api_errors,
     fswatch_to_maestral_error,
 )
+from .database import (
+    Base,
+    Session,
+    SyncEvent,
+    HashCacheEntry,
+    IndexEntry,
+    SyncDirection,
+    SyncStatus,
+    ItemType,
+    ChangeType,
+)
 from .utils import removeprefix
 from .utils.caches import LRUCache
 from .utils.path import (
@@ -145,16 +145,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 _cpu_count = os.cpu_count() or 1  # os.cpu_count can return None
 
-db_naming_convention = {
-    "ix": "ix_%(column_0_label)s",
-    "uq": "uq_%(table_name)s_%(column_0_name)s",
-    "ck": "ck_%(table_name)s_%(column_0_name)s",
-    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-    "pk": "pk_%(table_name)s",
-}
-Base = declarative_base(metadata=MetaData(naming_convention=db_naming_convention))
-Session = sessionmaker(expire_on_commit=False)
-
+# type definitions
 ExecInfoType = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
 FT = TypeVar("FT", bound=Callable[..., Any])
 
@@ -171,41 +162,6 @@ class Conflict(enum.Enum):
     Conflict = "conflict"
     Identical = "identical"
     LocalNewerOrIdentical = "local newer or identical"
-
-
-class SyncDirection(enum.Enum):
-    """Enumeration of sync directions"""
-
-    Up = "up"
-    Down = "down"
-
-
-class SyncStatus(enum.Enum):
-    """Enumeration of sync status"""
-
-    Queued = "queued"
-    Syncing = "syncing"
-    Done = "done"
-    Failed = "failed"
-    Skipped = "skipped"
-    Aborted = "aborted"
-
-
-class ItemType(enum.Enum):
-    """Enumeration of SyncEvent types"""
-
-    File = "file"
-    Folder = "folder"
-    Unknown = "unknown"  # This can occur for remote deleted events, see issue #198
-
-
-class ChangeType(enum.Enum):
-    """Enumeration of SyncEvent change types"""
-
-    Added = "added"
-    Removed = "removed"
-    Moved = "moved"
-    Modified = "modified"
 
 
 class _Ignore:
@@ -428,397 +384,6 @@ class PersistentStateMutableSet(abc.MutableSet):
             f"<{self.__class__.__name__}(section='{self.section}',"
             f"option='{self.option}', entries={list(self)})>"
         )
-
-
-class SyncEvent(Base):  # type: ignore
-    """Represents a file or folder change in the sync queue
-
-    This is used to abstract the :class:`watchdog.events.FileSystemEvent` created for
-    local changes and the :class:`dropbox.files.Metadata` created for remote changes.
-    All arguments are used to construct instance attributes and some attributes may not
-    be set for all event types. Note that some instance attributes depend on the state
-    of the Maestral instance, e.g., :attr:`local_path` will depend on the current path
-    of the local Dropbox folder. They may therefore become invalid after sync sessions.
-
-    The convenience methods :meth:`from_dbx_metadata` and :meth:`from_file_system_event`
-    should be used to properly construct a SyncEvent from Dropbox Metadata or a local
-    FileSystemEvent, respectively.
-    """
-
-    __tablename__ = "history"
-
-    id = Column(Integer, primary_key=True)
-    """A unique identifier of the SyncEvent."""
-
-    direction = Column(Enum(SyncDirection), nullable=False)
-    """The :class:`SyncDirection`."""
-
-    item_type = Column(Enum(ItemType), nullable=False)
-    """
-    The :class:`ItemType`. May be undetermined for remote deletions.
-    """
-
-    sync_time = Column(Float, nullable=False)
-    """The time the SyncEvent was registered."""
-
-    dbx_id = Column(String)
-    """
-    A unique dropbox ID for the file or folder. Will only be set for download events
-    which are not deletions.
-    """
-
-    dbx_path = Column(String, nullable=False)
-    """
-    Dropbox path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. Follows the casing from server.
-    """
-
-    local_path = Column(String, nullable=False)
-    """
-    Local path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. Follows the casing from server.
-    """
-
-    dbx_path_from = Column(String)
-    """
-    Dropbox path that this item was moved from. Will only be set if :attr:`change_type`
-    is :attr:`ChangeType.Moved`. Follows the casing from server.
-    """
-
-    local_path_from = Column(String)
-    """
-    Local path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. Follows the casing from server.
-    """
-
-    rev = Column(String)
-    """
-    The file revision. Will only be set for remote changes. Will be ``'folder'`` for
-    folders and ``None`` for deletions.
-    """
-
-    content_hash = Column(String)
-    """
-    A hash representing the file content. Will be ``'folder'`` for folders and ``None``
-    for deletions. Set for both local and remote changes.
-    """
-
-    change_type = Column(Enum(ChangeType), nullable=False)
-    """
-    The :class:`ChangeType`. Remote SyncEvents currently do not generate moved events
-    but are reported as deleted and added at the new location.
-    """
-
-    change_time = Column(Float)
-    """
-    Local ctime or remote ``client_modified`` time for files. ``None`` for folders or
-    for remote deletions. Note that ``client_modified`` may not be reliable as it is set
-    by other clients and not verified.
-    """
-
-    change_dbid = Column(String)
-    """
-    The Dropbox ID of the account which performed the changes. This may not be set for
-    added folders or deletions on the server.
-    """
-
-    change_user_name = Column(String)
-    """
-    The user name corresponding to :attr:`change_dbid`, if the account still exists.
-    This field may not be set for performance reasons.
-    """
-
-    status = Column(Enum(SyncStatus), nullable=False)
-    """The :class:`SyncStatus`."""
-
-    size = Column(Integer, nullable=False)
-    """Size of the item in bytes. Always zero for folders."""
-
-    completed = Column(Integer, default=0)
-    """
-    File size in bytes which has already been uploaded or downloaded. Always zero for
-    folders.
-    """
-
-    @hybrid_property
-    def change_time_or_sync_time(self) -> float:
-        """
-        Change time when available, otherwise sync time. This can be used for sorting or
-        user information purposes.
-        """
-        return self.change_time or self.sync_time
-
-    @change_time_or_sync_time.expression  # type: ignore
-    def change_time_or_sync_time(cls) -> Case:
-        return case(
-            [(cls.change_time != None, cls.change_time)],  # noqa: E711
-            else_=cls.sync_time,
-        )
-
-    @property
-    def is_file(self) -> bool:
-        """Returns True for file changes"""
-        return self.item_type == ItemType.File
-
-    @property
-    def is_directory(self) -> bool:
-        """Returns True for folder changes"""
-        return self.item_type == ItemType.Folder
-
-    @property
-    def is_added(self) -> bool:
-        """Returns True for added items"""
-        return self.change_type == ChangeType.Added
-
-    @property
-    def is_moved(self) -> bool:
-        """Returns True for moved items"""
-        return self.change_type == ChangeType.Moved
-
-    @property
-    def is_changed(self) -> bool:
-        """Returns True for changed file contents"""
-        return self.change_type == ChangeType.Modified
-
-    @property
-    def is_deleted(self) -> bool:
-        """Returns True for deleted items"""
-        return self.change_type == ChangeType.Removed
-
-    @property
-    def is_upload(self) -> bool:
-        """Returns True for changes to upload"""
-        return self.direction == SyncDirection.Up
-
-    @property
-    def is_download(self) -> bool:
-        """Returns True for changes to download"""
-        return self.direction == SyncDirection.Down
-
-    def __repr__(self):
-        return (
-            f"<{self.__class__.__name__}(direction={self.direction.name}, "
-            f"change_type={self.change_type.name}, dbx_path='{self.dbx_path}')>"
-        )
-
-    @classmethod
-    def from_dbx_metadata(cls, md: Metadata, sync_engine: "SyncEngine") -> "SyncEvent":
-        """
-        Initializes a SyncEvent from the given Dropbox metadata.
-
-        :param md: Dropbox Metadata.
-        :param sync_engine: SyncEngine instance.
-        :returns: An instance of this class with attributes populated from the given
-            Dropbox Metadata.
-        """
-        if isinstance(md, DeletedMetadata):
-            # there is currently no API call to determine who deleted a file or folder
-            change_type = ChangeType.Removed
-            change_time = None
-            size = 0
-            rev = None
-            hash_str = None
-            dbx_id = None
-            change_dbid = None
-
-            local_rev = sync_engine.get_local_rev(md.path_lower)
-            if local_rev == "folder":
-                item_type = ItemType.Folder
-            elif local_rev is not None:
-                item_type = ItemType.File
-            else:
-                item_type = ItemType.Unknown
-
-        elif isinstance(md, FolderMetadata):
-            # there is currently no API call to determine who added a folder
-            change_type = ChangeType.Added
-            item_type = ItemType.Folder
-            size = 0
-            rev = "folder"
-            hash_str = "folder"
-            dbx_id = md.id
-            change_time = None
-            change_dbid = None
-
-        elif isinstance(md, FileMetadata):
-            item_type = ItemType.File
-            rev = md.rev
-            hash_str = md.content_hash
-            dbx_id = md.id
-            size = md.size
-            change_time = md.client_modified.replace(tzinfo=timezone.utc).timestamp()
-            if sync_engine.get_local_rev(md.path_lower):
-                change_type = ChangeType.Modified
-            else:
-                change_type = ChangeType.Added
-            if md.sharing_info:
-                change_dbid = md.sharing_info.modified_by
-            else:
-                # file is not a shared folder, therefore
-                # the current user must have added or modified it
-                change_dbid = sync_engine.client.account_id
-        else:
-            raise RuntimeError(f"Cannot convert {md} to SyncEvent")
-
-        dbx_path_cased = sync_engine.correct_case(md.path_display)
-
-        return cls(
-            direction=SyncDirection.Down,
-            item_type=item_type,
-            sync_time=time.time(),
-            dbx_path=dbx_path_cased,
-            dbx_id=dbx_id,
-            local_path=sync_engine.to_local_path_from_cased(dbx_path_cased),
-            rev=rev,
-            content_hash=hash_str,
-            change_type=change_type,
-            change_time=change_time,
-            change_dbid=change_dbid,
-            status=SyncStatus.Queued,
-            size=size,
-            completed=0,
-        )
-
-    @classmethod
-    def from_file_system_event(
-        cls, event: FileSystemEvent, sync_engine: "SyncEngine"
-    ) -> "SyncEvent":
-        """
-        Initializes a SyncEvent from the given local file system event.
-
-        :param event: Local file system event.
-        :param sync_engine: SyncEngine instance.
-        :returns: An instance of this class with attributes populated from the given
-            SyncEvent.
-        """
-
-        change_dbid = sync_engine.client.account_id
-        to_path = get_dest_path(event)
-        from_path = None
-
-        if event.event_type == EVENT_TYPE_CREATED:
-            change_type = ChangeType.Added
-        elif event.event_type == EVENT_TYPE_DELETED:
-            change_type = ChangeType.Removed
-        elif event.event_type == EVENT_TYPE_MOVED:
-            change_type = ChangeType.Moved
-            from_path = event.src_path
-        elif event.event_type == EVENT_TYPE_MODIFIED:
-            change_type = ChangeType.Modified
-        else:
-            raise RuntimeError(f"Cannot convert {event} to SyncEvent")
-
-        change_time: Optional[float]
-        stat: Optional[os.stat_result]
-
-        try:
-            stat = os.stat(to_path)
-        except OSError:
-            stat = None
-
-        if event.is_directory:
-            item_type = ItemType.Folder
-            size = 0
-            try:
-                change_time = stat.st_birthtime  # type: ignore
-            except AttributeError:
-                change_time = None
-        else:
-            item_type = ItemType.File
-            change_time = stat.st_ctime if stat else None
-            size = stat.st_size if stat else 0
-
-        # Note: We get the content hash here instead of later, even though the
-        # calculation may be slow and :meth:`from_file_system_event` may be called
-        # serially and not from a thread pool. This is because hashing is CPU bound
-        # and parallelization would cause large multi-core CPU usage (or result in
-        # throttling of our thread-pool).
-
-        return cls(
-            direction=SyncDirection.Up,
-            item_type=item_type,
-            sync_time=time.time(),
-            dbx_path=sync_engine.to_dbx_path(to_path),
-            local_path=to_path,
-            dbx_path_from=sync_engine.to_dbx_path(from_path) if from_path else None,
-            local_path_from=from_path,
-            content_hash=sync_engine.get_local_hash(to_path),
-            change_type=change_type,
-            change_time=change_time,
-            change_dbid=change_dbid,
-            status=SyncStatus.Queued,
-            size=size,
-            completed=0,
-        )
-
-
-class IndexEntry(Base):  # type: ignore
-    """Represents an entry in our local sync index"""
-
-    __tablename__ = "index"
-
-    dbx_path_lower = Column(String, nullable=False, primary_key=True)
-    """
-    Dropbox path of the item in lower case. This acts as a primary key for the SQLites
-    database since there can only be one entry per case-insensitive Dropbox path.
-    """
-
-    dbx_path_cased = Column(String, nullable=False)
-    """Dropbox path of the item, correctly cased."""
-
-    dbx_id = Column(String, nullable=False)
-    """The unique dropbox ID for the item."""
-
-    item_type = Column(Enum(ItemType), nullable=False)
-    """The :class:`ItemType`."""
-
-    last_sync = Column(Float)
-    """
-    The last time a local change was uploaded. Should be the ctime of the local item.
-    """
-
-    rev = Column(String, nullable=False)
-    """The file revision. Will be ``'folder'`` for folders."""
-
-    content_hash = Column(String)
-    """
-    A hash representing the file content. Will be ``'folder'`` for folders. May be
-    ``None`` if not yet calculated.
-    """
-
-    @property
-    def is_file(self) -> bool:
-        """Returns True for file changes"""
-        return self.item_type == ItemType.File
-
-    @property
-    def is_directory(self) -> bool:
-        """Returns True for folder changes"""
-        return self.item_type == ItemType.Folder
-
-    def __repr__(self):
-        return (
-            f"<{self.__class__.__name__}(item_type={self.item_type.name}, "
-            f"dbx_path='{self.dbx_path_cased}')>"
-        )
-
-
-class HashCacheEntry(Base):  # type: ignore
-    """Represents an entry in our cache of content hashes"""
-
-    __tablename__ = "hash_cache"
-
-    local_path = Column(String, nullable=False, primary_key=True)
-    """The local path of the item."""
-
-    hash_str = Column(String)
-    """The content hash of the item."""
-
-    mtime = Column(Float)
-    """
-    The mtime of the item just before the hash was computed. When the current ctime is
-    newer, the hash will need to be recalculated.
-    """
 
 
 class SyncEngine:

--- a/src/maestral/utils/__init__.py
+++ b/src/maestral/utils/__init__.py
@@ -107,9 +107,9 @@ def sanitize_string(string: str) -> str:
     """
     Converts a string provided by file system APIs, which may contain surrogate escapes
     for bytes with unknown encoding, to a string which can always be displayed or
-    printed. This is done by replacing invalid characters with "?".
+    printed. This is done by replacing invalid characters with "�".
 
     :param string: Original string.
-    :returns: Sanitised path where all surrogate escapes have been replaced with "?".
+    :returns: Sanitised path where all surrogate escapes have been replaced with "�".
     """
     return os.fsencode(string).decode(errors="replace")

--- a/src/maestral/utils/__init__.py
+++ b/src/maestral/utils/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Utility modules and functions"""
+import os
 
 from packaging.version import Version
 from typing import List, Iterator, TypeVar, Optional, Iterable
@@ -100,3 +101,15 @@ def removeprefix(string: str, prefix: str) -> str:
         return string[len(prefix) :]
     else:
         return string[:]
+
+
+def sanitize_string(string: str) -> str:
+    """
+    Converts a string provided by file system APIs, which may contain surrogate escapes
+    for bytes with unknown encoding, to a string which can always be displayed or
+    printed. This is done by replacing invalid characters with "?".
+
+    :param string: Original string.
+    :returns: Sanitised path where all surrogate escapes have been replaced with "?".
+    """
+    return os.fsencode(string).decode(errors="replace")

--- a/src/maestral/utils/serializer.py
+++ b/src/maestral/utils/serializer.py
@@ -15,6 +15,7 @@ from dropbox.stone_serializers import json_encode  # type: ignore
 from dropbox.stone_validators import Struct  # type: ignore
 
 # local imports
+from . import sanitize_string
 from ..sync import SyncEvent
 
 if TYPE_CHECKING:
@@ -47,7 +48,7 @@ def error_to_dict(err: Exception) -> ErrorType:
         'traceback', 'title', and 'message'.
     """
 
-    err_dict: ErrorType = dict(
+    serialized: ErrorType = dict(
         type=err.__class__.__name__,
         inherits=[base.__name__ for base in err.__class__.__bases__],
         traceback="".join(
@@ -59,11 +60,13 @@ def error_to_dict(err: Exception) -> ErrorType:
     for key, value in err.__dict__.items():
 
         if value is None:
-            err_dict[key] = value
+            serialized[key] = value
+        elif isinstance(value, str):
+            serialized[key] = sanitize_string(value)
         else:
-            err_dict[key] = str(value)
+            serialized[key] = str(value)
 
-    return err_dict
+    return serialized
 
 
 def sync_event_to_dict(event: SyncEvent) -> StoneType:
@@ -74,18 +77,22 @@ def sync_event_to_dict(event: SyncEvent) -> StoneType:
     :param event: SyncEvent to convert.
     :returns: Serialized SyncEvent.
     """
+
+    attributes = [x for x in dir(event) if not x.startswith("_") and x != "metadata"]
+
     serialized = dict()
+    keep_types = (int, float, type(None))
 
-    for field in [x for x in dir(event) if not x.startswith("_") and x != "metadata"]:
-        data = event.__getattribute__(field)
-        if isinstance(data, Enum):
-            new_data = data.value
-        else:
-            new_data = data
+    for attr_name in attributes:
+        value = getattr(event, attr_name)
 
-        if isinstance(new_data, (str, int, float)) or new_data is None:
-            serialized[field] = new_data
+        if isinstance(value, Enum):
+            serialized[attr_name] = value.value
+        elif isinstance(value, str):
+            serialized[attr_name] = sanitize_string(value)
+        elif isinstance(value, keep_types):
+            serialized[attr_name] = value
         else:
-            serialized[field] = str(new_data)
+            serialized[attr_name] = str(value)
 
     return serialized

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -809,7 +809,9 @@ def test_excluded_folder_cleared_on_deletion(m):
     assert not m.fatal_errors
 
 
-@pytest.mark.skipif(sys.platform != "linux")
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="macOS enforces utf-8 path encoding"
+)
 def test_unknown_path_encoding(m, capsys):
     """
     Tests the handling of a local path with bytes that cannot be decoded with the

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -29,6 +29,7 @@ def test_setup(m):
 
 
 def test_file_lifecycle(m):
+    """Tests creating, modifying and deleting a file."""
 
     # test creating a local file
 
@@ -75,6 +76,7 @@ def test_file_lifecycle(m):
 
 
 def test_file_conflict(m):
+    """Tests conflicting local vs remote file changes."""
 
     # create a local file
     shutil.copy(resources + "/file.txt", m.test_folder_local)
@@ -109,6 +111,7 @@ def test_file_conflict(m):
 
 
 def test_parallel_deletion_when_paused(m):
+    """Tests parallel remote and local deletions of an item."""
 
     # create a local file
     shutil.copy(resources + "/file.txt", m.test_folder_local)
@@ -136,6 +139,7 @@ def test_parallel_deletion_when_paused(m):
 
 
 def test_local_and_remote_creation_with_equal_content(m):
+    """Tests parallel and equal remote and local changes of an item."""
 
     m.pause_sync()
     wait_for_idle(m)
@@ -157,6 +161,7 @@ def test_local_and_remote_creation_with_equal_content(m):
 
 
 def test_local_and_remote_creation_with_different_content(m):
+    """Tests parallel and different remote and local changes of an item."""
 
     m.pause_sync()
     wait_for_idle(m)
@@ -179,6 +184,7 @@ def test_local_and_remote_creation_with_different_content(m):
 
 
 def test_local_deletion_during_upload(m):
+    """Tests the case where a local item is deleted during the upload."""
 
     # we mimic a deletion during upload by queueing a fake FileCreatedEvent
     fake_created_event = FileCreatedEvent(m.test_folder_local + "/file.txt")
@@ -194,6 +200,7 @@ def test_local_deletion_during_upload(m):
 
 
 def test_rapid_local_changes(m):
+    """Tests local changes to the content of a file with varying intervals."""
 
     for t in (0.1, 0.1, 0.5, 0.5, 1.0, 1.0, 2.0, 2.0):
         time.sleep(t)
@@ -211,6 +218,7 @@ def test_rapid_local_changes(m):
 
 
 def test_rapid_remote_changes(m):
+    """Tests remote changes to the content of a file with varying intervals."""
 
     shutil.copy(resources + "/file.txt", m.test_folder_local)
     wait_for_idle(m)
@@ -241,6 +249,7 @@ def test_rapid_remote_changes(m):
 
 
 def test_folder_tree_created_local(m):
+    """Tests the upload sync of a nested local folder structure."""
 
     # test creating tree
 
@@ -267,6 +276,7 @@ def test_folder_tree_created_local(m):
 
 
 def test_folder_tree_created_remote(m):
+    """Tests the download sync of a nested remote folder structure."""
 
     # test creating remote tree
 
@@ -292,6 +302,7 @@ def test_folder_tree_created_remote(m):
 
 
 def test_remote_file_replaced_by_folder(m):
+    """Tests the download sync when a file is replaced by a folder."""
 
     shutil.copy(resources + "/file.txt", m.test_folder_local + "/file.txt")
     wait_for_idle(m)
@@ -315,6 +326,10 @@ def test_remote_file_replaced_by_folder(m):
 
 
 def test_remote_file_replaced_by_folder_and_unsynced_local_changes(m):
+    """
+    Tests the download sync when a file is replaced by a folder and the local file has
+    unsynced changes.
+    """
 
     shutil.copy(resources + "/file.txt", m.test_folder_local + "/file.txt")
     wait_for_idle(m)
@@ -343,6 +358,7 @@ def test_remote_file_replaced_by_folder_and_unsynced_local_changes(m):
 
 
 def test_remote_folder_replaced_by_file(m):
+    """Tests the download sync when a folder is replaced by a file."""
 
     os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
@@ -366,6 +382,10 @@ def test_remote_folder_replaced_by_file(m):
 
 
 def test_remote_folder_replaced_by_file_and_unsynced_local_changes(m):
+    """
+    Tests the download sync when a folder is replaced by a file and the local folder has
+    unsynced changes.
+    """
 
     os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
@@ -393,6 +413,7 @@ def test_remote_folder_replaced_by_file_and_unsynced_local_changes(m):
 
 
 def test_local_folder_replaced_by_file(m):
+    """Tests the upload sync when a local folder is replaced by a file."""
 
     os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
@@ -415,6 +436,10 @@ def test_local_folder_replaced_by_file(m):
 
 
 def test_local_folder_replaced_by_file_and_unsynced_remote_changes(m):
+    """
+    Tests the upload sync when a local folder is replaced by a file and the remote
+    folder has unsynced changes.
+    """
 
     # remote folder is currently not checked for unsynced changes but replaced
 
@@ -443,6 +468,7 @@ def test_local_folder_replaced_by_file_and_unsynced_remote_changes(m):
 
 
 def test_local_file_replaced_by_folder(m):
+    """Tests the upload sync when a local file is replaced by a folder."""
 
     shutil.copy(resources + "/file.txt", m.test_folder_local + "/file.txt")
     wait_for_idle(m)
@@ -466,6 +492,10 @@ def test_local_file_replaced_by_folder(m):
 
 
 def test_local_file_replaced_by_folder_and_unsynced_remote_changes(m):
+    """
+    Tests the upload sync when a local file is replaced by a folder and the remote
+    file has unsynced changes.
+    """
 
     # Check if server-modified time > last_sync of file and only delete file if
     # older. Otherwise, let Dropbox handle creating a conflicting copy.
@@ -500,6 +530,10 @@ def test_local_file_replaced_by_folder_and_unsynced_remote_changes(m):
 
 
 def test_selective_sync_conflict(m):
+    """
+    Tests the creation of a selective sync conflict when a local item is created with a
+    path that is excluded by selective sync.
+    """
 
     os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
@@ -532,6 +566,10 @@ def test_selective_sync_conflict(m):
     not is_fs_case_sensitive("/home"), reason="file system is not case sensitive"
 )
 def test_case_conflict(m):
+    """
+    Tests the creation of a case conflict when a local item is created with a path that
+    only differs in casing from an existing path.
+    """
 
     os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
@@ -551,6 +589,10 @@ def test_case_conflict(m):
 
 
 def test_case_change_local(m):
+    """
+    Tests the upload sync of local rename which only changes the casing of the local
+    file name.
+    """
 
     # start with nested folders
     os.mkdir(m.test_folder_local + "/folder")
@@ -576,6 +618,10 @@ def test_case_change_local(m):
 
 
 def test_case_change_remote(m):
+    """
+    Tests the download sync of remote rename which only changes the casing of the remote
+    file name.
+    """
 
     # start with nested folders
     os.mkdir(m.test_folder_local + "/folder")
@@ -601,6 +647,7 @@ def test_case_change_remote(m):
 
 
 def test_mignore(m):
+    """Tests the exclusion of local items by an mignore file."""
 
     # 1) test that tracked items are unaffected
 
@@ -646,6 +693,10 @@ def test_mignore(m):
 
 
 def test_upload_sync_issues(m):
+    """
+    Tests error handling for issues during upload sync. This is done by creating a local
+    folder with a name that ends with a backslash (not allowed by Dropbox).
+    """
 
     # paths with backslash are not allowed on Dropbox
     # we create such a local folder and assert that it triggers a sync issue
@@ -677,6 +728,12 @@ def test_upload_sync_issues(m):
 
 
 def test_download_sync_issues(m):
+    """
+    Tests error handling for issues during download sync. This is done by attempting to
+    download sync a file with a DMCA take down notice (not allowed through the public
+    API).
+    """
+
     test_path_local = m.test_folder_local + "/dmca.gif"
     test_path_dbx = "/sync_tests/dmca.gif"
 
@@ -724,6 +781,11 @@ def test_download_sync_issues(m):
 
 
 def test_excluded_folder_cleared_on_deletion(m):
+    """
+    Tests that an entry in our selective sync excluded list gets removed when the
+    corresponding item is deleted.
+    """
+
     dbx_path = "/sync_tests/selective_sync_test_folder"
     local_path = m.to_local_path("/sync_tests/selective_sync_test_folder")
 
@@ -752,6 +814,9 @@ def test_excluded_folder_cleared_on_deletion(m):
 
 
 def test_indexing_performance(m):
+    """
+    Tests the performance of converting remote file changes to SyncEvents.
+    """
 
     # generate tree with 5 entries
     shutil.copytree(resources + "/test_folder", m.test_folder_local + "/test_folder")

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -859,7 +859,7 @@ def test_unknown_path_encoding(m, capsys):
     # This requires that `SyncEngine.upload_local_changes_while_inactive` can handle
     # strings with surrogate escapes all they way to `SyncEngine._on_local_deleted`.
 
-    m.client.remove(test_path_dbx)
+    delete(test_path_local_bytes)  # type: ignore
     wait_for_idle(m)
 
     assert len(m.fatal_errors) == 0


### PR DESCRIPTION
This PR fixes #230 by enabling proper handling of Python surrogate escapes throughout the `sync` module.

#230 arrises in the first place because paths in Unix are bytes while Python handles all paths as strings. Normally, the platform will report a file system encoding with `sys.getfilesystemencoding` which is used by Python to decode byte paths to strings. However, the OS APIs never actually enforce this encoding. It is therefore possible to receive bytes with a different encoding which Python will replace with "surrogate escapes" in the string (see the [docs](https://docs.python.org/3/library/os.html#os.fsdecode) and an excellent writeup of the problem by [beets](https://beets.io/blog/paths.html)).

Working with such strings can be difficult. Printing them to the console (or to our logs) may raise a `UnicodeEncodingError`, as will submitting sqlite3 queries which such strings. Finally, the Dropbox APIs will rightly reject them as a malformed paths because there is no way of knowing which character was meant. 

This PR achieves handling those paths through the following changes:

1. Introduces a new function to replace all surrogate escapes with "?".
2. Surrogate escapes are stripped from database queries. This is currently done in a non-reversible way but may be improved in the future.
3. Surrogate escapes are stripped from all strings returned by the public `main.Maestral` API.
4. Watchdog is patched to handle surrogate-escaped strings which are returned from Python's `os` APIs.
5. Manually raise a `PathError` during sync instead of letting the SDK deal with it. This gives us a better error message and allows us to fail faster.
6. Ensure that our state file can handle saving sync errors with surrogate-escaped paths.
7. Add integration tests for all of the above.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
