### PR TITLE
Fix download interrupted by connection problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * Added a command group `maestral config` to provide direct access to config values.
   Subcommands are:
-  
+
   * `get`: Gets the config value for a key.
   * `set`: Sets the config value for a key.
 
@@ -33,6 +33,7 @@
 #### Changed:
 
 * Changes to indexing:
+
   * Avoiding scanning of objects matching an  `.mignore` pattern (file watches will
     still be added however). This results in performance improvements during startup and
     resume. A resulting behavioral change is that **maestral will remove files matching
@@ -45,7 +46,9 @@
     change.
   * Defer periodic reindexing, typically carried out weekly, if we the device is not
     connected to an AC power supply.
+  
 * Changes to CLI:
+
   * Moved linking and unlinking to a new command group `maestral auth` with subcommands
     `link`, `unlink` and `status`.
   * Renamed command `file-status` to `filestatus`.
@@ -53,6 +56,7 @@
   * Renamed the `configs` command to list config files to `config-files`.
   * Added an option `--clean` to `config-files` to remove all stale config files without
     a linked Dropbox account.
+
 * Improved error message when the user is running out of inotify watches: Recommend
   default values of `max_user_watches = 524,288` and `max_user_instances = 1024` or
   double the current values, whichever is higher. Advise to apply the changes with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
   button could be incorrectly enabled or disabled.
 * Fixes an issue where a lost internet connection while starting the sync could lead to
   a stuck sync thread or an endless sync cycle.
+* Fixes an issue where a lost internet connection during the download of a folder newly
+  included in selective sync could result in the download never being completed.
+* Fixes an issue where pausing the sync during the download of a folder newly included
+  in selective sync could result in the download never being completed.
 
 #### Removed:
 

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -35,7 +35,7 @@ class MaestralApiError(Exception):
     def __init__(
         self,
         title: str,
-        message: str,
+        message: str = "",
         dbx_path: Optional[str] = None,
         dbx_path_dst: Optional[str] = None,
         local_path: Optional[str] = None,
@@ -58,83 +58,57 @@ class MaestralApiError(Exception):
 class SyncError(MaestralApiError):
     """Base class for recoverable sync issues."""
 
-    pass
-
 
 class InsufficientPermissionsError(SyncError):
     """Raised when accessing a file or folder fails due to insufficient permissions,
     both locally and on Dropbox servers."""
 
-    pass
-
 
 class InsufficientSpaceError(SyncError):
     """Raised when the Dropbox account or local drive has insufficient storage space."""
-
-    pass
 
 
 class PathError(SyncError):
     """Raised when there is an issue with the provided file or folder path such as
     invalid characters, a too long file name, etc."""
 
-    pass
-
 
 class NotFoundError(SyncError):
     """Raised when a file or folder is requested but does not exist."""
-
-    pass
 
 
 class ConflictError(SyncError):
     """Raised when trying to create a file or folder which already exists."""
 
-    pass
-
 
 class FileConflictError(ConflictError):
     """Raised when trying to create a file which already exists."""
-
-    pass
 
 
 class FolderConflictError(SyncError):
     """Raised when trying to create or folder which already exists."""
 
-    pass
-
 
 class IsAFolderError(SyncError):
     """Raised when a file is required but a folder is provided."""
-
-    pass
 
 
 class NotAFolderError(SyncError):
     """Raised when a folder is required but a file is provided."""
 
-    pass
-
 
 class DropboxServerError(SyncError):
     """Raised in case of internal Dropbox errors."""
-
-    pass
 
 
 class RestrictedContentError(SyncError):
     """Raised when trying to sync restricted content, for instance when adding a file
     with a DMCA takedown notice to a public folder."""
 
-    pass
-
 
 class UnsupportedFileError(SyncError):
     """Raised when this file type cannot be downloaded but only exported. This is the
     case for G-suite files."""
-
-    pass
 
 
 class FileSizeError(SyncError):
@@ -142,82 +116,60 @@ class FileSizeError(SyncError):
     or larger than 150 MB in a single upload. Also raised when attempting to download a
     file with a size that exceeds file system's limit."""
 
-    pass
-
 
 class FileReadError(SyncError):
     """Raised when reading a local file failed."""
-
-    pass
 
 
 # ==== errors which are not related to a specific sync event ===========================
 
 
+class CancelledError(MaestralApiError):
+    """Raised when syncing is cancelled by the user."""
+
+
 class NotLinkedError(MaestralApiError):
     """Raised when no Dropbox account is linked."""
-
-    pass
 
 
 class InvalidDbidError(MaestralApiError):
     """Raised when the given Dropbox ID does not correspond to an existing account."""
 
-    pass
-
 
 class KeyringAccessError(MaestralApiError):
     """Raised when retrieving a saved auth token from the user keyring fails."""
-
-    pass
 
 
 class NoDropboxDirError(MaestralApiError):
     """Raised when the local Dropbox folder cannot be found."""
 
-    pass
-
 
 class CacheDirError(MaestralApiError):
     """Raised when creating the cache directory fails."""
-
-    pass
 
 
 class InotifyError(MaestralApiError):
     """Raised when the local Dropbox folder is too large to monitor with inotify."""
 
-    pass
-
 
 class OutOfMemoryError(MaestralApiError):
     """Raised when there is insufficient memory to complete an operation."""
-
-    pass
 
 
 class DatabaseError(MaestralApiError):
     """Raised when reading or writing to the database fails."""
 
-    pass
-
 
 class DropboxAuthError(MaestralApiError):
     """Raised when authentication fails."""
-
-    pass
 
 
 class TokenExpiredError(DropboxAuthError):
     """Raised when authentication fails because the user's token has expired."""
 
-    pass
-
 
 class TokenRevokedError(DropboxAuthError):
     """Raised when authentication fails because the user's token has been revoked."""
-
-    pass
 
 
 class CursorResetError(MaestralApiError):
@@ -226,33 +178,23 @@ class CursorResetError(MaestralApiError):
     cursor for the respective folder has to be obtained through files_list_folder. This
     may require re-syncing the entire Dropbox."""
 
-    pass
-
 
 class BadInputError(MaestralApiError):
     """Raised when an API request is made with bad input. This should not happen
     during syncing but only in case of manual API calls."""
-
-    pass
 
 
 class BusyError(MaestralApiError):
     """Raised when trying to perform an action which is only possible in the idle
     state and we cannot block or queue the job."""
 
-    pass
-
 
 class UnsupportedFileTypeForDiff(MaestralApiError):
     """Raised when a diff for an unsupported file type was issued."""
 
-    pass
-
 
 class SharedLinkError(MaestralApiError):
     """Raised when creating a shared link fails."""
-
-    pass
 
 
 # connection errors are handled as warnings
@@ -281,6 +223,7 @@ GENERAL_ERRORS = (
 
 SYNC_ERRORS = (
     SyncError,
+    CancelledError,
     InsufficientPermissionsError,
     InsufficientSpaceError,
     PathError,

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3927,10 +3927,13 @@ class SyncMonitor:
             if self.connected and not self.running.is_set() and self.autostart.is_set():
                 logger.info(CONNECTED)
                 self.start()
+
             elif not self.connected and self.running.is_set():
-                logger.info(DISCONNECTED)
-                self.stop()
-                self.autostart.set()
+
+                # Don't stop sync threads, let them deal with the connection issues with
+                # their own timeout. This prevents us from aborting any uploads or
+                # downloads which could still be saved on reconnection.
+
                 logger.info(CONNECTING)
 
             time.sleep(self.connection_check_interval)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1411,6 +1411,8 @@ class SyncEngine:
 
         self._cancel_requested.clear()
 
+        logger.info("Sync aborted")
+
     def busy(self) -> bool:
         """
         Checks if we are currently syncing.
@@ -2535,6 +2537,8 @@ class SyncEngine:
         :returns: Whether download was successful.
         """
 
+        logger.info(f"Syncing ↓ {dbx_path}")
+
         with self.sync_lock:
 
             md = self.client.get_metadata(dbx_path, include_deleted=True)
@@ -2573,8 +2577,6 @@ class SyncEngine:
         """
 
         with self.sync_lock:
-
-            logger.info(f"Syncing ↓ {dbx_path}")
 
             try:
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -86,6 +86,7 @@ from .constants import (
 from .errors import (
     MaestralApiError,
     SyncError,
+    CancelledError,
     NoDropboxDirError,
     CacheDirError,
     PathError,
@@ -1399,7 +1400,7 @@ class SyncEngine:
 
     def cancel_sync(self) -> None:
         """
-        Cancels all pending sync jobs and blocks until the sync cycle is complete.
+        Raises a CancelledError in all sync threads and waits for them to shut down.
         """
 
         self._cancel_requested.set()
@@ -1563,8 +1564,7 @@ class SyncEngine:
             else:
                 logger.debug("No local changes while inactive")
 
-            if not self._cancel_requested.is_set():
-                self.local_cursor = local_cursor
+            self.local_cursor = local_cursor
 
     def _get_local_changes_while_inactive(self) -> Tuple[List[FileSystemEvent], float]:
         """
@@ -1683,13 +1683,13 @@ class SyncEngine:
             changes, cursor = self.list_local_changes()
             self.apply_local_changes(changes)
 
-            if not self._cancel_requested.is_set():
-                # Save local cursor if not sync was not aborted by user.
-                # Failed uploads will be tracked and retried individually.
-                self.local_cursor = cursor
+            self.local_cursor = cursor
 
             del changes
             self._free_memory()
+
+            if self._cancel_requested.is_set():
+                raise CancelledError("Sync cancelled")
 
     def list_local_changes(self, delay: float = 1) -> Tuple[List[SyncEvent], float]:
         """
@@ -2120,9 +2120,7 @@ class SyncEngine:
         """
 
         if self._cancel_requested.is_set():
-            event.status = SyncStatus.Aborted
-            self.syncing.remove(event)
-            return event
+            raise CancelledError("Sync cancelled")
 
         self._slow_down()
 
@@ -2605,6 +2603,9 @@ class SyncEngine:
                         for e in download_res
                     )
 
+                    if self._cancel_requested.is_set():
+                        raise CancelledError("Sync cancelled")
+
             except SyncError as e:
                 self._handle_sync_error(e, direction=SyncDirection.Down)
                 return False
@@ -2655,11 +2656,11 @@ class SyncEngine:
                     # Don't send desktop notifications during indexing.
                     self.notify_user(downloaded)
 
+                # Save (incremental) remote cursor.
+                self.remote_cursor = cursor
+
                 if self._cancel_requested.is_set():
-                    break
-                else:
-                    # Save (incremental) remote cursor.
-                    self.remote_cursor = cursor
+                    raise CancelledError("Sync cancelled")
 
                 del changes
                 del downloaded
@@ -3133,9 +3134,7 @@ class SyncEngine:
         """
 
         if self._cancel_requested.is_set():
-            event.status = SyncStatus.Aborted
-            self.syncing.remove(event)
-            return event
+            raise CancelledError("Sync cancelled")
 
         self._slow_down()
 
@@ -3495,6 +3494,8 @@ def handle_sync_thread_errors(
         yield
     except DropboxServerError:
         logger.info("Dropbox server error", exc_info=True)
+    except CancelledError:
+        running.clear()
     except ConnectionError:
         logger.info(DISCONNECTED)
         logger.debug("Connection error", exc_info=True)
@@ -3647,7 +3648,6 @@ def startup_worker(
             logger.info("Retrying failed syncs...")
 
         for dbx_path in list(sync.download_errors):
-            logger.info(f"Syncing ↓ {dbx_path}")
             sync.get_remote_item(dbx_path)
 
         # Resume interrupted downloads.
@@ -3655,7 +3655,6 @@ def startup_worker(
             logger.info("Resuming interrupted syncs...")
 
         for dbx_path in list(sync.pending_downloads):
-            logger.info(f"Syncing ↓ {dbx_path}")
             sync.get_remote_item(dbx_path)
             sync.pending_downloads.discard(dbx_path)
 
@@ -3898,10 +3897,8 @@ class SyncMonitor:
     def stop(self) -> None:
         """Stops syncing and destroys worker threads."""
 
-        if not self.running.is_set():
-            return
-
-        logger.info("Shutting down threads...")
+        if self.running.is_set():
+            logger.info("Shutting down threads...")
 
         self.sync.fs_events.disable()
         self.running.clear()


### PR DESCRIPTION
This PR fixes a problem where the download of a folder newly included by selective sync would never complete under two circumstances:

1. If syncing is manually paused by the user during the download.
2. If the connection to Dropbox is lost and the download thread is externally stopped as a result.

In both circumstances, there was no error raised in the download thread itself and the `pending_download` entry was cleared when `get_remote_item` returned without an error. The fix now ensures that the download thread is always aborted when externally stopped.

In addition, this PR changes the way we handle connection issues. If the low-latency check shows connection issues, we update the status reported by the public API to `connected = False` but do not force the sync threads to abort. Instead, they may abort themselves when they encounter a `ConnectionError`. Since they have a longer timeout, this will allow some syncs to continue even when faced with a flaky internet connection.

This PR fixes #309.

