### PR TITLE
Update keyring requirement to >= 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 #### Dependencies:
 
 * Bumped survey to version >=3.2.2,<4.0.
+* Bumped keyring to version >=22,<23.  
 * Removed bugsnag dependency.
 
 ## v1.3.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "fasteners>=0.15",
     "importlib_metadata;python_version<'3.8'",
     "importlib_resources;python_version<'3.9'",
-    "keyring>=19,<22",
+    "keyring>=22,<23",
     "keyrings.alt>=3.1.0,<5.0",
     "packaging",
     "pathspec>=0.5.8",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     "fasteners>=0.15",
     "importlib_metadata;python_version<'3.8'",
     "importlib_resources;python_version<'3.9'",
-    "keyring>=22,<23",
+    "keyring>=22",
     "keyrings.alt>=3.1.0,<5.0",
     "packaging",
     "pathspec>=0.5.8",

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1409,6 +1409,8 @@ class Maestral:
             self._update_from_pre_v1_2_0()
         elif Version(updated_from) < Version("1.2.1"):
             self._update_from_pre_v1_2_1()
+        elif Version(updated_from) < Version("1.3.2"):
+            self._update_from_pre_v1_3_2()
 
         self.set_state("app", "updated_scripts_completed", __version__)
 
@@ -1462,6 +1464,12 @@ class Maestral:
                             }
 
                         batch_op.drop_constraint(constraint_name=name, type_="unique")
+
+    def _update_from_pre_v1_3_2(self) -> None:
+
+        if self._conf.get("app", "keyring") == "keyring.backends.OS_X.Keyring":
+            logger.info("Migrating keyring after update from pre v1.3.2")
+            self._conf.set("app", "keyring", "keyring.backends.macOS.Keyring")
 
     # ==== period async jobs ===========================================================
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -135,11 +135,9 @@ class Maestral:
         self._setup_logging()
 
         # set up sync infrastructure
-        self.client = DropboxClient(
-            config_name=self.config_name
-        )  # interface to Dbx SDK
-        self.monitor = SyncMonitor(self.client)  # coordinates sync threads
-        self.sync = self.monitor.sync  # provides core sync functionality
+        self.client = DropboxClient(config_name=self.config_name)
+        self.monitor = SyncMonitor(self.client)
+        self.sync = self.monitor.sync
 
         self._check_and_run_post_update_scripts()
 

--- a/src/maestral/oauth.py
+++ b/src/maestral/oauth.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 # external imports
 import keyring.backends  # type: ignore
-import keyring.backends.OS_X  # type: ignore
+import keyring.backends.macOS  # type: ignore
 import keyring.backends.SecretService  # type: ignore
 import keyring.backends.kwallet  # type: ignore
 from keyring.backend import KeyringBackend  # type: ignore
@@ -33,7 +33,7 @@ __all__ = ["OAuth2Session"]
 logger = logging.getLogger(__name__)
 
 supported_keyring_backends = (
-    keyring.backends.OS_X.Keyring,
+    keyring.backends.macOS.Keyring,
     keyring.backends.SecretService.Keyring,
     keyring.backends.kwallet.DBusKeyring,
     keyring.backends.kwallet.DBusKeyringKWallet4,


### PR DESCRIPTION
Keyring v22.0 has renamed the macOS backend from `keyring.backends.OS_X` to `keyring.backends.macOS`.

This PR bumps keyring to >=22.0, adapts imports, and migrates relevant config values.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
