### PR TITLE
Improve inotify error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
     `link`, `unlink` and `status`.
   * Renamed command `file-status` to `filestatus`.
   * Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
+* Improved error message when the user is running out of inotify watches: Recommend
+  default values of `max_user_watches = 524,288` and `max_user_instances = 1024` or
+  double the current values, whichever is higher. Advise to apply the changes with
+  `sysctl -p`.
 
 #### Fixed:
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -403,7 +403,8 @@ def start_maestral_daemon(
 
     :param config_name: The name of the Maestral configuration to use.
     :param log_to_stdout: If ``True``, write logs to stdout.
-    :param start_sync: If ``True``, start syncing once the daemon has started.
+    :param start_sync: If ``True``, start syncing once the daemon has started. If the
+        ``start_sync`` call fails, an error will be logged but not raised.
     :raises RuntimeError: if a daemon for the given ``config_name`` is already running.
     """
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3869,9 +3869,9 @@ class SyncMonitor:
 
                 msg = (
                     "Changes to your Dropbox folder cannot be monitored because it "
-                    "contains too many items. Please increase the inotify limit in "
-                    "your system by adding the following line to /etc/sysctl.conf and "
-                    "restart your PC: " + new_config
+                    "contains too many items. Please increase the inotify limit by "
+                    "adding the following line to /etc/sysctl.conf, then apply the "
+                    'settings with "sysctl -p":\n\n' + new_config
                 )
                 err_cls = InotifyError
 


### PR DESCRIPTION
Following the discussion in #305, this PR improves the error message when the user is running out of inotify watches or instances:

1. Recommend default values of `max_user_watches = 524288` and `max_user_instances = 1024` if the current limits are lower. Otherwise, recommend to double the current values. There is no good way to predict how many watches will be needed since we do not know what other programs are using (unless they are currently running) or might be using in the future.
2. Recommend to apply the new settings with `sysctl -p` instead of rebooting.

This error message is generated and handled by the daemon and therefore should remain as brief as possible. Handling by the GUI can be more verbose and may in the future offer to adjust inotify settings on behalf of the user.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
