### PR TITLE
Clarify how to find PyQt5 version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ labels: bug
 
 **System:**
 <!--- Please complete the following information. --->
-<!--- To find PyQt5 version, run `python3 -c "from PyQt5.Qt import PYQT_VERSION_STR; print(PYQT_VERSION_STR)"` --->
+<!--- To find the PyQt5 version, run `python3 -c "from PyQt5.Qt import PYQT_VERSION_STR; print(PYQT_VERSION_STR)"` --->
  - Maestral version:
  - OS: [e.g. Ubuntu]
  - Desktop environment: [e.g. Gnome 3.32]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,6 +16,7 @@ labels: bug
 
 **System:**
 <!--- Please complete the following information. --->
+<!--- To find PyQt5 version, run `python3 -c "from PyQt5.Qt import PYQT_VERSION_STR; print(PYQT_VERSION_STR)"` --->
  - Maestral version:
  - OS: [e.g. Ubuntu]
  - Desktop environment: [e.g. Gnome 3.32]


### PR DESCRIPTION
The python pip package PyQt5 has no __version__ attribute (unlike most of the other ones who does).

The solution I found to find the PyQt5 package version is this.

Update the bug report template to clarify how to find PyQt5 package version