### PR TITLE
Only trigger periodic indexing if we have AC power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,24 @@
 
 #### Changed:
 
-* Avoiding scanning of objects matching an  `.mignore` pattern (file watches will still
-  be added however). This results in performance improvements during startup and resume.
-  A resulting behavioral change is that **maestral will remove files matching an ignore
-  pattern from Dropbox**. After this change it will be immaterial if an `.mignore`
-  pattern is added before or after having matching files  in Dropbox.
-* If Maestral is quit or interrupted during indexing, for instance due to connection
-  problems, it will later resume from the same position instead of restarting from the
-  beginning.
-* Indexing will no longer skip excluded folders. This is necessary for the above change.
-* Moved linking and unlinking to a new command group `maestral auth` with subcommands
-  `link`, `unlink` and `status`.
-* Renamed command `file-status` to `filestatus`.  
-* Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
+* Changes to indexing:
+  * Avoiding scanning of objects matching an  `.mignore` pattern (file watches will
+    still be added however). This results in performance improvements during startup and
+    resume. A resulting behavioral change is that **maestral will remove files matching
+    an ignore pattern from Dropbox**. After this change it will be immaterial if an
+    `.mignore` pattern is added before or after having matching files  in Dropbox.
+  * If Maestral is quit or interrupted during indexing, for instance due to connection
+    problems, it will later resume from the same position instead of restarting from the
+    beginning.
+  * Indexing will no longer skip excluded folders. This is necessary for the above
+    change.
+  * Defer periodic reindexing, typically carried out weekly, if we the device is not
+    connected to an AC power supply.
+* Changes to CLI:
+  * Moved linking and unlinking to a new command group `maestral auth` with subcommands
+    `link`, `unlink` and `status`.
+  * Renamed command `file-status` to `filestatus`.
+  * Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
 
 #### Fixed:
 
@@ -47,15 +52,16 @@
 * Removed automatic error reporting via bugsnag. Please file issues directly on GitHub
   instead. This allows following up on errors and investigating their cause while
   removing third party access to potentially private information.
-* Removed the `maestral restart` command. Use `stop` and `start` instead.
-* Removed the `maestral account-info` command. Use `maestral auth status` instead.
+* Removed from CLI:
+  * The `maestral restart` command. Use `stop` and `start` instead.
+  * The `maestral account-info` command. Use `maestral auth status` instead.
 * Removed main API `Maestral.resume_sync` and `Maestral.pause_sync`. Use
   `Maestral.start_sync` and `Maestral.stop_sync` instead.
 
 #### Dependencies:
 
 * Bumped survey to version >=3.2.2,<4.0.
-* Bumped keyring to version >=22.  
+* Bumped keyring to version >=22.
 * Removed bugsnag dependency.
 
 ## v1.3.1
@@ -85,7 +91,7 @@ series of bug fixes for GUI and daemon.
 #### Changed:
 
 * Significant improvements to the command line interface:
-    * Overhauled all CLI dialogs with nicer formatting and more interactive prompts 
+    * Overhauled all CLI dialogs with nicer formatting and more interactive prompts
       using the `survey` package.
     * Improved output of many CLI commands, including `ls`, `activity`, and `restore`.
     * Increased speed of many CLI commands by importing only necessary modules.
@@ -115,10 +121,10 @@ series of bug fixes for GUI and daemon.
 * Fixes possible loss of data when excluding an item from syncing while it is
   downloaded. This is no longer possible and will raise a `BusyError` instead.
 * Fixes an issue where `maestral ls` would fail when run with the `-l, --long` flag.
-* Fixes an occasional `IndexError` during a download sync when trying to query past 
+* Fixes an occasional `IndexError` during a download sync when trying to query past
   versions of a deleted item.
 * Fixes an issue which could cause a segfault of the selective sync dialog on macOS.
-* Fixes an issue where the selective sync dialog on Linux would not load the contents of 
+* Fixes an issue where the selective sync dialog on Linux would not load the contents of
   more than 10 folders.
 * Fixes a regression with the autostart functionality of the Linux GUI. Autostart
   entries created with v1.2.2 will need be reset by toggling the checkbox "start on

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -70,6 +70,7 @@ from .utils.serializer import (
     ErrorType,
 )
 from .utils.appdirs import get_log_path, get_cache_path, get_data_path
+from .utils.integration import get_ac_state, ACState
 from .constants import IDLE, FileStatus, GITHUB_RELEASES_API
 
 
@@ -1571,10 +1572,13 @@ class Maestral:
 
             if self.monitor.running.is_set():
                 elapsed = time.time() - self.sync.last_reindex
+                ac_state = get_ac_state()
+
                 reindexing_due = elapsed > self.monitor.reindex_interval
                 is_idle = self.monitor.idle_time > 20 * 60
+                has_ac_power = ac_state in (ACState.Connected, ACState.Undetermined)
 
-                if reindexing_due and is_idle:
+                if reindexing_due and is_idle and has_ac_power:
                     self.monitor.rebuild_index()
 
             await sleep_rand(60 * 5)

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1535,11 +1535,13 @@ class Maestral:
     # ==== period async jobs ===========================================================
 
     def _schedule_task(self, coro: Awaitable) -> None:
+        """Schedules a task in our asyncio loop."""
 
         task = self._loop.create_task(coro)
         self._tasks.add(task)
 
     async def _periodic_refresh_info(self) -> None:
+        """Periodically refresh the account information from Dropbox servers."""
 
         await asyncio.sleep(60 * 5)
 
@@ -1555,6 +1557,7 @@ class Maestral:
             await sleep_rand(60 * 45)
 
     async def _period_update_check(self) -> None:
+        """Periodically check for software updates."""
 
         await asyncio.sleep(60 * 3)
 
@@ -1567,6 +1570,10 @@ class Maestral:
             await sleep_rand(60 * 60)
 
     async def _period_reindexing(self) -> None:
+        """
+        Trigger periodic reindexing, determined by the 'reindex_interval' setting. Don't
+        reindex if we are running on battery power.
+        """
 
         while True:
 

--- a/src/maestral/utils/integration.py
+++ b/src/maestral/utils/integration.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+This module provides some basic platform integration. At the moment, it only provides
+code to determine if the device is connected to AC power.
+"""
+
+import os
+import platform
+import enum
+from pathlib import Path
+from typing import Union
+
+
+__all__ = ["get_ac_state", "ACState"]
+
+
+LINUX_POWER_SUPPLY_PATH = "/sys/class/power_supply"
+
+
+def multi_cat(*paths: Path) -> Union[int, bytes, None]:
+    """
+    Attempts to read the content of multiple files which may not exist. Returns the
+    content of the first file which can be read. If none of them can be read return
+    None. Returns an integer if the content is a digit.
+    """
+
+    for path in paths:
+        try:
+            ret = path.read_bytes().strip()
+        except OSError:
+            pass
+        else:
+            return int(ret) if ret.isdigit() else ret
+
+    return None
+
+
+class ACState(enum.Enum):
+    """Enumeration of AC power states"""
+
+    Connected = "Connected"
+    Disconnected = "Disconnected"
+    Undetermined = "Undetermined"
+
+
+def get_ac_state() -> ACState:
+    """
+    Checks if the current device has AC power or is running on battery.
+
+    :returns: ``True`` if the device has AC power, ``False`` otherwise.
+    """
+
+    if platform.system() == "Darwin":
+
+        from ctypes import c_double
+        from rubicon.objc.runtime import load_library
+
+        iokit = load_library("IOKit")
+        kIOPSTimeRemainingUnlimited = -2.0
+
+        iokit.IOPSGetTimeRemainingEstimate.restype = c_double
+
+        remaining_time = iokit.IOPSGetTimeRemainingEstimate()
+
+        if remaining_time == kIOPSTimeRemainingUnlimited:
+            return ACState.Connected
+        else:
+            return ACState.Disconnected
+
+    elif platform.system() == "Linux":
+
+        # taken from https://github.com/giampaolo/psutil
+
+        supplies = list(os.scandir(LINUX_POWER_SUPPLY_PATH))
+
+        ac_paths = [
+            Path(s.path)
+            for s in supplies
+            if s.name.startswith("A") or "ac" in s.name.lower()
+        ]
+
+        bat_paths = [
+            Path(s.path)
+            for s in supplies
+            if s.name.startswith("B") or "battery" in s.name.lower()
+        ]
+
+        online = multi_cat(*iter(path / "online" for path in ac_paths))
+
+        if online is not None:
+            if online == 1:
+                return ACState.Connected
+            else:
+                return ACState.Disconnected
+
+        elif len(bat_paths) > 0:
+
+            # Get the first available battery. Usually this is "BAT0", except
+            # some rare exceptions:
+            # https://github.com/giampaolo/psutil/issues/1238
+            bat0 = sorted(bat_paths)[0]
+
+            try:
+                status = (bat0 / "status").read_text().strip().lower()
+            except OSError:
+                status = ""
+
+            if status == "discharging":
+                return ACState.Disconnected
+            elif status in ("charging", "full"):
+                return ACState.Connected
+
+    return ACState.Undetermined


### PR DESCRIPTION
This PR will prevent any periodic (typically weekly) reindexing if the device is not connected to AC power. This will prevent draining the battery due to CPU heavy hashing for file content.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
