### PR TITLE
One way sync and config access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,27 @@
 * Resurrected the command `maestral revs` to list previous versions of a file.
 * Added a command group `maestral sharelink` to create and manage shared links.
   Subcommands are:
+
   * `create`: Create a shared link for a file or folder, optionally with password
     protection and an expiry date on supported accounts (business and professional).
-  * `list`: List shared links, either for a specific file or folder or for all items in
-    your Dropbox.
+  * `list`: List shared links, either for a specific file or folder or for all items
+    in your Dropbox.
   * `revoke`: Revoke a shared link.
+
+* Added a command group `maestral config` to provide direct access to config values.
+  Subcommands are:
+  
+  * `get`: Gets the config value for a key.
+  * `set`: Sets the config value for a key.
+
+  Use these commands with caution: setting some config values may leave the daemon in an
+  inconsistent state (e.g., changing the location of the Dropbox folder). Always prefer
+  the equivalent command from the Settings group (e.g., `maestral move-dir`).  
+* Added the ability to turn off one sync direction, for instance to enable download 
+  syncs only. This can be useful when you want to mirror a remote folder while ignoring
+  local changes. Note that conflict resolution remain unaffected. For instance, when
+  an unsynced local change would be overwritten by a remote change, the local file will
+  be moved to a "conflicting copy" first.
 
 #### Changed:
 
@@ -33,6 +49,7 @@
     `link`, `unlink` and `status`.
   * Renamed command `file-status` to `filestatus`.
   * Added a `--yes, -Y` flag to the `unlink` to command to skip the confirmation prompt.
+  * Renamed the `configs` command to list config files to `config-files`.
 * Improved error message when the user is running out of inotify watches: Recommend
   default values of `max_user_watches = 524,288` and `max_user_instances = 1024` or
   double the current values, whichever is higher. Advise to apply the changes with

--- a/docs/background/config_files.rst
+++ b/docs/background/config_files.rst
@@ -23,14 +23,11 @@ made to one of the options through the ``maestral.config`` module.
     # The current Dropbox directory
     path = /Users/samschott/Dropbox (Maestral)
 
-    # Default directory name for the config
-    default_dir_name = Dropbox (Maestral)
-
     # List of excluded files and folders
     excluded_items = ['/test_folder', '/sub/folder']
 
     # Config file version (not the Maestral version!)
-    version = 12.0.0
+    version = 15.0.0
 
     [account]
 
@@ -57,12 +54,19 @@ made to one of the options through the ``maestral.config`` module.
     # Interval in sec to check for updates
     update_notification_interval = 604800
 
-    # Enable or disable automatic error reports
-    analytics = False
-
     [sync]
 
     # Interval in sec to perform a full reindexing
     reindex_interval = 604800
+
     # Maximum CPU usage per core
     max_cpu_percent = 20.0
+
+    # Sync history to keep in seconds
+    keep_history = 604800
+
+    # Enable upload syncing
+    upload = True
+
+    # Enable download syncing
+    download = True

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -1765,15 +1765,16 @@ def log_level(level_name: str, config_name: str) -> None:
 @main.group(
     section="Maintenance",
     help="""
-Direct access to config file.
+Direct access to config values.
 
 Warning: Changing some config values must be accompanied by maintenance tasks. For
 example, changing the config value for the Dropbox location needs to be accompanied by
-actually moving the folder. This command only changes the value in the config file.
-Changes will also require a restart of the daemon to become effective.
+actually moving the folder. This command only gets / sets the value in the config file.
+Most changes will also require a restart of the daemon to become effective.
 
-Use the commands from the Settings section instead wherever possible, they will take
-effect immediately and never leave the daemon in an inconsistent state.
+Use the commands from the Settings section instead wherever possible. They will take
+effect immediately, perform accompanying tasks for you, and never leave the daemon in an
+inconsistent state.
 
 Currently available config keys are:
 
@@ -1810,7 +1811,7 @@ def config_get(key: str, config_name: str) -> None:
     )
 
     if not section:
-        raise cli.CliException(f"'{key}' is not a valid configuration key")
+        raise cli.CliException(f"'{key}' is not a valid configuration key.")
 
     try:
         with MaestralProxy(config_name) as m:
@@ -1846,7 +1847,7 @@ def config_set(key: str, value: str, config_name: str) -> None:
     )
 
     if not section or not defaults:
-        raise cli.CliException(f"'{key}' is not a valid configuration key")
+        raise cli.CliException(f"'{key}' is not a valid configuration key.")
 
     default_value = defaults[key]
 

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -37,18 +37,18 @@ DEFAULTS_CONFIG: DefaultsType = [
     (
         "app",
         {
-            "notification_level": 15,  # desktop notification level, default to FILECHANGE
-            "log_level": 20,  # log level for journal and file, default to INFO
-            "update_notification_interval": 60 * 60 * 24 * 7,  # default to weekly
+            "notification_level": 15,  # desktop notification level, default: FILECHANGE
+            "log_level": 20,  # log level for journal and file, default: INFO
+            "update_notification_interval": 60 * 60 * 24 * 7,  # default: weekly
             "keyring": "automatic",  # keychain backend to use for credential storage
         },
     ),
     (
         "sync",
         {
-            "reindex_interval": 60 * 60 * 24 * 14,  # default to every fortnight
-            "max_cpu_percent": 20.0,  # max usage target per cpu core, default to 20%
-            "keep_history": 60 * 60 * 24 * 7,  # default one week
+            "reindex_interval": 60 * 60 * 24 * 14,  # default: every fortnight
+            "max_cpu_percent": 20.0,  # max usage target per cpu core, default: 20%
+            "keep_history": 60 * 60 * 24 * 7,  # default: one week
             "upload": True,  # if download sync is enabled
             "download": True,  # if upload sync is enabled
         },

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -40,7 +40,6 @@ DEFAULTS_CONFIG: DefaultsType = [
             "notification_level": 15,  # desktop notification level, default to FILECHANGE
             "log_level": 20,  # log level for journal and file, default to INFO
             "update_notification_interval": 60 * 60 * 24 * 7,  # default to weekly
-            "analytics": False,  # automatic errors reports with bugsnag, default to disabled
             "keyring": "automatic",  # keychain backend to use for credential storage
         },
     ),
@@ -98,7 +97,7 @@ DEFAULTS_STATE: DefaultsType = [
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = "14.0.0"
+CONF_VERSION = "15.0.0"
 
 
 # =============================================================================

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -50,6 +50,8 @@ DEFAULTS_CONFIG: DefaultsType = [
             "reindex_interval": 60 * 60 * 24 * 7,  # default to weekly
             "max_cpu_percent": 20.0,  # max usage target per cpu core, default to 20%
             "keep_history": 60 * 60 * 24 * 7,  # default one week
+            "upload": True,  # if download sync is enabled
+            "download": True,  # if upload sync is enabled
         },
     ),
 ]

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -47,7 +47,7 @@ DEFAULTS_CONFIG: DefaultsType = [
     (
         "sync",
         {
-            "reindex_interval": 60 * 60 * 24 * 7,  # default to weekly
+            "reindex_interval": 60 * 60 * 24 * 14,  # default to every fortnight
             "max_cpu_percent": 20.0,  # max usage target per cpu core, default to 20%
             "keep_history": 60 * 60 * 24 * 7,  # default one week
             "upload": True,  # if download sync is enabled

--- a/src/maestral/config/user.py
+++ b/src/maestral/config/user.py
@@ -493,15 +493,8 @@ class UserConfig(DefaultsConfig):
 
         if isinstance(default_value, str):
             value = raw_value
-        elif isinstance(default_value, bool):
-            value = ast.literal_eval(raw_value)
-        elif isinstance(default_value, float):
-            value = float(raw_value)
-        elif isinstance(default_value, int):
-            value = int(raw_value)
         else:
             try:
-                # Lists, tuples, None, ...
                 value = ast.literal_eval(raw_value)
             except (SyntaxError, ValueError):
                 value = raw_value
@@ -541,18 +534,15 @@ class UserConfig(DefaultsConfig):
             default_value = value
             self.set_default(section, option, default_value)
 
-        if isinstance(default_value, bool):
-            value = bool(value)
-        elif isinstance(default_value, float):
+        if isinstance(default_value, float) and isinstance(value, int):
             value = float(value)
-        elif isinstance(default_value, int):
-            value = int(value)
-        # elif isinstance(default_value, list):
-        #     value = list(value)
-        # elif isinstance(default_value, tuple):
-        #     value = tuple(value)
-        elif not isinstance(default_value, str):
-            value = repr(value)
+
+        if type(default_value) is not type(value):
+            raise ValueError(
+                f"Inconsistent config type for [{section}][{option}]. "
+                f"Expected {default_value.__class__.__name__} but "
+                f"got {value.__class__.__name__}."
+            )
 
         self._set(section, option, value)
         if save:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2580,7 +2580,6 @@ class SyncEngine:
 
             try:
 
-
                 idx = 0
 
                 # iterate over index and download results
@@ -2697,7 +2696,9 @@ class SyncEngine:
         for changes in changes_iter:
 
             idx += len(changes.entries)
-            logger.info(f"Indexing {idx}...")
+
+            if idx > 0:
+                logger.info(f"Indexing {idx}...")
 
             logger.debug("Listed remote changes:\n%s", entries_repr(changes.entries))
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1582,7 +1582,9 @@ class SyncEngine:
 
         changes = []
         snapshot_time = time.time()
-        snapshot = self._dir_snapshot_with_mignore(self.dropbox_path)
+        snapshot = DirectorySnapshot(
+            self.dropbox_path, listdir=self._scandir_with_mignore
+        )
         lowercase_snapshot_paths: Set[str] = set()
 
         # don't use iterator here but pre-fetch all entries
@@ -3406,7 +3408,7 @@ class SyncEngine:
 
             # add created and deleted events of children as appropriate
 
-            snapshot = self._dir_snapshot_with_mignore(local_path)
+            snapshot = DirectorySnapshot(local_path, listdir=self._scandir_with_mignore)
             lowercase_snapshot_paths = {x.lower() for x in snapshot.paths}
             local_path_lower = local_path.lower()
 
@@ -3474,12 +3476,6 @@ class SyncEngine:
             for f in os.scandir(path)
             if not self._is_mignore_path(self.to_dbx_path(f.path), f.is_dir())
         ]
-
-    def _dir_snapshot_with_mignore(self, path: str) -> DirectorySnapshot:
-        return DirectorySnapshot(
-            path,
-            listdir=self._scandir_with_mignore,
-        )
 
 
 # ======================================================================================

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1518,7 +1518,7 @@ class SyncEngine:
             else:
                 raise new_exc
 
-    def free_memory(self) -> None:
+    def _free_memory(self) -> None:
         """
         Frees memory by resetting our database session and the requests session,
         clearing out case-conversion cache and clearing all expired event ignores and.
@@ -1687,7 +1687,7 @@ class SyncEngine:
                 self.local_cursor = cursor
 
             del changes
-            self.free_memory()
+            self._free_memory()
 
     def list_local_changes(self, delay: float = 1) -> Tuple[List[SyncEvent], float]:
         """
@@ -2605,6 +2605,8 @@ class SyncEngine:
                 e = self._create_local_entry(event)
                 success = e.status in (SyncStatus.Done, SyncStatus.Skipped)
 
+            self._free_memory()
+
             return success
 
     def wait_for_remote_changes(self, last_cursor: str, timeout: int = 40) -> bool:
@@ -2660,7 +2662,7 @@ class SyncEngine:
                 del changes
                 del downloaded
 
-            self.free_memory()
+            self._free_memory()
 
     def list_remote_changes_iterator(
         self, last_cursor: str
@@ -3587,9 +3589,6 @@ def download_worker_added_item(
                     sync.pending_downloads.discard(dbx_path)
 
                     logger.info(IDLE)
-
-                    # free some memory
-                    sync.free_memory()
 
 
 def upload_worker(

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -852,11 +852,11 @@ class SyncEngine:
         with convert_api_errors(local_path=local_path):
             hash_str, mtime = content_hash(local_path)
 
-        self.save_local_hash(local_path, hash_str, mtime)
+        self._save_local_hash(local_path, hash_str, mtime)
 
         return hash_str
 
-    def save_local_hash(
+    def _save_local_hash(
         self, local_path: str, hash_str: Optional[str], mtime: Optional[float]
     ) -> None:
         """
@@ -3249,7 +3249,7 @@ class SyncEngine:
                 )
 
         self.update_index_from_sync_event(event)
-        self.save_local_hash(event.local_path, event.content_hash, mtime)
+        self._save_local_hash(event.local_path, event.content_hash, mtime)
 
         logger.debug('Created local file "%s"', event.dbx_path)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -308,6 +308,8 @@ class FSEventHandler(FileSystemEventHandler):
             for ignore in new_ignores:
                 ignore.ttl = time.time() + self.ignore_timeout
 
+            self.expire_ignored_events()
+
     def expire_ignored_events(self) -> None:
         """Removes all expired ignore entries."""
 
@@ -329,8 +331,6 @@ class FSEventHandler(FileSystemEventHandler):
         :param event: Local file system event.
         :returns: Whether the event should be ignored.
         """
-
-        self.expire_ignored_events()
 
         for ignore in self._ignored_events.copy():
             ignore_event = ignore.event

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1252,7 +1252,10 @@ class SyncEngine:
     def to_local_path(self, dbx_path: str) -> str:
         """
         Converts a Dropbox path to the corresponding local path. Only the basename must
-        be correctly cased. This is slower than :meth:`to_local_path_from_cased`.
+        be correctly cased, as guaranteed by the Dropbox API for the ``display_path``
+        attribute of file or folder metadata.
+
+        This method slower than :meth:`to_local_path_from_cased`.
 
         :param dbx_path: Path relative to Dropbox folder, must be correctly cased in its
             basename.
@@ -1394,9 +1397,9 @@ class SyncEngine:
             while cpu_usage > self._max_cpu_percent:
                 cpu_usage = cpu_usage_percent(0.5 + 2 * random.random())
 
-    def cancel_sync(self):
+    def cancel_sync(self) -> None:
         """
-        Cancels all pending sync jobs and returns when idle.
+        Cancels all pending sync jobs and blocks until the sync cycle is complete.
         """
 
         self._cancel_requested.set()


### PR DESCRIPTION
This PR introduces the ability to have one-way syncing only, for instance only download syncs. This can be useful if the user just wants to mirror a remote Dropbox or has a local file system which does generate events for file changes (for instance some distributed file systems which have inotify disabled for good reasons).

Note that conflict resolution remain unaffected. For instance, when an unsynced local change would be overwritten by a remote change, the local file will be still moved to a "conflicting copy". However, the conflicting copy will not be uploaded.

Together with the above change, a new CLI command group `maestral config` has been introduced with subcommands `get` and `set`. It provides direct access to config values. For example:

```
maestral config set max_cpu_percent 50
maestral config set download False
maestral config set upload False
```

This enables command line access to config values such as `reindex_interval`, `max_cpu_percent`, etc, which are not exposed otherwise. Note that this interface can be dangerous to use: changing config values may require carrying out accompanying maintenance tasks. For example, changing the config value for the local directory requires actually moving the Dropbox folder to the new location, adding a folder to the excluded list also requires manually deleting the local folder. Therefore, the direct commands exposed by the Settings CLI should be used instead, they will perform those tasks for you.

To prevent confusion, the existing command `maestral configs` to list available config files / Dropbox accounts, has been renamed to `maestral config-files`.

Finally, because we are now exposing config values to the end user, type checking for config values has become stricter. A `ValueError` will be raised when trying to set a config value to a type which is different from the default.

Closes #95.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
