### PR TITLE
Use SIGTERM to shut down daemon

### DIFF
--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -601,7 +601,7 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
         cli.ok("Setup completed. Starting sync.")
 
     if foreground:
-        del m
+        m.shutdown_daemon()
         start_maestral_daemon(config_name, log_to_stdout=verbose, start_sync=True)
     else:
         m.start_sync()

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -553,6 +553,8 @@ def start_maestral_daemon(
         logger.error(exc.args[0], exc_info=True)
     finally:
 
+        loop.close()
+
         if NOTIFY_SOCKET:
             # notify systemd that we are shutting down
             sd_notifier.notify("STOPPING=1")

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -506,6 +506,7 @@ def start_maestral_daemon(
                 loop.add_reader(socket.fileno(), daemon.events, daemon.sockets)
 
             # handle sigterm gracefully
+
             signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT)
             for s in signals:
                 loop.add_signal_handler(s, maestral_daemon.shutdown_daemon)

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -142,6 +142,8 @@ for err_cls in (*SYNC_ERRORS, *GENERAL_ERRORS):
 
 def _get_lockdata() -> Tuple[bytes, str, int]:
 
+    # see cpython/Lib/test/test_fcntl.py
+
     try:
         os.O_LARGEFILE
     except AttributeError:
@@ -149,10 +151,7 @@ def _get_lockdata() -> Tuple[bytes, str, int]:
     else:
         start_len = "qq"
 
-    if (
-        sys.platform.startswith(("netbsd", "freebsd", "openbsd"))
-        or sys.platform == "darwin"
-    ):
+    if sys.platform == "darwin":
         if struct.calcsize("l") == 8:
             off_t = "l"
             pid_t = "i"
@@ -163,14 +162,6 @@ def _get_lockdata() -> Tuple[bytes, str, int]:
         fmt = off_t + off_t + pid_t + "hh"
         pid_index = 2
         lockdata = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0)
-    # elif sys.platform.startswith('gnukfreebsd'):
-    #     fmt = 'qqihhi'
-    #     pid_index = 2
-    #     lockdata = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0, 0)
-    # elif sys.platform in ('hp-uxB', 'unixware7'):
-    #     fmt = 'hhlllii'
-    #     pid_index = 2
-    #     lockdata = struct.pack(fmt, fcntl.F_WRLCK, 0, 0, 0, 0, 0, 0)
     elif sys.platform.startswith("linux"):
         fmt = "hh" + start_len + "ih"
         pid_index = 4

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1427,7 +1427,8 @@ class Maestral:
 
     def shutdown_daemon(self) -> None:
         """
-        Stop the event loop. This will also shut down the pyro daemon if running.
+        Stop syncing and clean up our asyncio tasks. Set a result for the
+        :attr:`shutdown_complete` future.
         """
 
         self.stop_sync()

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1435,6 +1435,10 @@ class Maestral:
         for task in self._tasks:
             task.cancel()
 
+        self._loop.run_until_complete(
+            asyncio.gather(*self._tasks, return_exceptions=True)
+        )
+
         self._pool.shutdown(wait=False)
 
         if self._loop.is_running():


### PR DESCRIPTION
This PR simplifies the way we shut down the daemon. Instead of calling `Maestral.shutdown_daemon()` directly via Pyro5, we send SIGTERM to the daemon process and rely on the signal handler to invoke `Maestral.shutdown_daemon()`.

This has the advantage that, if the daemon process has become completely unresponsive, the remote `Maestral.shutdown_daemon()` call would block while sending SIGTERM will just fail to stop the process and can be followed up by SIGKILL after a timeout.

This change means that we need to know the daemon's PID. This is currently obtained by finding the process which has a write lock on the lock file, using ctypes calls which may fail on the some platforms. In this case, `maestral stop` will report "failed" and the user must manually stop the process.

Do not merge before https://github.com/beeware/rubicon-objc/issues/202 has been fixed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
