### PR TITLE
Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN set -eux ; \
     musl-dev \
     python3-dev \
     libffi-dev \
-    openssl-dev ; \
+    openssl-dev \
+    cargo ; \
   pip install -U pip; \
   pip install maestral==${VERSION} ; \
   pip cache purge ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux ; \
     python3-dev \
     libffi-dev \
     openssl-dev ; \
+  pip install -U pip; \
   pip install maestral==${VERSION} ; \
   pip cache purge ; \
   apk del --no-network .build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-alpine3.12
+FROM python:3.9.1-alpine3.13
 
 ARG UID=1000
 ARG VERSION


### PR DESCRIPTION
This PR updates the docker image to be based on alpine 3.13 with Python 3.9. It also updated the build dependencies to include cargo, which is required to build `cryptography` (in turn a dependency of `SecretService` and therefore `keyring`),