### PR TITLE
Fix resuming sync after paused while disconnected

### DIFF
--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -890,10 +890,8 @@ def status(config_name: str) -> None:
 
             email = m.get_state("account", "email")
             account_type = m.get_state("account", "type").capitalize()
-
-            status_info = m.status if m.running else "Paused"
             usage = m.get_state("account", "usage")
-
+            status_info = m.status
             n_errors = len(m.sync_errors)
             color = "red" if n_errors > 0 else "green"
             n_errors_str = click.style(str(n_errors), fg=color)

--- a/src/maestral/constants.py
+++ b/src/maestral/constants.py
@@ -60,7 +60,7 @@ EXCLUDED_DIR_NAMES = frozenset([".dropbox.cache", FILE_CACHE])
 # state messages
 IDLE = "Up to date"
 SYNCING = "Syncing..."
-STOPPED = "Syncing stopped"
+PAUSED = "Paused"
 CONNECTED = "Connected"
 DISCONNECTED = "Connection lost"
 CONNECTING = "Connecting..."

--- a/tests/linked/test_cli.py
+++ b/tests/linked/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from maestral.cli import main
-from maestral.constants import IDLE, STOPPED, ERROR
+from maestral.constants import IDLE, PAUSED, ERROR
 from maestral.daemon import MaestralProxy
 
 
@@ -18,7 +18,7 @@ def wait_for_idle(m: MaestralProxy, minimum: int = 2):
 
     while True:
         current_status = m.status
-        if current_status in (IDLE, STOPPED, ERROR, ""):
+        if current_status in (IDLE, PAUSED, ERROR, ""):
             m.status_change_longpoll(timeout=minimum)
             if m.status == current_status:
                 # status did not change, we are done

--- a/tests/linked/test_cli.py
+++ b/tests/linked/test_cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import time
 
 import pytest
 from click.testing import CliRunner
@@ -18,6 +19,7 @@ def wait_for_idle(m: MaestralProxy, minimum: int = 2):
 
     while True:
         current_status = m.status
+        time.sleep(minimum)
         if current_status in (IDLE, PAUSED, ERROR, ""):
             m.status_change_longpoll(timeout=minimum)
             if m.status == current_status:
@@ -55,10 +57,16 @@ def test_status(proxy):
 
 def test_filestatus(proxy):
     runner = CliRunner()
-    proxy.start_sync()
-    wait_for_idle(proxy)
 
     local_path = proxy.to_local_path("/sync_tests")
+
+    result = runner.invoke(main, ["filestatus", local_path, "-c", proxy.config_name])
+
+    assert result.exit_code == 0
+    assert result.output == "unwatched\n"
+
+    proxy.start_sync()
+    wait_for_idle(proxy)
 
     result = runner.invoke(main, ["filestatus", local_path, "-c", proxy.config_name])
 


### PR DESCRIPTION
This PR fixes an issue where the daemon would restart syncing when an internet connection is established despite being paused.

This PR also cleans up some status messages left over from the old API where it was possible to either pause or stop the daemon.