### PR TITLE
Switch from sqlalchemy to our own ORM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup, find_packages  # type: ignore
 
 # proceed with actual install
 install_requires = [
-    "alembic>=1.3",
     "click>=7.1.1",
     "desktop-notifier>=3.2.2",
     "dropbox>=10.9.0,<12.0",
@@ -22,7 +21,6 @@ install_requires = [
     "rubicon-objc>=0.4.0;sys_platform=='darwin'",
     "sdnotify>=0.3.2",
     "setuptools",
-    "sqlalchemy>=1.3",
     "survey>=3.2.2,<4.0",
     "watchdog>=2.0.1",
 ]

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -88,6 +88,26 @@ class SyncEvent(Model):
     :class:`watchdog.events.FileSystemEvent` instance, respectively.
     """
 
+    __slots__ = [
+        "_id",
+        "_direction",
+        "_item_type",
+        "_sync_time",
+        "_dbx_id",
+        "_dbx_path",
+        "_local_path",
+        "_dbx_path_from",
+        "_local_path_from",
+        "_rev",
+        "_content_hash",
+        "_change_type",
+        "_change_dbid",
+        "_change_user_name",
+        "_status",
+        "_size",
+        "_completed",
+    ]
+
     __tablename__ = "history"
 
     id = Column(SqlInt(), primary_key=True)
@@ -392,6 +412,16 @@ class SyncEvent(Model):
 class IndexEntry(Model):
     """Represents an entry in our local sync index"""
 
+    __slots__ = [
+        "_dbx_path_lower",
+        "_dbx_path_cased",
+        "_dbx_id",
+        "_item_type",
+        "_last_sync",
+        "_rev",
+        "_content_hash",
+    ]
+
     __tablename__ = "'index'"
 
     dbx_path_lower = Column(SqlPath(), nullable=False, primary_key=True)
@@ -442,6 +472,8 @@ class IndexEntry(Model):
 
 class HashCacheEntry(Model):
     """Represents an entry in our cache of content hashes"""
+
+    __slots__ = ["_local_path", "_hash_str", "_mtime"]
 
     __tablename__ = "hash_cache"
 

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -12,13 +12,6 @@ from datetime import timezone
 from typing import Optional, TYPE_CHECKING
 
 # external imports
-import sqlalchemy.types as sqltypes  # type: ignore
-from sqlalchemy.ext.declarative import declarative_base  # type: ignore
-from sqlalchemy.orm import sessionmaker  # type: ignore
-from sqlalchemy.sql import case  # type: ignore
-from sqlalchemy.sql.elements import Case  # type: ignore
-from sqlalchemy.ext.hybrid import hybrid_property  # type: ignore
-from sqlalchemy import Column, MetaData  # type: ignore
 from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata  # type: ignore
 from watchdog.events import (
     FileSystemEvent,
@@ -27,6 +20,9 @@ from watchdog.events import (
     EVENT_TYPE_MOVED,
     EVENT_TYPE_MODIFIED,
 )
+
+# local imports
+from .utils.orm import Model, Column, SqlEnum, SqlInt, SqlString, SqlFloat, SqlPath
 
 if TYPE_CHECKING:
     from .sync import SyncEngine
@@ -40,21 +36,7 @@ __all__ = [
     "SyncEvent",
     "IndexEntry",
     "HashCacheEntry",
-    "Session",
-    "Base",
-    "db_naming_convention",
 ]
-
-
-db_naming_convention = {
-    "ix": "ix_%(column_0_label)s",
-    "uq": "uq_%(table_name)s_%(column_0_name)s",
-    "ck": "ck_%(table_name)s_%(column_0_name)s",
-    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-    "pk": "pk_%(table_name)s",
-}
-Base = declarative_base(metadata=MetaData(naming_convention=db_naming_convention))
-Session = sessionmaker(expire_on_commit=False)
 
 
 class SyncDirection(enum.Enum):
@@ -92,28 +74,7 @@ class ChangeType(enum.Enum):
     Modified = "modified"
 
 
-class StringPath(sqltypes.TypeDecorator):
-    """
-    Database column type which accepts strings the Python surrogate escapes as input.
-    Those may be passed when the local path contains bytes outside of the reported file
-    system encoding.
-    """
-
-    # TODO: bijective conversion of surrogate escapes in our database
-
-    impl = sqltypes.String
-
-    def process_bind_param(self, value: Optional[str], dialect) -> Optional[str]:
-        if value is None:
-            return value
-        else:
-            return os.fsencode(value).decode(errors="replace")
-
-    def process_result_value(self, value: Optional[str], dialect) -> Optional[str]:
-        return value
-
-
-class SyncEvent(Base):  # type: ignore
+class SyncEvent(Model):
     """Represents a file or folder change in the sync queue
 
     This class is used to represent both local and remote file system changes and track
@@ -129,113 +90,106 @@ class SyncEvent(Base):  # type: ignore
 
     __tablename__ = "history"
 
-    id = Column(sqltypes.Integer, primary_key=True)
+    id = Column(SqlInt(), primary_key=True)
     """A unique identifier of the SyncEvent."""
 
-    direction = Column(sqltypes.Enum(SyncDirection), nullable=False)
+    direction = Column(SqlEnum(SyncDirection), nullable=False)
     """The :class:`SyncDirection`."""
 
-    item_type = Column(sqltypes.Enum(ItemType), nullable=False)
+    item_type = Column(SqlEnum(ItemType), nullable=False)
     """
     The :class:`ItemType`. May be undetermined for remote deletions.
     """
 
-    sync_time = Column(sqltypes.Float, nullable=False)
+    sync_time = Column(SqlFloat(), nullable=False)
     """The time the SyncEvent was registered."""
 
-    dbx_id = Column(sqltypes.String)
+    dbx_id = Column(SqlString())
     """
     A unique dropbox ID for the file or folder. Will only be set for download events
     which are not deletions.
     """
 
-    dbx_path = Column(StringPath, nullable=False)
+    dbx_path = Column(SqlPath(), nullable=False)
     """
     Dropbox path of the item to sync. If the sync represents a move operation, this will
     be the destination path. Follows the casing from server.
     """
 
-    local_path = Column(StringPath, nullable=False)
+    local_path = Column(SqlPath(), nullable=False)
     """
     Local path of the item to sync. If the sync represents a move operation, this will
     be the destination path. This will be correctly cased.
     """
 
-    dbx_path_from = Column(StringPath)
+    dbx_path_from = Column(SqlPath())
     """
     Dropbox path that this item was moved from. Will only be set if :attr:`change_type`
     is :attr:`ChangeType.Moved`. Follows the casing from server.
     """
 
-    local_path_from = Column(StringPath)
+    local_path_from = Column(SqlPath())
     """
     Local path that this item was moved from. Will only be set if :attr:`change_type`
     is :attr:`ChangeType.Moved`. This will be correctly cased.
     """
 
-    rev = Column(sqltypes.String)
+    rev = Column(SqlString())
     """
     The file revision. Will only be set for remote changes. Will be ``'folder'`` for
     folders and ``None`` for deletions.
     """
 
-    content_hash = Column(sqltypes.String)
+    content_hash = Column(SqlString())
     """
     A hash representing the file content. Will be ``'folder'`` for folders and ``None``
     for deletions. Set for both local and remote changes.
     """
 
-    change_type = Column(sqltypes.Enum(ChangeType), nullable=False)
+    change_type = Column(SqlEnum(ChangeType), nullable=False)
     """
     The :class:`ChangeType`. Remote SyncEvents currently do not generate moved events
     but are reported as deleted and added at the new location.
     """
 
-    change_time = Column(sqltypes.Float)
+    change_time = Column(SqlFloat())
     """
     Local ctime or remote ``client_modified`` time for files. ``None`` for folders or
     for remote deletions. Note that ``client_modified`` may not be reliable as it is set
     by other clients and not verified.
     """
 
-    change_dbid = Column(sqltypes.String)
+    change_dbid = Column(SqlString())
     """
     The Dropbox ID of the account which performed the changes. This may not be set for
     added folders or deletions on the server.
     """
 
-    change_user_name = Column(sqltypes.String)
+    change_user_name = Column(SqlString())
     """
     The user name corresponding to :attr:`change_dbid`, if the account still exists.
     This field may not be set for performance reasons.
     """
 
-    status = Column(sqltypes.Enum(SyncStatus), nullable=False)
+    status = Column(SqlEnum(SyncStatus), nullable=False)
     """The :class:`SyncStatus`."""
 
-    size = Column(sqltypes.Integer, nullable=False)
+    size = Column(SqlInt(), nullable=False)
     """Size of the item in bytes. Always zero for folders."""
 
-    completed = Column(sqltypes.Integer, default=0)
+    completed = Column(SqlInt(), default=0)
     """
     File size in bytes which has already been uploaded or downloaded. Always zero for
     folders.
     """
 
-    @hybrid_property
+    @property
     def change_time_or_sync_time(self) -> float:
         """
         Change time when available, otherwise sync time. This can be used for sorting or
         user information purposes.
         """
         return self.change_time or self.sync_time
-
-    @change_time_or_sync_time.expression  # type: ignore
-    def change_time_or_sync_time(cls) -> Case:
-        return case(
-            [(cls.change_time != None, cls.change_time)],  # noqa: E711
-            else_=cls.sync_time,
-        )
 
     @property
     def is_file(self) -> bool:
@@ -435,35 +389,35 @@ class SyncEvent(Base):  # type: ignore
         )
 
 
-class IndexEntry(Base):  # type: ignore
+class IndexEntry(Model):
     """Represents an entry in our local sync index"""
 
-    __tablename__ = "index"
+    __tablename__ = "'index'"
 
-    dbx_path_lower = Column(StringPath, nullable=False, primary_key=True)
+    dbx_path_lower = Column(SqlPath(), nullable=False, primary_key=True)
     """
     Dropbox path of the item in lower case. This acts as a primary key for the SQLites
     database since there can only be one entry per case-insensitive Dropbox path.
     """
 
-    dbx_path_cased = Column(StringPath, nullable=False)
+    dbx_path_cased = Column(SqlPath(), nullable=False)
     """Dropbox path of the item, correctly cased."""
 
-    dbx_id = Column(sqltypes.String, nullable=False)
+    dbx_id = Column(SqlString(), nullable=False)
     """The unique dropbox ID for the item."""
 
-    item_type = Column(sqltypes.Enum(ItemType), nullable=False)
+    item_type = Column(SqlEnum(ItemType), nullable=False)
     """The :class:`ItemType`."""
 
-    last_sync = Column(sqltypes.Float)
+    last_sync = Column(SqlFloat())
     """
     The last time a local change was uploaded. Should be the ctime of the local item.
     """
 
-    rev = Column(sqltypes.String, nullable=False)
+    rev = Column(SqlString(), nullable=False)
     """The file revision. Will be ``'folder'`` for folders."""
 
-    content_hash = Column(sqltypes.String)
+    content_hash = Column(SqlString())
     """
     A hash representing the file content. Will be ``'folder'`` for folders. May be
     ``None`` if not yet calculated.
@@ -486,18 +440,18 @@ class IndexEntry(Base):  # type: ignore
         )
 
 
-class HashCacheEntry(Base):  # type: ignore
+class HashCacheEntry(Model):
     """Represents an entry in our cache of content hashes"""
 
     __tablename__ = "hash_cache"
 
-    local_path = Column(StringPath, nullable=False, primary_key=True)
+    local_path = Column(SqlPath(), nullable=False, primary_key=True)
     """The local path of the item."""
 
-    hash_str = Column(sqltypes.String)
+    hash_str = Column(SqlString())
     """The content hash of the item."""
 
-    mtime = Column(sqltypes.Float)
+    mtime = Column(SqlFloat())
     """
     The mtime of the item just before the hash was computed. When the current ctime is
     newer, the hash will need to be recalculated.

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -15,6 +15,7 @@ import urllib.parse
 import enum
 import pprint
 import gc
+import sqlite3
 from threading import Thread, Event, Condition, RLock, current_thread
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue, Empty
@@ -41,10 +42,6 @@ from types import TracebackType
 
 # external imports
 import click
-import sqlalchemy.exc  # type: ignore
-import sqlalchemy.engine.url  # type: ignore
-from sqlalchemy.sql import func  # type: ignore
-from sqlalchemy import create_engine  # type: ignore
 import pathspec  # type: ignore
 import dropbox  # type: ignore
 from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata  # type: ignore
@@ -103,8 +100,6 @@ from .client import (
     convert_api_errors,
 )
 from .database import (
-    Base,
-    Session,
     SyncEvent,
     HashCacheEntry,
     IndexEntry,
@@ -132,6 +127,7 @@ from .utils.path import (
     is_equal_or_child,
     content_hash,
 )
+from .utils.orm import Database, Manager
 from .utils.appdirs import get_data_path, get_home_dir
 
 
@@ -554,16 +550,10 @@ class SyncEngine:
             self.remote_cursor = ""
 
         # initialize SQLite database
-        url = sqlalchemy.engine.url.URL(
-            drivername="sqlite",
-            database=f"file:{self._db_path}",
-            query={"check_same_thread": "false", "uri": "true"},
-        )
-        self._db_engine = create_engine(url)
-        with self._database_access(log_errors=True):
-            Base.metadata.create_all(self._db_engine)
-            Session.configure(bind=self._db_engine)
-        self._db_session = Session()
+        self._db = Database(self._db_path, check_same_thread=False)
+        self._db_manager_index = Manager(self._db, IndexEntry)
+        self._db_manager_history = Manager(self._db, SyncEvent)
+        self._db_manager_hash_cache = Manager(self._db, HashCacheEntry)
 
         # load cached properties
         self._is_case_sensitive = is_fs_case_sensitive(get_home_dir())
@@ -702,10 +692,10 @@ class SyncEngine:
 
         with self._database_access():
 
-            res = self._db_session.query(func.max(IndexEntry.last_sync)).first()
+            res = self._db.execute("SELECT MAX(last_sync) FROM 'index'").fetchone()
 
             if res:
-                return res[0] or 0.0
+                return res["MAX(sync_time)"] or 0.0
             else:
                 return 0.0
 
@@ -721,16 +711,18 @@ class SyncEngine:
         interval specified by the config value ``keep_history`` (defaults to two weeks)
         but at most 1,000 events will be kept."""
         with self._database_access():
-            query = self._db_session.query(SyncEvent)
-            ordered_query = query.order_by(SyncEvent.change_time_or_sync_time)
-            return ordered_query.limit(self._max_history).all()
+
+            sync_events = self._db_manager_history.query_to_objects(
+                "SELECT * FROM history ORDER BY IFNULL(change_time, sync_time)"
+            )
+            return cast(List[SyncEvent], sync_events)
 
     def clear_sync_history(self) -> None:
         """Clears the sync history."""
         with self._database_access():
-            SyncEvent.metadata.drop_all(self._db_engine)
-            Base.metadata.create_all(self._db_engine)
-            self._db_session.expunge_all()
+            self._db.execute("DROP TABLE history")
+            self._db_manager_history.create_table()
+            self._db_manager_history.clear_cache()
 
     # ==== index management ============================================================
 
@@ -741,7 +733,7 @@ class SyncEngine:
         :returns: List of index entries.
         """
         with self._database_access():
-            return self._db_session.query(IndexEntry).all()
+            return cast(List[IndexEntry], self._db_manager_index.all())
 
     def iter_index(self) -> Iterator[IndexEntry]:
         """
@@ -750,8 +742,9 @@ class SyncEngine:
         :returns: Iterator over index entries.
         """
         with self._database_access():
-            for entry in self._db_session.query(IndexEntry).yield_per(1000):
-                yield entry
+            for entries in self._db_manager_index.iter_all():
+                for entry in entries:
+                    yield cast(IndexEntry, entry)
 
     def index_count(self) -> int:
         """
@@ -761,7 +754,7 @@ class SyncEngine:
         """
 
         with self._database_access():
-            return self._db_session.query(IndexEntry).count()
+            return self._db_manager_index.count()
 
     def get_local_rev(self, dbx_path: str) -> Optional[str]:
         """
@@ -772,15 +765,10 @@ class SyncEngine:
             been saved.
         """
 
-        with self._database_access():
-            res = (
-                self._db_session.query(IndexEntry.rev)
-                .filter(IndexEntry.dbx_path_lower == dbx_path.lower())
-                .first()
-            )
+        entry = self.get_index_entry(dbx_path)
 
-        if res:
-            return res[0]
+        if entry:
+            return entry.rev
         else:
             return None
 
@@ -792,11 +780,10 @@ class SyncEngine:
         :returns: Time of last sync.
         """
 
-        with self._database_access():
-            res = self._db_session.query(IndexEntry).get(dbx_path.lower())
+        entry = self.get_index_entry(dbx_path)
 
-        if res:
-            last_sync = res.last_sync or 0.0
+        if entry:
+            last_sync = entry.last_sync or 0.0
         else:
             last_sync = 0.0
 
@@ -811,7 +798,8 @@ class SyncEngine:
         """
 
         with self._database_access():
-            return self._db_session.query(IndexEntry).get(dbx_path.lower())
+            entry = self._db_manager_index.get(dbx_path.lower())
+            return cast(Optional[IndexEntry], entry)
 
     def get_local_hash(self, local_path: str) -> Optional[str]:
         """
@@ -827,9 +815,10 @@ class SyncEngine:
         except (FileNotFoundError, NotADirectoryError):
             # remove any existing cache entries for path
             with self._database_access():
-                cache_entry = self._db_session.query(HashCacheEntry).get(local_path)
+                cache_entry = self._db_manager_hash_cache.get(local_path)
+                cache_entry = cast(Optional[HashCacheEntry], cache_entry)
                 if cache_entry:
-                    self._db_session.delete(cache_entry)
+                    self._db_manager_hash_cache.delete(cache_entry)
             return None
         except OSError as err:
             raise os_to_maestral_error(err, local_path=local_path)
@@ -842,7 +831,8 @@ class SyncEngine:
 
         with self._database_access():
             # check cache for an up-to-date content hash and return if it exists
-            cache_entry = self._db_session.query(HashCacheEntry).get(local_path)
+            cache_entry = self._db_manager_hash_cache.get(local_path)
+            cache_entry = cast(Optional[HashCacheEntry], cache_entry)
 
             if cache_entry and cache_entry.mtime == mtime:
                 return cache_entry.hash_str
@@ -868,7 +858,8 @@ class SyncEngine:
 
         with self._database_access():
 
-            cache_entry = self._db_session.query(HashCacheEntry).get(local_path)
+            cache_entry = self._db_manager_hash_cache.get(local_path)
+            cache_entry = cast(Optional[HashCacheEntry], cache_entry)
 
             if hash_str:
 
@@ -876,25 +867,28 @@ class SyncEngine:
                     cache_entry.hash_str = hash_str
                     cache_entry.mtime = mtime
 
+                    self._db_manager_hash_cache.update(cache_entry)
+
                 else:
                     cache_entry = HashCacheEntry(
                         local_path=local_path, hash_str=hash_str, mtime=mtime
                     )
-                    self._db_session.add(cache_entry)
+                    self._db_manager_hash_cache.save(cache_entry)
             else:
                 if cache_entry:
-                    self._db_session.delete(cache_entry)
+                    self._db_manager_hash_cache.delete(cache_entry)
                 else:
                     pass
 
-            self._db_session.commit()
+            self._db.commit()
 
     def clear_hash_cache(self) -> None:
         """Clears the sync history."""
         with self._database_access():
-            HashCacheEntry.metadata.drop_all(self._db_engine)
-            Base.metadata.create_all(self._db_engine)
-            self._db_session.expunge_all()
+            self._db.execute("DROP TABLE hash_cache")
+            self._db_manager_hash_cache.clear_cache()
+            self._db_manager_hash_cache.create_table()
+            self._db.commit()
 
     def update_index_from_sync_event(self, event: SyncEvent) -> None:
         """
@@ -932,6 +926,8 @@ class SyncEngine:
                     entry.rev = event.rev
                     entry.content_hash = event.content_hash
 
+                    self._db_manager_index.update(entry)
+
                 else:
                     # create new entry
                     entry = IndexEntry(
@@ -944,9 +940,9 @@ class SyncEngine:
                         content_hash=event.content_hash,
                     )
 
-                    self._db_session.add(entry)
+                    self._db_manager_index.save(entry)
 
-            self._db_session.commit()
+            self._db.commit()
 
     def update_index_from_dbx_metadata(
         self, md: Metadata, client: Optional[DropboxClient] = None
@@ -990,6 +986,8 @@ class SyncEngine:
                     entry.rev = rev
                     entry.content_hash = hash_str
 
+                    self._db_manager_index.update(entry)
+
                 else:
                     entry = IndexEntry(
                         dbx_path_cased=dbx_path_cased,
@@ -1001,9 +999,9 @@ class SyncEngine:
                         content_hash=hash_str,
                     )
 
-                    self._db_session.add(entry)
+                    self._db_manager_index.save(entry)
 
-            self._db_session.commit()
+            self._db.commit()
 
     def remove_node_from_index(self, dbx_path: str) -> None:
         """
@@ -1015,24 +1013,25 @@ class SyncEngine:
         with self._database_access():
 
             dbx_path_lower = dbx_path.lower().rstrip("/")
-            match = f"{dbx_path_lower}/%"
 
-            self._db_session.query(IndexEntry).filter(
-                IndexEntry.dbx_path_lower == dbx_path_lower
-            ).delete(synchronize_session="fetch")
-            self._db_session.query(IndexEntry).filter(
-                IndexEntry.dbx_path_lower.ilike(match)
-            ).delete(synchronize_session="fetch")
+            self._db.execute(
+                "DELETE FROM 'index' WHERE dbx_path_lower = ?", dbx_path_lower
+            )
+            self._db.execute(
+                "DELETE FROM 'index' WHERE dbx_path_lower LIKE ?", f"{dbx_path_lower}/%"
+            )
 
-            self._db_session.commit()
+            self._db_manager_index.clear_cache()
+
+            self._db.commit()
 
     def clear_index(self) -> None:
         """Clears the revision index."""
         with self._database_access():
-
-            IndexEntry.metadata.drop_all(self._db_engine)
-            Base.metadata.create_all(self._db_engine)
-            self._db_session.expunge_all()
+            self._db.execute("DROP TABLE 'index'")
+            self._db_manager_index.clear_cache()
+            self._db_manager_index.create_table()
+            self._db.commit()
 
     # ==== mignore management ==========================================================
 
@@ -1507,10 +1506,12 @@ class SyncEngine:
         msg = ""
         new_exc = None
 
+        # TODO: update error handling
+
         try:
             with self._db_lock:
                 yield
-        except sqlalchemy.exc.OperationalError as exc:
+        except sqlite3.OperationalError as exc:
             title = "Database transaction error"
             msg = (
                 f'The index file at "{self._db_path}" cannot be read. '
@@ -1518,11 +1519,11 @@ class SyncEngine:
                 "rebuild the index if necessary."
             )
             new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
-        except sqlalchemy.exc.InternalError as exc:
+        except sqlite3.ProgrammingError as exc:
             title = "Database transaction error"
             msg = "Please restart Maestral to continue syncing."
             new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
-        except sqlalchemy.exc.DatabaseError as exc:
+        except sqlite3.IntegrityError as exc:
             title = "Database integrity error"
             msg = "Please rebuild the index to continue syncing."
             new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
@@ -1536,14 +1537,9 @@ class SyncEngine:
 
     def _free_memory(self) -> None:
         """
-        Frees memory by resetting our database session and the requests session,
-        clearing out case-conversion cache and clearing all expired event ignores and.
+        Frees memory by clearing out case-conversion cache, clearing all expired event
+        ignores and running garbage collection.
         """
-
-        with self._database_access():
-            self._db_session.flush()
-            self._db_session.close()
-            self._db_session = Session()
 
         self._case_conversion_cache.clear()
         self.fs_events.expire_ignored_events()
@@ -1783,8 +1779,8 @@ class SyncEngine:
 
             for event in dir_moved:
                 logger.info(f"Moving {event.dbx_path_from}...")
-                res = self._create_remote_entry(event)
-                results.append(res)
+                r = self._create_remote_entry(event)
+                results.append(r)
 
             # apply other events in parallel since order does not matter
             with ThreadPoolExecutor(
@@ -2175,7 +2171,7 @@ class SyncEngine:
         # add to history database
         if event.status == SyncStatus.Done:
             with self._database_access():
-                self._db_session.add(event)
+                self._db_manager_history.save(event)
 
         return event
 
@@ -3259,7 +3255,7 @@ class SyncEngine:
         # add to history database
         if event.status == SyncStatus.Done:
             with self._database_access():
-                self._db_session.add(event)
+                self._db_manager_history.save(event)
 
         return event
 
@@ -3472,19 +3468,20 @@ class SyncEngine:
         """
 
         with self._database_access():
-            old_entry = self.get_index_entry(event.dbx_path.lower())
+            entry = self.get_index_entry(event.dbx_path.lower())
 
-        if old_entry and old_entry.dbx_path_cased != event.dbx_path:
+        if entry and entry.dbx_path_cased != event.dbx_path:
 
-            local_path_old = self.to_local_path_from_cased(old_entry.dbx_path_cased)
+            local_path_old = self.to_local_path_from_cased(entry.dbx_path_cased)
 
             event_cls = DirMovedEvent if osp.isdir(local_path_old) else FileMovedEvent
             with self.fs_events.ignore(event_cls(local_path_old, event.local_path)):
                 move(local_path_old, event.local_path)
 
             with self._database_access():
-                old_entry.dbx_path_cased = event.dbx_path
-                self._db_session.commit()
+                entry.dbx_path_cased = event.dbx_path
+                self._db_manager_index.update(entry)
+                self._db.commit()
 
             logger.debug('Renamed "%s" to "%s"', local_path_old, event.local_path)
 
@@ -3518,15 +3515,16 @@ class SyncEngine:
             # add deleted events
 
             with self._database_access():
-                entries = (
-                    self._db_session.query(IndexEntry)
-                    .filter(IndexEntry.dbx_path_lower.like(f"{local_path_lower}%"))
-                    .all()
+
+                entries = self._db_manager_index.query_to_objects(
+                    "SELECT * FROM 'index' WHERE dbx_path_lower LIKE ?",
+                    f"{local_path_lower}%",
                 )
 
             dbx_root_lower = self.dropbox_path.lower()
 
             for entry in entries:
+                entry = cast(IndexEntry, entry)
                 child_path_uncased = f"{dbx_root_lower}{entry.dbx_path_lower}"
                 if child_path_uncased not in lowercase_snapshot_paths:
                     local_child = self.to_local_path_from_cased(entry.dbx_path_cased)
@@ -3553,19 +3551,20 @@ class SyncEngine:
         with self._database_access():
 
             # commit previous
-            self._db_session.commit()
+            self._db.commit()
 
             # drop all entries older than keep_history
             now = time.time()
             keep_history = self._conf.get("sync", "keep_history")
-            query = self._db_session.query(SyncEvent)
-            subquery = query.filter(
-                SyncEvent.change_time_or_sync_time < now - keep_history
+
+            self._db.execute(
+                "DELETE FROM history WHERE IFNULL(change_time, sync_time) < ?",
+                now - keep_history,
             )
-            subquery.delete(synchronize_session="fetch")
+            self._db_manager_history.clear_cache()
 
             # commit to drive
-            self._db_session.commit()
+            self._db.commit()
 
     def _scandir_with_mignore(self, path: str) -> List:
         return [

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1506,8 +1506,6 @@ class SyncEngine:
         msg = ""
         new_exc = None
 
-        # TODO: update error handling
-
         try:
             with self._db_lock:
                 yield
@@ -1519,13 +1517,16 @@ class SyncEngine:
                 "rebuild the index if necessary."
             )
             new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
-        except sqlite3.ProgrammingError as exc:
-            title = "Database transaction error"
-            msg = "Please restart Maestral to continue syncing."
-            new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
         except sqlite3.IntegrityError as exc:
             title = "Database integrity error"
             msg = "Please rebuild the index to continue syncing."
+            new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
+        except sqlite3.DatabaseError as exc:
+            title = "Database transaction error"
+            msg = (
+                "Please restart Maestral to continue syncing. "
+                "Rebuild the index if this issue persists."
+            )
             new_exc = DatabaseError(title, msg).with_traceback(exc.__traceback__)
 
         if new_exc:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1014,15 +1014,18 @@ class SyncEngine:
 
             dbx_path_lower = dbx_path.lower().rstrip("/")
 
-            self._db.execute(
-                "DELETE FROM 'index' WHERE dbx_path_lower = ?", dbx_path_lower
-            )
-            self._db.execute(
-                "DELETE FROM 'index' WHERE dbx_path_lower LIKE ?", f"{dbx_path_lower}/%"
-            )
+            try:
+                self._db.execute(
+                    "DELETE FROM 'index' WHERE dbx_path_lower = ?", dbx_path_lower
+                )
+                self._db.execute(
+                    "DELETE FROM 'index' WHERE dbx_path_lower LIKE ?",
+                    f"{dbx_path_lower}/%",
+                )
+            except UnicodeEncodeError:
+                return
 
             self._db_manager_index.clear_cache()
-
             self._db.commit()
 
     def clear_index(self) -> None:

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -43,8 +43,6 @@ class NoDefault:
     This is distinct from ``None`` which may be a valid default.
     """
 
-    pass
-
 
 class SqlType:
     """Base class to represent Python types in SQLite table"""
@@ -269,7 +267,7 @@ def column_value_dict(obj: "Model") -> Dict[str, Any]:
     """
     cols = columns(type(obj))
 
-    return dict((col.name, getattr(obj, col.name)) for col in cols)
+    return {col.name: getattr(obj, col.name) for col in cols}
 
 
 class Database:
@@ -481,7 +479,7 @@ class Manager:
         """
         sql = f"SELECT {self.primary_key_name} FROM {self.table_name} WHERE {self.primary_key_name} = ?"
         result = self.db.execute(sql, primary_key)
-        return True if result.fetchone() else False
+        return bool(result.fetchone())
 
     def save(self, obj: "Model") -> "Model":
         """
@@ -544,7 +542,7 @@ class Manager:
         """Checks if entity model already has a database table."""
         sql = "SELECT name len FROM sqlite_master WHERE type = 'table' AND name = ?"
         result = self.db.execute(sql, self.table_name.strip("'\""))
-        return True if result.fetchall() else False
+        return bool(result.fetchall())
 
 
 class Model:

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -1,0 +1,423 @@
+# -*- coding: utf-8 -*-
+"""
+A basic object relational mapper for SQLite.
+Contains only functionality needed by Maestral.
+"""
+import os
+import sqlite3
+from enum import Enum, EnumMeta
+from weakref import WeakValueDictionary
+from typing import Union, Type, Any, Dict, Generator, List, Optional, TypeVar
+
+
+ColumnValueType = Union[str, int, float, Enum, None]
+DefaultColumnValueType = Union[ColumnValueType, Type["NoDefault"]]
+SQLSafeType = Union[str, int, float, None]
+T = TypeVar("T")
+
+
+class NoDefault:
+    pass
+
+
+class SqlType:
+    sql_type = "TEXT"
+    py_type: Type[ColumnValueType] = str
+
+    def sql_to_py(self, value):
+        raise NotImplementedError()
+
+    def py_to_sql(self, value):
+        raise NotImplementedError()
+
+
+class SqlString(SqlType):
+    sql_type = "TEXT"
+    py_type = str
+
+    def sql_to_py(self, value: Optional[str]) -> Optional[str]:
+        return value
+
+    def py_to_sql(self, value: Optional[str]) -> Optional[str]:
+        return value
+
+
+class SqlInt(SqlType):
+    sql_type = "INTEGER"
+    py_type = int
+
+    def sql_to_py(self, value: Optional[int]) -> Optional[int]:
+        return value
+
+    def py_to_sql(self, value: Optional[int]) -> Optional[int]:
+        return value
+
+
+class SqlFloat(SqlType):
+    sql_type = "REAL"
+    py_type = float
+
+    def sql_to_py(self, value: Optional[float]) -> Optional[float]:
+        return value
+
+    def py_to_sql(self, value: Optional[float]) -> Optional[float]:
+        return value
+
+
+class SqlPath(SqlType):
+    sql_type = "TEXT"
+    py_type = str
+
+    def sql_to_py(self, value: Optional[str]) -> Optional[str]:
+        return value
+
+    def py_to_sql(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        else:
+            return os.fsencode(value).decode(errors="replace")
+
+
+class SqlEnum(SqlType):
+    sql_type = "TEXT"
+    py_type = Enum
+
+    def __init__(self, enum: EnumMeta) -> None:
+        self.enum_type = enum
+
+    def sql_to_py(self, value: Optional[str]) -> Optional[Enum]:
+        if value is None:
+            return None
+        else:
+            return getattr(self.enum_type, value)
+
+    def py_to_sql(self, value: Optional[Enum]) -> Optional[str]:
+        if value is None:
+            return None
+        else:
+            return value.name
+
+
+class Column(property):
+    def __init__(
+        self,
+        type: SqlType,
+        nullable: bool = True,
+        unique: bool = False,
+        primary_key: bool = False,
+        default: DefaultColumnValueType = None,
+    ):
+        super().__init__(fget=self._fget, fset=self._fset)
+
+        self.type = type
+        self.nullable = nullable
+        self.unique = unique
+        self.primary_key = primary_key
+
+        self.default: DefaultColumnValueType
+
+        if not nullable and default is None:
+            self.default = NoDefault
+        else:
+            self.default = default
+
+    def __set_name__(self, owner: Any, name: str):
+        self.name = name
+        self.private_name = "_" + name
+
+    def _fget(self, obj: Any) -> Any:
+        if self.default is NoDefault:
+            return getattr(obj, self.private_name)
+        else:
+            return getattr(obj, self.private_name, self.default)
+
+    def _fset(self, obj: Any, value: Any) -> None:
+        setattr(obj, self.private_name, value)
+
+    def render_constraints(self) -> str:
+
+        constraints = []
+
+        if isinstance(self.type, SqlEnum):
+            values = ", ".join(  # type: ignore
+                repr(member.name) for member in self.type.enum_type
+            )
+            constraints.append(f"CHECK( {self.name} IN ({values}) )")
+
+        if not self.nullable:
+            constraints.append("NOT NULL")
+
+        if self.unique:
+            constraints.append("UNIQUE")
+
+        return " ".join(constraints)
+
+    def render_properties(self) -> str:
+
+        properties = []
+
+        if self.primary_key:
+            properties.append("PRIMARY KEY")
+
+        if self.default in (None, NoDefault):
+            properties.append("DEFAULT NULL")
+        else:
+            properties.append(f"DEFAULT {repr(self.default)}")
+
+        return " ".join(properties)
+
+    def render_column(self) -> str:
+        return " ".join(
+            [
+                self.name,
+                self.type.sql_type,
+                self.render_constraints(),
+                self.render_properties(),
+            ]
+        )
+
+    def py_to_sql(self, value: ColumnValueType) -> SQLSafeType:
+        return self.type.py_to_sql(value)
+
+    def sql_to_py(self, value: SQLSafeType) -> ColumnValueType:
+        return self.type.sql_to_py(value)
+
+
+def columns(klass: Type["Model"]) -> List[Column]:
+    """ Return column values dictionary for an object """
+    return [attr for attr in vars(klass).values() if isinstance(attr, Column)]
+
+
+def column_value_dict(obj: "Model") -> Dict[str, Any]:
+    """ Return column values dictionary for an object """
+    cols = columns(type(obj))
+
+    return dict((col.name, getattr(obj, col.name)) for col in cols)
+
+
+class Database:
+    """ Proxy class to access sqlite3.connect method """
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self._connection: Optional[sqlite3.Connection] = None
+        self.Model = type(f"Model{self}", (Model,), {"_db": self})
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """ Create SQL connection """
+
+        if self._connection:
+            return self._connection
+        else:
+            connection = sqlite3.connect(*self.args, **self.kwargs)
+            connection.row_factory = sqlite3.Row
+            self._connection = connection
+            return connection
+
+    def close(self) -> None:
+        """ Close SQL connection """
+        if self._connection:
+            self._connection.close()
+        self._connection = None
+
+    def commit(self) -> None:
+        """ Commit SQL changes """
+        self.connection.commit()
+
+    def execute(self, sql: str, *args) -> sqlite3.Cursor:
+        """ Execute SQL """
+        return self.connection.execute(sql, args)
+
+    def executescript(self, script: str) -> None:
+        """ Execute SQL script """
+        self.connection.cursor().executescript(script)
+        self.commit()
+
+
+class Manager:
+    """ Data mapper interface (generic repository) for models """
+
+    def __init__(self, db: Database, model: Type["Model"]) -> None:
+        self.db = db
+        self.model = model
+        self.table_name = model.__tablename__
+        self.primary_key_name = self._find_primary_key(model)
+
+        self._cache: "WeakValueDictionary[SQLSafeType, Model]" = WeakValueDictionary()
+
+        # Precompute expensive SQL query strings.
+        self._columns = columns(model)
+
+        column_names = [col.name for col in self._columns]
+        column_names_str = ", ".join(column_names)
+        column_refs = ", ".join(["?"] * len(self._columns))
+
+        self._sql_insert_template = "INSERT INTO {} ({}) VALUES ({})".format(
+            self.table_name, column_names_str, column_refs
+        )
+
+        where_expressions = [f"{name} = ?" for name in column_names]
+        where_expressions_str = ", ".join(where_expressions)
+        self._sql_update_template = "UPDATE {} SET {} WHERE {} = ?".format(
+            self.table_name,
+            where_expressions_str,
+            self.primary_key_name,
+        )
+
+        # Create table if required.
+        if not self._has_table():
+            self.create_table()
+
+    def create_table(self) -> None:
+
+        column_defs = [col.render_column() for col in columns(self.model)]
+        column_defs_str = ", ".join(column_defs)
+        sql = f"CREATE TABLE {self.model.__tablename__} ({column_defs_str});"
+
+        self.db.executescript(sql)
+
+    def clear_cache(self) -> None:
+        self._cache.clear()
+
+    def _find_primary_key(self, model: Type["Model"]) -> str:
+        for col in columns(model):
+            if col.primary_key:
+                return col.name
+
+        raise ValueError("Model has no primary key")
+
+    def get_primary_key(self, obj: "Model") -> SQLSafeType:
+        return getattr(obj, self.primary_key_name)
+
+    def all(self) -> List["Model"]:
+        """ Get all model objects from database """
+        result = self.db.execute(f"SELECT * FROM {self.table_name}")
+        return [self.create(**row) for row in result.fetchall()]
+
+    def iter_all(self, size: int = 1000) -> Generator[List["Model"], Any, None]:
+        result = self.db.execute(f"SELECT * FROM {self.table_name}")
+        rows = result.fetchmany(size)
+
+        while len(rows) > 0:
+            yield [self.create(**row) for row in rows]
+            rows = result.fetchmany(size)
+
+    def create(self, **kwargs) -> "Model":
+        """ Create a model object from SQL column values"""
+
+        # Convert any types as appropriate.
+        for key, value in kwargs.items():
+            col = getattr(self.model, key)
+            kwargs[key] = col.sql_to_py(value)
+
+        obj = self.model(**kwargs)
+
+        pk = self.get_primary_key(obj)
+        self._cache[pk] = obj
+
+        return obj
+
+    def delete(self, obj: "Model") -> None:
+        """ Delete a model object from database """
+        pk = self.get_primary_key(obj)
+        sql = f"DELETE from {self.table_name} WHERE {self.primary_key_name} = ?"
+        self.db.execute(sql, self.get_primary_key(obj))
+
+        try:
+            del self._cache[pk]
+        except KeyError:
+            pass
+
+    def get(self, primary_key) -> Optional["Model"]:
+        """ Get a model object from database by its primary key """
+        sql = f"SELECT * FROM {self.table_name} WHERE {self.primary_key_name} = ?"
+        result = self.db.execute(sql, primary_key)
+        row = result.fetchone()
+
+        if not row:
+            return None
+
+        return self.create(**row)
+
+    def has(self, primary_key) -> bool:
+        """ Check if a model object exists in database by its id """
+        sql = f"SELECT {self.primary_key_name} FROM {self.table_name} WHERE {self.primary_key_name} = ?"
+        result = self.db.execute(sql, primary_key)
+        return True if result.fetchone() else False
+
+    def save(self, obj: "Model") -> "Model":
+        """ Save a model object """
+        primary_key = self.get_primary_key(obj)
+
+        if self.has(primary_key):
+            msg = f"Object with primary key {primary_key} is already registered"
+            raise ValueError(msg)
+
+        py_values = column_value_dict(obj).values()
+        sql_values = (col.py_to_sql(val) for col, val in zip(self._columns, py_values))
+
+        self.db.execute(self._sql_insert_template, *sql_values)
+
+        if primary_key is None:
+            # Round trip to fetch created primary key.
+            res = self.db.execute("SELECT last_insert_rowid()").fetchone()
+            setattr(obj, self.primary_key_name, res["last_insert_rowid()"])
+
+        self._cache[primary_key] = obj
+
+        return obj
+
+    def update(self, obj: "Model") -> None:
+        """ Update a model object """
+        py_values = column_value_dict(obj).values()
+        sql_values = (col.py_to_sql(val) for col, val in zip(self._columns, py_values))
+        pk = self.get_primary_key(obj)
+        self.db.execute(self._sql_update_template, *(list(sql_values) + [pk]))
+
+    def query_to_objects(self, q: str, *args) -> List["Model"]:
+        result = self.db.execute(q, *args)
+        return [self.create(**row) for row in result.fetchall()]
+
+    def count(self) -> int:
+        res = self.db.execute(f"SELECT COUNT(*) FROM {self.table_name};")
+        counts = res.fetchone()
+        return counts[0]
+
+    def _has_table(self) -> bool:
+        """ Check if entity model already has a database table """
+        sql = "SELECT name len FROM sqlite_master WHERE type = 'table' AND name = ?"
+        result = self.db.execute(sql, self.table_name.strip("'\""))
+        return True if result.fetchall() else False
+
+
+class Model:
+    """ Abstract entity model with an active record interface """
+
+    __tablename__ = ""
+    _manager = None
+
+    def __init__(self, **kwargs) -> None:
+        """Allows initialization from kwargs.
+
+        Sets attributes on the constructed instance using the names and values in
+        ``kwargs``.
+        """
+
+        cls_ = type(self)
+
+        for col in columns(cls_):
+
+            if isinstance(col, Column):
+                if col.default is NoDefault:
+                    try:
+                        setattr(self, col.name, kwargs[col.name])
+                    except KeyError:
+                        raise TypeError(f"Column value for '{col.name}' must be given")
+                else:
+                    setattr(self, col.name, kwargs.get(col.name, col.default))
+
+    def __repr__(self) -> str:
+        attributes = ", ".join(f"{k}={v}" for k, v in column_value_dict(self).items())
+        return f"<{type(self).__name__}({attributes})>"

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -9,9 +9,9 @@ memory is constrained.
 """
 import os
 import sqlite3
-from enum import Enum, EnumMeta
+from enum import Enum
 from weakref import WeakValueDictionary
-from typing import Union, Type, Any, Dict, Generator, List, Optional, TypeVar
+from typing import Union, Type, Any, Dict, Generator, List, Optional, TypeVar, Iterable
 
 
 ColumnValueType = Union[str, int, float, Enum, None]
@@ -127,7 +127,7 @@ class SqlEnum(SqlType):
     sql_type = "TEXT"
     py_type = Enum
 
-    def __init__(self, enum: EnumMeta) -> None:
+    def __init__(self, enum: Iterable[Enum]) -> None:
         self.enum_type = enum
 
     def sql_to_py(self, value: Optional[str]) -> Optional[Enum]:
@@ -200,9 +200,7 @@ class Column(property):
         constraints = []
 
         if isinstance(self.type, SqlEnum):
-            values = ", ".join(  # type: ignore
-                repr(member.name) for member in self.type.enum_type
-            )
+            values = ", ".join(repr(member.name) for member in self.type.enum_type)
             constraints.append(f"CHECK( {self.name} IN ({values}) )")
 
         if not self.nullable:


### PR DESCRIPTION
This PR switches from using sqlalchemy for database access to our own ORM layer which is a lot more basic. This has a few advantages:

1. Reduced baseline memory usage: the sqlalchemy module requires about 10 MB of memory while our own ORM only requires 0.5 MB.
2. Reduced peak memory usage: Our own index entry object requires about 50% less memory. This reduces the peak memory usage during indexing, especially when starting up the sync.
3. Increased performance: More complex database operations are handled by explicitly writing the SQL statements, resulting in less overhead to generate statements.

See #205 and #248.