### PR TITLE
Resumable indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   change is that **maestral will remove existing matching files from Dropbox as well**.
   After this change it will be immaterial if an `.mignore` pattern is added before or
   after having matching files  in Dropbox.
+* If Maestral is quit or interrupted during indexing, for instance due to connection
+  problems, it will later resume from the same position instead of restarting the
+  beginning.
+* Indexing will no longer skip excluded folders. This is necessary for the above change.
 
 #### Fixes:
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -863,7 +863,16 @@ class Maestral:
 
             return content, md
 
+        md_new = self.client.get_metadata(f"rev:{new_rev}", include_deleted=True)
         md_old = self.client.get_metadata(f"rev:{old_rev}", include_deleted=True)
+
+        if md_new is None or md_old is None:
+            missing_rev = new_rev if md_new is None else old_rev
+            raise NotFoundError(
+                f"Could not a file with revision {missing_rev}",
+                "Use 'list_revisions' to list past revisions of a file.",
+            )
+
         dbx_path = self.sync.correct_case(md_old.path_display)
         local_path = self.sync.to_local_path(md_old.path_display)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1494,8 +1494,8 @@ class SyncEngine:
                 ctime_check = snapshot_time > stats.st_ctime > last_sync
 
                 # always upload untracked items, check ctime of tracked items
-                local_entry = self.get_index_entry(dbx_path_lower)
-                is_new = local_entry is None
+                index_entry = self.get_index_entry(dbx_path_lower)
+                is_new = index_entry is None
                 is_modified = ctime_check and not is_new
 
                 if is_new:
@@ -1506,10 +1506,10 @@ class SyncEngine:
                     changes.append(event)
 
                 elif is_modified:
-                    if snapshot.isdir(path) and local_entry.is_directory:  # type: ignore
+                    if snapshot.isdir(path) and index_entry.is_directory:  # type: ignore
                         event = DirModifiedEvent(path)
                         changes.append(event)
-                    elif not snapshot.isdir(path) and not local_entry.is_directory:  # type: ignore
+                    elif not snapshot.isdir(path) and not index_entry.is_directory:  # type: ignore
                         event = FileModifiedEvent(path)
                         changes.append(event)
                     elif snapshot.isdir(path):
@@ -1522,8 +1522,9 @@ class SyncEngine:
                         changes += [event0, event1]
 
         # get deleted items
+        dbx_root_lower = self.dropbox_path.lower()
         for entry in entries:
-            local_path_uncased = f"{self.dropbox_path}{entry.dbx_path_lower}".lower()
+            local_path_uncased = f"{dbx_root_lower}{entry.dbx_path_lower}"
             if local_path_uncased not in lowercase_snapshot_paths:
                 local_path = self.to_local_path_from_cased(entry.dbx_path_cased)
                 if entry.is_directory:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3507,10 +3507,10 @@ def startup_worker(
 
         with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
 
-            if sync.remote_cursor == "":
-                sync.clear_sync_errors()
-
             sync.ensure_dropbox_folder_present()
+
+            # Download remote changes / indexing.
+            sync.download_sync_cycle()
 
             # Retry failed downloads.
             if len(sync.download_errors) > 0:
@@ -3540,9 +3540,6 @@ def startup_worker(
 
             if not running.is_set():
                 continue
-
-            # Download remote changes / indexing.
-            sync.download_sync_cycle()
 
             if not running.is_set():
                 continue

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1543,6 +1543,8 @@ class SyncEngine:
 
     def wait_for_local_changes(self, timeout: float = 40) -> bool:
 
+        logger.debug("Waiting for local changes since cursor: %s", self.local_cursor)
+
         with self.fs_events.local_file_event_queue.not_empty:
             return self.fs_events.local_file_event_queue.not_empty.wait(timeout)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3397,10 +3397,11 @@ def download_worker(
         with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
 
             has_changes = sync.wait_for_remote_changes(sync.remote_cursor)
-            sync.ensure_dropbox_folder_present()
 
             if not (running.is_set() and syncing.is_set()):
                 continue
+
+            sync.ensure_dropbox_folder_present()
 
             if has_changes:
                 logger.info(SYNCING)
@@ -3471,10 +3472,11 @@ def upload_worker(
         with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
 
             has_changes = sync.wait_for_local_changes()
-            sync.ensure_dropbox_folder_present()
 
             if not (running.is_set() and syncing.is_set()):
                 continue
+
+            sync.ensure_dropbox_folder_present()
 
             if has_changes:
                 logger.info(SYNCING)
@@ -3506,8 +3508,6 @@ def startup_worker(
         startup.wait()
 
         with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
-
-            sync.ensure_dropbox_folder_present()
 
             # Download remote changes / indexing.
             sync.download_sync_cycle()

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1545,8 +1545,13 @@ class SyncEngine:
 
         logger.debug("Waiting for local changes since cursor: %s", self.local_cursor)
 
-        with self.fs_events.local_file_event_queue.not_empty:
-            return self.fs_events.local_file_event_queue.not_empty.wait(timeout)
+        try:
+            event = self.fs_events.local_file_event_queue.get(timeout=timeout)
+        except Empty:
+            return False
+
+        self.fs_events.local_file_event_queue.queue.append(event)
+        return True
 
     def upload_sync_cycle(self):
         """

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2497,7 +2497,6 @@ class SyncEngine:
 
             1) :meth:`list_remote_changes_iterator`
             2) :meth:`apply_remote_changes`
-            3) :meth:`notify_user`
 
         Handles updating the remote cursor and resuming interrupted syncs for you.
         Calling this method will perform a full indexing if this is the first download.
@@ -2505,12 +2504,17 @@ class SyncEngine:
 
         with self.sync_lock:
 
+            is_indexing = self.remote_cursor == ""
+
             changes_iter = self.list_remote_changes_iterator(self.remote_cursor)
 
-            # download changes in chunks to reduce memory usage
+            # Download changes in chunks to reduce memory usage.
             for changes, cursor in changes_iter:
                 downloaded = self.apply_remote_changes(changes)
-                self.notify_user(downloaded)
+
+                if not is_indexing:
+                    # Don't send desktop notifications during indexing.
+                    self.notify_user(downloaded)
 
                 if self._cancel_requested.is_set():
                     break

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3510,9 +3510,6 @@ def startup_worker(
 
         with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
 
-            # Download remote changes / indexing.
-            sync.download_sync_cycle()
-
             # Retry failed downloads.
             if len(sync.download_errors) > 0:
                 logger.info("Retrying failed syncs...")
@@ -3537,6 +3534,7 @@ def startup_worker(
             # for dbx_path in list(sync.upload_errors):
             #     sync.rescan(sync.to_local_path(dbx_path))
 
+            sync.download_sync_cycle()
             sync.upload_local_changes_while_inactive()
 
             if not running.is_set():

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1441,7 +1441,7 @@ class SyncEngine:
                 sync_events = [
                     SyncEvent.from_file_system_event(e, self) for e in events
                 ]
-            except FileNotFoundError:
+            except (FileNotFoundError, NotADirectoryError):
                 self.ensure_dropbox_folder_present()
                 return
 
@@ -2852,7 +2852,7 @@ class SyncEngine:
 
         try:
             stat = os.stat(local_path)
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
             # don't check ctime for deleted items (os won't give stat info)
             # but confirm absence from index
             return index_entry is not None
@@ -2907,7 +2907,7 @@ class SyncEngine:
                 return ctime
             else:
                 return os.stat(local_path).st_ctime
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
             return -1.0
 
     def _clean_remote_changes(
@@ -3210,7 +3210,7 @@ class SyncEngine:
             self.update_index_from_sync_event(event)
             logger.debug('Deleted local item "%s"', event.dbx_path)
             return event
-        elif isinstance(exc, FileNotFoundError):
+        elif isinstance(exc, (FileNotFoundError, NotADirectoryError)):
             self.update_index_from_sync_event(event)
             logger.debug('Deletion failed: "%s" not found', event.dbx_path)
             return None

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3375,7 +3375,7 @@ class SyncEngine:
 
 
 @contextmanager
-def _handle_sync_thread_errors(
+def handle_sync_thread_errors(
     syncing: Event,
     running: Event,
     connected: Event,
@@ -3416,7 +3416,8 @@ def download_worker(
 
         syncing.wait()
 
-        with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+        with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+
             has_changes = sync.wait_for_remote_changes(sync.remote_cursor)
             sync.ensure_dropbox_folder_present()
 
@@ -3453,7 +3454,8 @@ def download_worker_added_item(
 
         syncing.wait()
 
-        with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+        with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+
             dbx_path = added_item_queue.get()
             sync.pending_downloads.add(dbx_path.lower())  # protect against crashes
 
@@ -3488,7 +3490,8 @@ def upload_worker(
 
         syncing.wait()
 
-        with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+        with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+
             has_changes = sync.wait_for_local_changes()
             sync.ensure_dropbox_folder_present()
 
@@ -3524,7 +3527,7 @@ def startup_worker(
 
         startup.wait()
 
-        with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
+        with handle_sync_thread_errors(syncing, running, connected, sync.notifier):
 
             if sync.remote_cursor == "":
                 sync.clear_sync_errors()

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1578,8 +1578,6 @@ class SyncEngine:
         :returns: (list of sync times events, time_stamp)
         """
 
-        self.ensure_dropbox_folder_present()
-
         events = []
         local_cursor = time.time()
 
@@ -3420,6 +3418,7 @@ def download_worker(
 
         with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
             has_changes = sync.wait_for_remote_changes(sync.remote_cursor)
+            sync.ensure_dropbox_folder_present()
 
             if not (running.is_set() and syncing.is_set()):
                 continue
@@ -3491,6 +3490,7 @@ def upload_worker(
 
         with _handle_sync_thread_errors(syncing, running, connected, sync.notifier):
             has_changes = sync.wait_for_local_changes()
+            sync.ensure_dropbox_folder_present()
 
             if not (running.is_set() and syncing.is_set()):
                 continue
@@ -3528,6 +3528,8 @@ def startup_worker(
 
             if sync.remote_cursor == "":
                 sync.clear_sync_errors()
+
+            sync.ensure_dropbox_folder_present()
 
             # Retry failed downloads.
             if len(sync.download_errors) > 0:
@@ -3804,6 +3806,7 @@ class SyncMonitor:
         """
 
         while True:
+
             if check_connection("www.dropbox.com"):
                 self.on_connect()
             else:

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -130,7 +130,9 @@ def wait_for_idle(m: Maestral, minimum: int = 4):
     t0 = time.time()
     while time.time() - t0 < minimum:
         if m.sync.busy():
-            m.monitor._wait_for_idle()
+            # Wait until we can acquire the sync lock => we are idle.
+            m.sync.sync_lock.acquire()
+            m.sync.sync_lock.release()
             t0 = time.time()
         else:
             time.sleep(0.1)

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -545,7 +545,7 @@ def test_selective_sync_conflict(m):
     m.exclude_item("/sync_tests/folder")
     wait_for_idle(m)
 
-    assert not (osp.exists(m.test_folder_local + "/folder"))
+    assert not osp.exists(m.test_folder_local + "/folder")
 
     # recreate 'folder' locally
     os.mkdir(m.test_folder_local + "/folder")

--- a/tests/offline/test_ignoring_events.py
+++ b/tests/offline/test_ignoring_events.py
@@ -19,7 +19,8 @@ def test_receiving_events(sync):
     new_dir = Path(sync.dropbox_path) / "parent"
     new_dir.mkdir()
 
-    sync_events, local_cursor = sync.wait_for_local_changes()
+    sync.wait_for_local_changes()
+    sync_events, _ = sync.list_local_changes()
 
     assert len(sync_events) == 1
 
@@ -46,7 +47,8 @@ def test_ignore_tree_creation(sync):
             file = new_dir / f"test_{i}"
             file.touch()
 
-    sync_events, local_cursor = sync.wait_for_local_changes()
+    sync.wait_for_local_changes()
+    sync_events, _ = sync.list_local_changes()
     assert len(sync_events) == 0
 
 
@@ -60,13 +62,15 @@ def test_ignore_tree_move(sync):
         file.touch()
 
     sync.wait_for_local_changes()
+    sync.list_local_changes()
 
     new_dir_1 = Path(sync.dropbox_path) / "parent2"
 
     with sync.fs_events.ignore(DirMovedEvent(str(new_dir), str(new_dir_1))):
         move(new_dir, new_dir_1)
 
-    sync_events, local_cursor = sync.wait_for_local_changes()
+    sync.wait_for_local_changes()
+    sync_events, _ = sync.list_local_changes()
     assert len(sync_events) == 0
 
 
@@ -81,5 +85,6 @@ def test_catching_non_ignored_events(sync):
             file = new_dir / f"test_{i}"
             file.touch()
 
-    sync_events, local_cursor = sync.wait_for_local_changes()
+    sync.wait_for_local_changes()
+    sync_events, _ = sync.list_local_changes()
     assert all(not si.is_directory for si in sync_events)


### PR DESCRIPTION
This PR refactors the initial indexing and subsequent `/files/list_folder/continue` calls to be resumable, i.e., to work with an intermediate curser during an indexing job.

This means that we must always start by indexing the entire Dropbox to work with global cursers instead of skipping excluded folders and therefore may incur a performance tradeoff in case of a large number of excluded items. However, this results results in more robust behaviour for very large Dropbox folders when restarting an indexing job after a lost connection or a restart.

See #289, #186 and #138.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
