### PR TITLE
Fix inavlid path in pending downloads

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2468,6 +2468,18 @@ class SyncEngine:
 
             self.pending_downloads.add(dbx_path.lower())
             md = self.client.get_metadata(dbx_path, include_deleted=True)
+
+            if md is None:
+                # create a fake deleted event
+                index_entry = self.get_index_entry(dbx_path)
+                cased_path = index_entry.dbx_path_cased if index_entry else dbx_path
+
+                md = DeletedMetadata(
+                    name=osp.basename(dbx_path),
+                    path_lower=dbx_path.lower(),
+                    path_display=cased_path,
+                )
+
             event = SyncEvent.from_dbx_metadata(md, self)
 
             if event.is_directory:

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -933,6 +933,29 @@ def test_indexing_performance(m):
     assert duration < 3  # expected ~ 1.8 sec
 
 
+def test_invalid_pending_download(m):
+    """
+    Tests error handling when an invalid path is saved in the pending downloads list.
+    This can happen for instance when Dropbox servers have a hickup or when our state
+    file gets corrupted.
+    """
+
+    # add a non-existent path to the pending downloads list
+    bogus_path = "/bogus path"
+    m.sync.pending_downloads.add(bogus_path)
+
+    # trigger a resync
+    m.pause_sync()
+    m.resume_sync()
+    wait_for_idle(m)
+
+    # assert that there are no sync errors / fatal errors and that the invalid path
+    # was cleared
+    assert bogus_path not in m.sync.pending_downloads
+    assert len(m.sync_errors) == 0
+    assert len(m.fatal_errors) == 0
+
+
 # ==== helper functions ================================================================
 
 


### PR DESCRIPTION
Fixes #243 by creating fake `DeletedMetadata` when we cannot locate remote Metadata (existing or deleted) for a path in our pending downloads.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
