### PR TITLE
Fix upload sync of modified MS Office files on macOS

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1924,8 +1924,10 @@ class SyncEngine:
                             unique_events.append(FileDeletedEvent(path))
                             unique_events.append(DirCreatedEvent(path))
                     else:
-                        # item was only temporary
-                        pass
+                        # Item was likely only temporary. We still trigger a rescan of
+                        # the path because some atomic modifications may be reported as
+                        # out-of-order created and deleted events on macOS.
+                        self.rescan(path)
 
         # event order does not matter anymore from this point because we have already
         # consolidated events for every path

--- a/tests/offline/test_cleaning_events.py
+++ b/tests/offline/test_cleaning_events.py
@@ -119,10 +119,10 @@ def test_move_events(sync):
 def test_gedit_save(sync):
 
     file_events = [
-        FileCreatedEvent(".gedit-save-UR4EC0"),  # save new version to tmp file
-        FileModifiedEvent(".gedit-save-UR4EC0"),  # modify tmp file
+        FileCreatedEvent("/.gedit-save-UR4EC0"),  # save new version to tmp file
+        FileModifiedEvent("/.gedit-save-UR4EC0"),  # modify tmp file
         FileMovedEvent(ipath(1), ipath(1) + "~"),  # move old version to backup
-        FileMovedEvent(".gedit-save-UR4EC0", ipath(1)),  # replace old version with tmp
+        FileMovedEvent("/.gedit-save-UR4EC0", ipath(1)),  # replace old version with tmp
     ]
 
     res = [
@@ -156,12 +156,12 @@ def test_msoffice_created(sync):
         FileCreatedEvent(ipath(1)),
         FileDeletedEvent(ipath(1)),
         FileCreatedEvent(ipath(1)),
-        FileCreatedEvent("~$" + ipath(1)),
+        FileCreatedEvent("/~$" + ipath(1)),
     ]
 
     res = [
         FileCreatedEvent(ipath(1)),  # created file
-        FileCreatedEvent("~$" + ipath(1)),  # backup
+        FileCreatedEvent("/~$" + ipath(1)),  # backup
     ]
 
     cleaned_events = sync._clean_local_events(file_events)


### PR DESCRIPTION
Fixes #337 by rescanning a local path if the reported file system events are ambiguous.