### PR TITLE
Optimise local indexing

### DIFF
--- a/src/maestral/constants.py
+++ b/src/maestral/constants.py
@@ -18,6 +18,7 @@ except ImportError:
 APP_NAME = "Maestral"
 BUNDLE_ID = "com.samschott.maestral"
 APP_ICON_PATH = files("maestral") / "resources" / "maestral.png"
+ENV = {"PYTHONOPTIMIZE": "2"}
 
 # sync
 OLD_REV_FILE = ".maestral"

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -35,6 +35,7 @@ from fasteners import InterProcessLock  # type: ignore
 from .errors import SYNC_ERRORS, GENERAL_ERRORS, MaestralApiError
 from .utils import exc_info_tuple
 from .utils.appdirs import get_runtime_path
+from .constants import ENV
 
 
 if TYPE_CHECKING:
@@ -602,7 +603,10 @@ def start_maestral_daemon_process(
         f'maestral.daemon.start_maestral_daemon("{cc}", start_sync={start_sync})'
     )
 
-    cmd = [sys.executable, "-OO", "-c", script]
+    cmd = [sys.executable, "-c", script]
+
+    subprocess_env = os.environ.copy()
+    subprocess_env.update(ENV)
 
     process = subprocess.Popen(
         cmd,
@@ -610,6 +614,7 @@ def start_maestral_daemon_process(
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        env=subprocess_env,
     )
 
     try:

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -35,7 +35,7 @@ from fasteners import InterProcessLock  # type: ignore
 from .errors import SYNC_ERRORS, GENERAL_ERRORS, MaestralApiError
 from .utils import exc_info_tuple
 from .utils.appdirs import get_runtime_path
-from .constants import ENV
+from .constants import IS_MACOS, ENV
 
 
 if TYPE_CHECKING:
@@ -162,10 +162,7 @@ def _get_lockdata() -> Tuple[bytes, str, int]:
     else:
         start_len = "qq"
 
-    if (
-        sys.platform.startswith(("netbsd", "freebsd", "openbsd"))
-        or sys.platform == "darwin"
-    ):
+    if sys.platform.startswith(("netbsd", "freebsd", "openbsd")) or IS_MACOS:
         if struct.calcsize("l") == 8:
             off_t = "l"
             pid_t = "i"
@@ -444,7 +441,7 @@ def start_maestral_daemon(
     os.nice(10)
 
     # Integrate with CFRunLoop in macOS.
-    if sys.platform == "darwin":
+    if IS_MACOS:
 
         logger.debug("Cancelling all tasks from asyncio event loop")
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -20,6 +20,7 @@ import warnings
 import argparse
 import ast
 import re
+from pprint import pformat
 from shlex import quote
 from typing import Optional, Any, Union, Tuple, Dict, Iterable, Type, TYPE_CHECKING
 from types import TracebackType
@@ -422,11 +423,10 @@ def start_maestral_daemon(
     from . import notify
     from .main import Maestral
 
-    if log_to_stdout:
-        logger.setLevel(logging.DEBUG)
-
     if threading.current_thread() is not threading.main_thread():
         raise RuntimeError("Must run daemon in main thread")
+
+    logger.debug("Environment:\n%s", pformat(os.environ.copy()))
 
     # acquire PID lock file
     lock = maestral_lock(config_name)

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -221,6 +221,7 @@ class Maestral:
         self.sync.clear_sync_history()
         self._conf.cleanup()
         self._state.cleanup()
+        self.sync._load_cached_config()  # reload cached config values
         delete(self.sync.database_path)
 
         logger.info("Unlinked Dropbox account.")

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -218,6 +218,8 @@ def startup_worker(
 
     with handle_sync_thread_errors(running, autostart, sync.notifier):
 
+        sync.load_mignore_file()
+
         with sync.client.clone_with_new_session() as client:
 
             # Retry failed downloads.

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -560,15 +560,10 @@ class SyncMonitor:
     def reset_sync_state(self) -> None:
         """Resets all saved sync state. Settings are not affected."""
 
-        if self.running.is_set() or self.sync.busy():
+        if self.running.is_set():
             raise RuntimeError("Cannot reset sync state while syncing.")
 
-        self.sync.remote_cursor = ""
-        self.sync.local_cursor = 0.0
-        self.sync.clear_index()
-        self.sync.clear_sync_history()
-
-        logger.debug("Sync state reset")
+        self.sync.reset_sync_state()
 
     def rebuild_index(self) -> None:
         """

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -12,8 +12,8 @@ import random
 import uuid
 import urllib.parse
 import enum
-import pprint
 import sqlite3
+from pprint import pformat
 from threading import Event, Condition, RLock, current_thread
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue, Empty
@@ -1554,7 +1554,7 @@ class SyncEngine:
                 events, local_cursor = self._get_local_changes_while_inactive()
 
                 if logger.getEffectiveLevel() <= logging.DEBUG:
-                    logger.debug("Retrieved local changes:\n%s", pprint.pformat(events))
+                    logger.debug("Retrieved local changes:\n%s", pformat(events))
 
                 events = self._clean_local_events(events)
                 sync_events = [
@@ -1712,7 +1712,7 @@ class SyncEngine:
                 break
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug("Retrieved local file events:\n%s", pprint.pformat(events))
+            logger.debug("Retrieved local file events:\n%s", pformat(events))
 
         events = self._clean_local_events(events)
         sync_events = [SyncEvent.from_file_system_event(e, self) for e in events]
@@ -1815,9 +1815,7 @@ class SyncEngine:
                 events_filtered.append(event)
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug(
-                "Filtered local file events:\n%s", pprint.pformat(events_filtered)
-            )
+            logger.debug("Filtered local file events:\n%s", pformat(events_filtered))
 
         return events_filtered, events_excluded
 
@@ -2005,9 +2003,7 @@ class SyncEngine:
                 cleaned_events.difference_update(split_events)
 
         if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug(
-                "Cleaned up local file events:\n%s", pprint.pformat(cleaned_events)
-            )
+            logger.debug("Cleaned up local file events:\n%s", pformat(cleaned_events))
 
         return list(cleaned_events)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -708,6 +708,19 @@ class SyncEngine:
             self._db_manager_history.create_table()
             self._db_manager_history.clear_cache()
 
+    def reset_sync_state(self) -> None:
+        """Resets all saved sync state. Settings are not affected."""
+
+        if self.busy():
+            raise RuntimeError("Cannot reset sync state while syncing.")
+
+        self.remote_cursor = ""
+        self.local_cursor = 0.0
+        self.clear_index()
+        self.clear_sync_history()
+
+        logger.debug("Sync state reset")
+
     # ==== index management ============================================================
 
     def get_index(self) -> List[IndexEntry]:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -857,15 +857,12 @@ class SyncEngine:
                 else:
                     pass
 
-            self._db.commit()
-
     def clear_hash_cache(self) -> None:
         """Clears the sync history."""
         with self._database_access():
             self._db.execute("DROP TABLE hash_cache")
             self._db_manager_hash_cache.clear_cache()
             self._db_manager_hash_cache.create_table()
-            self._db.commit()
 
     def update_index_from_sync_event(self, event: SyncEvent) -> None:
         """
@@ -918,8 +915,6 @@ class SyncEngine:
                     )
 
                     self._db_manager_index.save(entry)
-
-            self._db.commit()
 
     def update_index_from_dbx_metadata(
         self, md: Metadata, client: Optional[DropboxClient] = None
@@ -978,8 +973,6 @@ class SyncEngine:
 
                     self._db_manager_index.save(entry)
 
-            self._db.commit()
-
     def remove_node_from_index(self, dbx_path: str) -> None:
         """
         Removes any local index entries for the given path and all its children.
@@ -1003,7 +996,6 @@ class SyncEngine:
                 return
 
             self._db_manager_index.clear_cache()
-            self._db.commit()
 
     def clear_index(self) -> None:
         """Clears the revision index."""
@@ -1011,7 +1003,6 @@ class SyncEngine:
             self._db.execute("DROP TABLE 'index'")
             self._db_manager_index.clear_cache()
             self._db_manager_index.create_table()
-            self._db.commit()
 
     # ==== mignore management ==========================================================
 
@@ -3493,7 +3484,6 @@ class SyncEngine:
             with self._database_access():
                 entry.dbx_path_cased = event.dbx_path
                 self._db_manager_index.update(entry)
-                self._db.commit()
 
             logger.debug('Renamed "%s" to "%s"', local_path_old, event.local_path)
 
@@ -3562,9 +3552,6 @@ class SyncEngine:
 
         with self._database_access():
 
-            # commit previous
-            self._db.commit()
-
             # drop all entries older than keep_history
             now = time.time()
             keep_history = self._conf.get("sync", "keep_history")
@@ -3574,9 +3561,6 @@ class SyncEngine:
                 now - keep_history,
             )
             self._db_manager_history.clear_cache()
-
-            # commit to drive
-            self._db.commit()
 
     def _scandir_with_mignore(self, path: str) -> List:
         return [

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3116,8 +3116,8 @@ class SyncEngine:
             return False
 
         else:
-            # check our ctime against index
-            return os.stat(local_path).st_ctime > self.get_last_sync(dbx_path)
+            # Check our ctime against index.
+            return stat.st_ctime > self.get_last_sync(dbx_path)
 
     def _get_ctime(self, local_path: str) -> float:
         """
@@ -3145,7 +3145,7 @@ class SyncEngine:
 
                 return ctime
             else:
-                return os.stat(local_path).st_ctime
+                return stat.st_ctime
         except (FileNotFoundError, NotADirectoryError):
             return -1.0
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1247,9 +1247,7 @@ class SyncEngine:
         :returns: Corresponding local path on drive.
         """
 
-        dbx_path_cased = dbx_path_cased.lstrip("/")
-
-        return osp.join(self.dropbox_path, dbx_path_cased)
+        return f"{self.dropbox_path}{dbx_path_cased}"
 
     def to_local_path(self, dbx_path: str, client=Optional[DropboxClient]) -> str:
         """
@@ -1270,7 +1268,7 @@ class SyncEngine:
 
         dbx_path_cased = self.correct_case(dbx_path, client)
 
-        return osp.join(self.dropbox_path, dbx_path_cased.lstrip("/"))
+        return f"{self.dropbox_path}{dbx_path_cased}"
 
     def has_sync_errors(self) -> bool:
         """Returns ``True`` in case of sync errors, ``False`` otherwise."""
@@ -1387,7 +1385,7 @@ class SyncEngine:
         relative_path = dbx_path.lstrip("/")
 
         if is_dir:
-            relative_path += "/"
+            relative_path = f"{relative_path}/"
 
         return self.mignore_rules.match_file(relative_path)
 

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -49,13 +49,15 @@ class SqlType:
     sql_type = "TEXT"
     py_type: Type[ColumnValueType] = str
 
-    def sql_to_py(self, value):
+    @staticmethod
+    def sql_to_py(value):
         """Converts the return value from sqlite3 to the target Python type."""
-        raise NotImplementedError()
+        return value
 
-    def py_to_sql(self, value):
+    @staticmethod
+    def py_to_sql(value):
         """Converts a Python value to a type accepted by sqlite3."""
-        raise NotImplementedError()
+        return value
 
 
 class SqlString(SqlType):
@@ -64,12 +66,6 @@ class SqlString(SqlType):
     sql_type = "TEXT"
     py_type = str
 
-    def sql_to_py(self, value: Optional[str]) -> Optional[str]:
-        return value
-
-    def py_to_sql(self, value: Optional[str]) -> Optional[str]:
-        return value
-
 
 class SqlInt(SqlType):
     """Class to represent Python integers in SQLite table"""
@@ -77,24 +73,12 @@ class SqlInt(SqlType):
     sql_type = "INTEGER"
     py_type = int
 
-    def sql_to_py(self, value: Optional[int]) -> Optional[int]:
-        return value
-
-    def py_to_sql(self, value: Optional[int]) -> Optional[int]:
-        return value
-
 
 class SqlFloat(SqlType):
     """Class to represent Python floats in SQLite table"""
 
     sql_type = "REAL"
     py_type = float
-
-    def sql_to_py(self, value: Optional[float]) -> Optional[float]:
-        return value
-
-    def py_to_sql(self, value: Optional[float]) -> Optional[float]:
-        return value
 
 
 class SqlPath(SqlType):
@@ -108,12 +92,6 @@ class SqlPath(SqlType):
     sql_type = "TEXT"
     py_type = str
 
-    def sql_to_py(self, value: Optional[str]) -> Optional[str]:
-        return value
-
-    def py_to_sql(self, value: Optional[str]) -> Optional[str]:
-        return value
-
 
 class SqlEnum(SqlType):
     """Class to represent Python enums in SQLite table"""
@@ -124,13 +102,14 @@ class SqlEnum(SqlType):
     def __init__(self, enum: Iterable[Enum]) -> None:
         self.enum_type = enum
 
-    def sql_to_py(self, value: Optional[str]) -> Optional[Enum]:
+    def sql_to_py(self, value: Optional[str]) -> Optional[Enum]:  # type: ignore
         if value is None:
             return None
         else:
             return getattr(self.enum_type, value)
 
-    def py_to_sql(self, value: Optional[Enum]) -> Optional[str]:
+    @staticmethod
+    def py_to_sql(value: Optional[Enum]) -> Optional[str]:
         if value is None:
             return None
         else:
@@ -591,18 +570,8 @@ class Model:
         ``kwargs``.
         """
 
-        cls_ = type(self)
-
-        for col in columns(cls_):
-
-            if isinstance(col, Column):
-                if col.default is NoDefault:
-                    try:
-                        setattr(self, col.name, kwargs[col.name])
-                    except KeyError:
-                        raise TypeError(f"Column value for '{col.name}' must be given")
-                else:
-                    setattr(self, col.name, kwargs.get(col.name, col.default))
+        for name, value in kwargs.items():
+            setattr(self, name, value)
 
     def __repr__(self) -> str:
         attributes = ", ".join(f"{k}={v}" for k, v in column_value_dict(self).items())

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -305,7 +305,8 @@ class Database:
         :param args: Parameters to substitute for placeholders in SQL statement.
         :returns: The created cursor.
         """
-        return self.connection.execute(sql, args)
+        with self.connection:
+            return self.connection.execute(sql, args)
 
     def executescript(self, script: str) -> None:
         """
@@ -314,8 +315,8 @@ class Database:
         :param script: SQL script to execute.
         :returns: The created cursor.
         """
-        self.connection.cursor().executescript(script)
-        self.commit()
+        with self.connection:
+            self.connection.cursor().executescript(script)
 
 
 class Manager:

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -8,14 +8,13 @@ import shutil
 import timeit
 
 import pytest
-
+from watchdog.utils.dirsnapshot import DirectorySnapshot
+from watchdog.events import FileCreatedEvent
 from dropbox.files import WriteMode
-from maestral.sync import FileCreatedEvent
-from maestral.sync import delete, move
-from maestral.sync import is_fs_case_sensitive
-from maestral.sync import DirectorySnapshot, SyncEvent
+from maestral.database import SyncEvent
 from maestral.utils import sanitize_string
 from maestral.utils.appdirs import get_home_dir
+from maestral.utils.path import delete, move, is_fs_case_sensitive
 
 from .conftest import assert_synced, wait_for_idle, resources
 

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -637,9 +637,10 @@ def test_case_change_remote(m):
 def test_mignore(m):
     """Tests the exclusion of local items by an mignore file."""
 
-    # 1) test that tracked items are unaffected
+    # 1) test changes have no effect when sync is running
 
     os.mkdir(m.test_folder_local + "/bar")
+    os.mkdir(m.test_folder_local + "/folder")
     wait_for_idle(m)
 
     with open(m.sync.mignore_path, "w") as f:
@@ -652,16 +653,21 @@ def test_mignore(m):
     assert_synced(m)
     assert_exists(m, "/sync_tests", "bar")
 
-    # 2) test that new items are excluded
+    # 2) test that items are removed after restart
+
+    m.stop_sync()
+    wait_for_idle(m)
+    m.start_sync()
 
     os.mkdir(m.test_folder_local + "/foo")
     wait_for_idle(m)
 
     assert not m.client.get_metadata("/sync_tests/foo")
+    assert not m.client.get_metadata("/sync_tests/bar")
 
     # 3) test that renaming an item excludes it
 
-    move(m.test_folder_local + "/bar", m.test_folder_local + "/build")
+    move(m.test_folder_local + "/folder", m.test_folder_local + "/build")
     wait_for_idle(m)
 
     assert not m.client.get_metadata("/sync_tests/build")


### PR DESCRIPTION
This PR introduces a new local indexing algorithm which minimises memory usage by loading local file paths iteratively and freeing them immediately after use. This is similar to what was already done for loading index database entries in case of Dropbox with > 200,000 items.

The performance hit due to reduced caching has been mitigated with improvements to the ORM layer.

The reduced peak memory usage during indexing also has the advantage that pymalloc can do a more efficient job and we have less memory fragmentation over the lifetime of the process.