### PR TITLE
Shared link api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,27 @@
 
 #### Added:
 
-* Add a command `maestral diff` to compare different versions of a text file. The
+* Added a command `maestral diff` to compare different versions of a text file. The
   resulting diff is printed to the console. Thanks to @OrangeFran.
-* Resurrected the command `maestral revs` to list previous versions or a file.
+* Resurrected the command `maestral revs` to list previous versions of a file.
+* Added a command group `maestral sharelink` to create and manage shared links.
+  Subcommands are:
+  * `create`: Create a shared link for a file or folder, optionally with password
+    protection and an expiry date on supported accounts (business and professional).
+  * `list`: List shared links, either for a specific file or folder or for all items in
+    your Dropbox.
+  * `revoke`: Revoke a shared link.
+* Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
 
 #### Changed:
 
-* Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
-* Performance has been improved by avoiding scanning of objects matching an 
-  `.mignore` pattern (file watches will still be added however). A resulting behavioral
-  change is that **maestral will remove existing matching files from Dropbox as well**.
-  After this change it will be immaterial if an `.mignore` pattern is added before or
-  after having matching files  in Dropbox.
+* Avoiding scanning of objects matching an  `.mignore` pattern (file watches will still
+  be added however). This results in performance improvements during startup and resume.
+  A resulting behavioral change is that **maestral will remove files matching an ignore
+  pattern from Dropbox**. After this change it will be immaterial if an `.mignore`
+  pattern is added before or after having matching files  in Dropbox.
 * If Maestral is quit or interrupted during indexing, for instance due to connection
-  problems, it will later resume from the same position instead of restarting the
+  problems, it will later resume from the same position instead of restarting from the
   beginning.
 * Indexing will no longer skip excluded folders. This is necessary for the above change.
 

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -1219,7 +1219,7 @@ def notify():
 @click.argument(
     "level_name",
     required=False,
-    type=click.Choice(["ERROR", "SYNCISSUE", "FILECHANGE"]),
+    type=click.Choice(["ERROR", "SYNCISSUE", "FILECHANGE"], case_sensitive=False),
 )
 @existing_config_option
 def notify_level(level_name: str, config_name: str) -> None:
@@ -1615,7 +1615,7 @@ def log_clear(config_name: str) -> None:
 @click.argument(
     "level_name",
     required=False,
-    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"]),
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
 )
 @existing_config_option
 def log_level(level_name: str, config_name: str) -> None:

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -934,7 +934,7 @@ def history(config_name: str) -> None:
 
 
 @main.command(section="Information", help="List contents of a Dropbox directory.")
-@click.argument("dropbox_path", type=click.Path(), default="")
+@click.argument("dropbox_path", type=DropboxPath(), default="")
 @click.option(
     "-l",
     "--long",
@@ -1159,7 +1159,7 @@ def excluded_list(config_name: str) -> None:
     name="add",
     help="Add a file or folder to the excluded list and re-sync.",
 )
-@click.argument("dropbox_path", type=click.Path())
+@click.argument("dropbox_path", type=DropboxPath())
 @existing_config_option
 @catch_maestral_errors
 def excluded_add(dropbox_path: str, config_name: str) -> None:
@@ -1186,7 +1186,7 @@ not be downloaded again. If the given path lies inside an excluded folder, the p
 folder will be included as well (but no other items inside it).
 """,
 )
-@click.argument("dropbox_path", type=click.Path())
+@click.argument("dropbox_path", type=DropboxPath())
 @existing_config_option
 @catch_maestral_errors
 def excluded_remove(dropbox_path: str, config_name: str) -> None:
@@ -1509,7 +1509,7 @@ Restore a previous version of a file.
 If no revision number is given, old revisions will be listed.
 """,
 )
-@click.argument("dropbox_path", type=click.Path())
+@click.argument("dropbox_path", type=DropboxPath())
 @click.option("-v", "--rev", help="Revision to restore.", default="")
 @click.option(
     "-l",

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -746,11 +746,11 @@ def unlink(yes: bool, config_name: str) -> None:
 
 
 @main.group(section="Core Commands", help="Create and manage shared links.")
-def sharedlink():
+def sharelink():
     pass
 
 
-@sharedlink.command(name="create", help="Create a shared link for a file or folder.")
+@sharelink.command(name="create", help="Create a shared link for a file or folder.")
 @click.argument("dropbox_path", type=DropboxPath())
 @click.option(
     "-p",
@@ -766,7 +766,7 @@ def sharedlink():
 )
 @existing_config_option
 @catch_maestral_errors
-def sharedlink_create(
+def sharelink_create(
     dropbox_path: str,
     password: str,
     expiry: Optional[datetime],
@@ -796,11 +796,11 @@ def sharedlink_create(
     cli.echo(link_info["url"])
 
 
-@sharedlink.command(name="revoke", help="Revoke a shared link.")
+@sharelink.command(name="revoke", help="Revoke a shared link.")
 @click.argument("url")
 @existing_config_option
 @catch_maestral_errors
-def sharedlink_revoke(url: str, config_name: str) -> None:
+def sharelink_revoke(url: str, config_name: str) -> None:
 
     from .daemon import MaestralProxy
 
@@ -810,7 +810,7 @@ def sharedlink_revoke(url: str, config_name: str) -> None:
     cli.echo("Revoked shared link.")
 
 
-@sharedlink.command(
+@sharelink.command(
     name="list",
     help="""
 List shared links.
@@ -822,7 +822,7 @@ the Dropbox.
 @click.argument("dropbox_path", required=False, type=DropboxPath())
 @existing_config_option
 @catch_maestral_errors
-def sharedlink_list(dropbox_path: Optional[str], config_name: str) -> None:
+def sharelink_list(dropbox_path: Optional[str], config_name: str) -> None:
 
     from .daemon import MaestralProxy
 

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -765,6 +765,7 @@ def sharedlink():
     help="Expiry time for the link (e.g. '2025-07-24 20:50').",
 )
 @existing_config_option
+@catch_maestral_errors
 def sharedlink_create(
     dropbox_path: str,
     password: str,
@@ -798,6 +799,7 @@ def sharedlink_create(
 @sharedlink.command(name="revoke", help="Revoke a shared link.")
 @click.argument("url")
 @existing_config_option
+@catch_maestral_errors
 def sharedlink_revoke(url: str, config_name: str) -> None:
 
     from .daemon import MaestralProxy
@@ -819,6 +821,7 @@ the Dropbox.
 )
 @click.argument("dropbox_path", required=False, type=DropboxPath())
 @existing_config_option
+@catch_maestral_errors
 def sharedlink_list(dropbox_path: Optional[str], config_name: str) -> None:
 
     from .daemon import MaestralProxy
@@ -829,12 +832,11 @@ def sharedlink_list(dropbox_path: Optional[str], config_name: str) -> None:
     with MaestralProxy(config_name, fallback=True) as m:
         links = m.list_shared_links(dropbox_path)
 
-    link_table = cli.Table(
-        [cli.Column("URL"), cli.Column("Visibility"), cli.Column("Expires")]
-    )
+    link_table = cli.Table(["URL", "Item", "Visibility", "Expires"])
 
     for link in links:
         url = cast(str, link["url"])
+        file_name = cast(str, link["name"])
         visibility = cast(str, link["link_permissions"]["resolved_visibility"][".tag"])
 
         dt_field: cli.Field
@@ -847,7 +849,7 @@ def sharedlink_list(dropbox_path: Optional[str], config_name: str) -> None:
         else:
             dt_field = cli.TextField("-")
 
-        link_table.append([url, visibility, dt_field])
+        link_table.append([url, file_name, visibility, dt_field])
 
     cli.echo("")
     link_table.echo()

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -811,13 +811,7 @@ def sharelink_revoke(url: str, config_name: str) -> None:
 
 
 @sharelink.command(
-    name="list",
-    help="""
-List shared links.
-
-Lists all shared links for a file or folder. If not path is given, lists all links for
-the Dropbox.
-""",
+    name="list", help="List shared links for a path or all shared links."
 )
 @click.argument("dropbox_path", required=False, type=DropboxPath())
 @existing_config_option
@@ -832,7 +826,7 @@ def sharelink_list(dropbox_path: Optional[str], config_name: str) -> None:
     with MaestralProxy(config_name, fallback=True) as m:
         links = m.list_shared_links(dropbox_path)
 
-    link_table = cli.Table(["URL", "Item", "Visibility", "Expires"])
+    link_table = cli.Table(["URL", "Item", "Access", "Expires"])
 
     for link in links:
         url = cast(str, link["url"])

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -11,6 +11,7 @@ import os
 import os.path as osp
 import functools
 import time
+from datetime import datetime
 from typing import Optional, Dict, List, Tuple, Callable, Union, cast, TYPE_CHECKING
 
 # external imports
@@ -905,7 +906,6 @@ def activity(config_name: str) -> None:
 @catch_maestral_errors
 def history(config_name: str) -> None:
 
-    from datetime import datetime
     from .daemon import MaestralProxy
 
     with MaestralProxy(config_name, fallback=True) as m:
@@ -953,7 +953,6 @@ def history(config_name: str) -> None:
 @catch_maestral_errors
 def ls(long: bool, dropbox_path: str, include_deleted: bool, config_name: str) -> None:
 
-    from datetime import datetime
     from .utils import natural_size
     from .daemon import MaestralProxy
 
@@ -1332,7 +1331,6 @@ def rebuild_index(config_name: str) -> None:
 @catch_maestral_errors
 def revs(dropbox_path: str, limit: int, config_name: str) -> None:
 
-    from datetime import datetime
     from .daemon import MaestralProxy
 
     with MaestralProxy(config_name, fallback=True) as m:
@@ -1396,7 +1394,6 @@ def diff(
     config_name: str,
 ) -> None:
 
-    from datetime import datetime
     from .daemon import MaestralProxy
 
     # Reason for rel_dbx_path: os.path.join does not like leading /
@@ -1522,7 +1519,7 @@ If no revision number is given, old revisions will be listed.
 @existing_config_option
 @catch_maestral_errors
 def restore(dropbox_path: str, rev: str, limit: int, config_name: str) -> None:
-    from datetime import datetime
+
     from .daemon import MaestralProxy
 
     if not dropbox_path.startswith("/"):

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -721,7 +721,7 @@ def link(relink: bool, config_name: str) -> None:
 @main.command(
     section="Core Commands",
     help="""
-Unlinks your Dropbox account.
+Unlink your Dropbox account.
 
 If Maestral is running, it will be stopped before unlinking.
 """,

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -808,14 +808,22 @@ def sharedlink_revoke(url: str, config_name: str) -> None:
     cli.echo("Revoked shared link.")
 
 
-@sharedlink.command(name="list", help="List all shared links for a file or folder.")
-@click.argument("dropbox_path", type=DropboxPath())
+@sharedlink.command(
+    name="list",
+    help="""
+List shared links.
+
+Lists all shared links for a file or folder. If not path is given, lists all links for
+the Dropbox.
+""",
+)
+@click.argument("dropbox_path", required=False, type=DropboxPath())
 @existing_config_option
-def sharedlink_list(dropbox_path: str, config_name: str) -> None:
+def sharedlink_list(dropbox_path: Optional[str], config_name: str) -> None:
 
     from .daemon import MaestralProxy
 
-    if not dropbox_path.startswith("/"):
+    if dropbox_path and not dropbox_path.startswith("/"):
         dropbox_path = "/" + dropbox_path
 
     with MaestralProxy(config_name, fallback=True) as m:

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -401,7 +401,7 @@ class DropboxClient:
         call.
 
         :param dbx_path: Path of folder on Dropbox.
-        :param kwargs: Keyword arguments for Dropbox SDK files_download_to_file.
+        :param kwargs: Keyword arguments for Dropbox SDK files_get_metadata.
         :returns: Metadata of item at the given path or ``None`` if item cannot be found.
         """
 
@@ -455,7 +455,7 @@ class DropboxClient:
         :param local_path: Path to local download destination.
         :param sync_event: If given, the sync event will be updated with the number of
             downloaded bytes.
-        :param kwargs: Keyword arguments for Dropbox SDK files_download_to_file.
+        :param kwargs: Keyword arguments for Dropbox SDK files_download.
         :returns: Metadata of downloaded item.
         """
 
@@ -970,19 +970,25 @@ class DropboxClient:
         visibility: sharing.RequestedVisibility = sharing.RequestedVisibility.public,
         password: Optional[str] = None,
         expires: Optional[datetime] = None,
+        **kwargs,
     ) -> sharing.SharedLinkMetadata:
         """
         Creates a shared link for the given path. Some options are only available for
-        Professional and Business accounts
+        Professional and Business accounts. Note that the requested visibility as access
+        level for the link may not be granted, depending on the Dropbox folder or team
+        settings. Check the returned link metadata to verify the visibility and access
+        level.
 
         :param dbx_path: Dropbox path to file or folder to share.
-        :param visibility: The visibility of the shared item. Can be public, team-only,
+        :param visibility: The visibility of the shared link. Can be public, team-only,
             or password protected. In case of the latter, the password argument must be
             given. Only available for Professional and Business accounts.
         :param password: Password to protect shared link. Is required if visibility
             is set to password protected and will be ignored otherwise
         :param expires: Expiry time for shared link. Only available for Professional and
             Business accounts.
+        :param kwargs: Additional keyword arguments for the
+            :class:`dropbox.sharing.SharedLinkSettings`.
         :returns: Metadata for shared link.
         """
 
@@ -1005,6 +1011,7 @@ class DropboxClient:
             requested_visibility=visibility,
             link_password=password,
             expires=expires,
+            **kwargs,
         )
 
         with convert_api_errors(dbx_path=dbx_path):

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1227,7 +1227,10 @@ def dropbox_to_maestral_error(
     :returns: :class:`MaestralApiError` instance.
     """
 
-    err_cls: Type[MaestralApiError]
+    title = "An unexpected error occurred"
+    text = "Please contact the developer with the traceback information from the logs."
+    err_cls = MaestralApiError
+
     # ---- Dropbox API Errors ----------------------------------------------------------
     if isinstance(exc, exceptions.ApiError):
 
@@ -1332,7 +1335,6 @@ def dropbox_to_maestral_error(
             elif error.is_properties_error():
                 # this is a programming error in maestral
                 text = "Invalid property group provided."
-                err_cls = MaestralApiError
             else:
                 text = "Please check the logs or traceback for more information"
                 err_cls = SyncError
@@ -1342,11 +1344,9 @@ def dropbox_to_maestral_error(
             if error.is_concurrent_session_close_not_allowed():
                 # this is a programming error in maestral
                 text = "Can not start a closed concurrent upload session."
-                err_cls = MaestralApiError
             elif error.is_concurrent_session_data_not_allowed():
                 # this is a programming error in maestral
                 text = "Uploading data not allowed when starting concurrent upload session."
-                err_cls = MaestralApiError
             else:
                 text = "Please check the logs or traceback for more information"
                 err_cls = SyncError
@@ -1362,7 +1362,6 @@ def dropbox_to_maestral_error(
             elif error.is_properties_error():
                 # this is a programming error in maestral
                 text = "Invalid property group provided."
-                err_cls = MaestralApiError
             elif error.is_too_many_write_operations():
                 text = (
                     "There are too many write operations happening in your "
@@ -1394,12 +1393,6 @@ def dropbox_to_maestral_error(
             if error.is_path():
                 lookup_error = error.get_path()
                 text, err_cls = _get_lookup_error_msg(lookup_error)
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, files.ListFolderContinueError):
             title = "Could not list folder contents"
@@ -1412,12 +1405,6 @@ def dropbox_to_maestral_error(
                     "Maestral's index to re-sync your Dropbox."
                 )
                 err_cls = CursorResetError
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, files.ListFolderLongpollError):
             title = "Could not get Dropbox changes"
@@ -1427,12 +1414,6 @@ def dropbox_to_maestral_error(
                     "Maestral's index to re-sync your Dropbox."
                 )
                 err_cls = CursorResetError
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, async_.PollError):
 
@@ -1446,13 +1427,9 @@ def dropbox_to_maestral_error(
                 )
                 err_cls = DropboxServerError
             else:
-                # Other tags include invalid_async_job_id. Neither should occur in our
-                # SDK usage.
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
+                # Other tags include invalid_async_job_id.
+                # Neither should occur in our SDK usage.
+                pass
 
         elif isinstance(error, files.ListRevisionsError):
 
@@ -1461,12 +1438,6 @@ def dropbox_to_maestral_error(
             if error.is_path():
                 lookup_error = error.get_path()
                 text, err_cls = _get_lookup_error_msg(lookup_error)
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, files.RestoreError):
 
@@ -1481,12 +1452,6 @@ def dropbox_to_maestral_error(
             elif error.is_path_write():
                 write_error = error.get_path_write()
                 text, err_cls = _get_write_error_msg(write_error)
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, files.GetMetadataError):
             title = "Could not get metadata"
@@ -1494,12 +1459,6 @@ def dropbox_to_maestral_error(
             if error.is_path():
                 lookup_error = error.get_path()
                 text, err_cls = _get_lookup_error_msg(lookup_error)
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, users.GetAccountError):
             title = "Could not get account info"
@@ -1510,12 +1469,6 @@ def dropbox_to_maestral_error(
                     "exist or has been deleted"
                 )
                 err_cls = InvalidDbidError
-            else:
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
-                err_cls = MaestralApiError
 
         elif isinstance(error, sharing.CreateSharedLinkWithSettingsError):
             title = "Could not create shared link"
@@ -1592,19 +1545,12 @@ def dropbox_to_maestral_error(
                 # Other tags are invalid_select_admin, invalid_select_user,
                 # missing_scope, route_access_denied. Neither should occur in our SDK
                 # usage.
-                err_cls = MaestralApiError
-                title = "An unexpected error occurred"
-                text = (
-                    "Please contact the developer with the traceback "
-                    "information from the logs."
-                )
+                pass
 
         else:
             err_cls = DropboxAuthError
             title = "Authentication error"
-            text = (
-                "Please check if you can log into your account on the Dropbox website."
-            )
+            text = "Please check if you can log in on the Dropbox website."
 
     # ---- OAuth2 flow errors ----------------------------------------------------------
     elif isinstance(exc, requests.HTTPError):
@@ -1637,15 +1583,6 @@ def dropbox_to_maestral_error(
             "Something went wrong with the job on Dropbox’s end. Please "
             "verify on the Dropbox website if the job succeeded and try "
             "again if it failed."
-        )
-
-    # ---- Everything else -------------------------------------------------------------
-    else:
-        err_cls = MaestralApiError
-        title = "An unexpected error occurred"
-        text = (
-            "Please contact the developer with the traceback "
-            "information from the logs."
         )
 
     maestral_exc = err_cls(title, text, dbx_path=dbx_path, local_path=local_path)

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1029,9 +1029,12 @@ class DropboxClient:
         with convert_api_errors():
             self.dbx.sharing_revoke_shared_link(url)
 
-    def list_shared_links(self, dbx_path: str) -> sharing.ListSharedLinksResult:
+    def list_shared_links(
+        self, dbx_path: Optional[str] = None
+    ) -> sharing.ListSharedLinksResult:
         """
-        Lists all shared links for a given Dropbox path (file or folder).
+        Lists all shared links for a given Dropbox path (file or folder). If no path is
+        given, list all shared links for the account, up to a maximum of 1,000 links.
 
         :param dbx_path: Dropbox path to file or folder.
         :returns: Shared links for a path, including any shared links for parents

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -22,8 +22,14 @@ from typing import (
     Iterator,
     TypeVar,
     Optional,
+    cast,
     TYPE_CHECKING,
 )
+
+try:
+    from typing import Protocol  # type: ignore
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
 # external imports
 import requests
@@ -121,8 +127,20 @@ SessionLookupErrorType = Type[
         FileSizeError,
     ]
 ]
-_FT = Callable[..., Any]
-_T = TypeVar("_T")
+FT = TypeVar("FT", bound=Callable[..., Any])
+
+
+class ResultType(Protocol):
+    def __init__(self, entries: list, cursor: str, has_more: bool) -> None:
+        ...
+
+    @property
+    def cursor(self) -> str:
+        ...
+
+    @property
+    def has_more(self) -> bool:
+        ...
 
 
 # create single requests session for all clients

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -249,6 +249,12 @@ class UnsupportedFileTypeForDiff(MaestralApiError):
     pass
 
 
+class SharedLinkError(MaestralApiError):
+    """Raised when creating a shared link fails."""
+
+    pass
+
+
 # connection errors are handled as warnings
 # sync errors only appear in the sync errors list
 # all other errors raise an error dialog in the GUI
@@ -270,6 +276,7 @@ GENERAL_ERRORS = (
     OutOfMemoryError,
     BusyError,
     UnsupportedFileTypeForDiff,
+    SharedLinkError,
 )
 
 SYNC_ERRORS = (

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -27,13 +27,13 @@ import tempfile
 import mimetypes
 import difflib
 
-
 # external imports
 import requests
 from watchdog.events import DirDeletedEvent, FileDeletedEvent  # type: ignore
 from packaging.version import Version
 from datetime import datetime, timezone
 from dropbox.files import FileMetadata
+from dropbox.sharing import RequestedVisibility
 
 try:
     from systemd import journal  # type: ignore
@@ -1298,6 +1298,75 @@ class Maestral:
         # resume syncing
         if resume:
             self.resume_sync()
+
+    def create_shared_link(
+        self,
+        dbx_path: str,
+        visibility: str = "public",
+        password: Optional[str] = None,
+        expires: Optional[float] = None,
+    ) -> StoneType:
+        """
+        Creates a shared link for the given ``dbx_path``. Returns a dictionary with
+        information regarding the link, including the URL, access permissions, expiry
+        time, etc. The shared link will grant read / download access only.
+
+        :param dbx_path: Path to item on Dropbox.
+        :param visibility: Requested visibility of the shared link. Must be "public",
+            "team_only" or "password". The actual visibility may be different, depending
+            on the team and folder settings. Inspect the "link_permissions" entry of the
+            returned dictionary.
+        :param password: An optional password required to access the link. Will be
+            ignored if the visibility is not "password".
+        :param expires: An optional expiry time for the link as POSIX timestamp.
+        :returns: Shared link information as dict. See
+            :class:`dropbox.sharing.SharedLinkMetadata` for keys and values.
+        :raises DropboxAuthError: in case of an invalid access token.
+        :raises DropboxServerError: for internal Dropbox errors.
+        :raises ConnectionError: if the connection to Dropbox fails.
+        """
+
+        self._check_linked()
+
+        link_info = self.client.create_shared_link(
+            dbx_path=dbx_path,
+            visibility=RequestedVisibility(visibility),
+            password=password,
+            expires=datetime.utcfromtimestamp(expires) if expires else None,
+        )
+
+        return dropbox_stone_to_dict(link_info)
+
+    def revoke_shared_link(self, url: str) -> None:
+        """
+        Revokes the given shared link. Note that any other links to the same file or
+        folder will remain valid.
+
+        :param url: URL of shared link to revoke.
+        :raises DropboxAuthError: in case of an invalid access token.
+        :raises DropboxServerError: for internal Dropbox errors.
+        :raises ConnectionError: if the connection to Dropbox fails.
+        """
+
+        self._check_linked()
+        self.client.revoke_shared_link(url)
+
+    def list_shared_links(self, dbx_path: str) -> List[StoneType]:
+        """
+        Returns a list of all shared links for the given Dropbox path.
+
+        :param dbx_path: Path to item on Dropbox.
+        :returns: List of shared link information as dictionaries. See
+            :class:`dropbox.sharing.SharedLinkMetadata` for keys and values.
+        :raises DropboxAuthError: in case of an invalid access token.
+        :raises DropboxServerError: for internal Dropbox errors.
+        :raises ConnectionError: if the connection to Dropbox fails.
+        """
+
+        self._check_linked()
+        res = self.client.list_shared_links(dbx_path)
+
+        return [dropbox_stone_to_dict(link) for link in res.links]
 
     # ==== utility methods for front ends ==============================================
 

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -101,6 +101,12 @@ def m():
     except NotFoundError:
         pass
 
+    # remove all shared links
+    res = m.client.list_shared_links()
+
+    for link in res.links:
+        m.revoke_shared_link(link.url)
+
     # remove creds from system keyring
     m.client.auth.delete_creds()
 


### PR DESCRIPTION
This PR introduces support to create and manage shared links.

1. Adds methods to the client API: `create_shared_link`, `revoke_shared_link` and `list_shared_links`.
2. Adds methods to the public API: `create_shared_link`, `revoke_shared_link` and `list_shared_links`.
3. Add CLI command group `sharelink` with the following commands:
    * `sharelink create DROPBOX_PATH --password='secret' --expires='2022-12-18 20:50'`: Creates a new shared link, optionally with password and expiry time. The last two options are not supported on basic accounts.
    * `sharelink revoke URL`: Revokes the given link.
    * `sharelink list [DROPBOX_PATH]`: List all shared links for a path or the entire Dropbox.

Closes #213.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
