### PR TITLE
Scope loggers by config name

### DIFF
--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -539,7 +539,7 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
         MaestralProxy,
         start_maestral_daemon,
         start_maestral_daemon_process,
-        _wait_for_startup,
+        wait_for_startup,
         is_running,
         Start,
     )
@@ -552,7 +552,8 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
 
     def startup_dialog():
 
-        _wait_for_startup(config_name, timeout=5)
+        if wait_for_startup(config_name) is Start.Failed:
+            return
 
         m = MaestralProxy(config_name)
 

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -214,8 +214,8 @@ def check_for_fatal_errors(m: Union["MaestralProxy", "Maestral"]) -> bool:
 
 def convert_py_errors(func: Callable) -> Callable:
     """
-    Decorator that catches a MaestralApiError and prints it as a useful message to the
-    command line instead of printing the full stacktrace.
+    Decorator that catches a MaestralApiError and prints a formatted error message to
+    stdout before exiting.
     """
 
     from .errors import MaestralApiError
@@ -225,7 +225,8 @@ def convert_py_errors(func: Callable) -> Callable:
         try:
             return func(*args, **kwargs)
         except MaestralApiError as exc:
-            raise cli.CliException(f"{exc.title}. {exc.message}")
+            cli.warn(f"{exc.title}. {exc.message}")
+            sys.exit(1)
 
     return wrapper
 
@@ -550,6 +551,7 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
         click.echo("Daemon is already running.")
         return
 
+    @convert_py_errors
     def startup_dialog():
 
         if wait_for_startup(config_name) is Start.Failed:

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -601,11 +601,13 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
 
             cli.ok("Setup completed. Starting sync.")
 
+        m.start_sync()
+
     t = threading.Thread(target=startup_dialog)
     t.start()
 
     if foreground:
-        start_maestral_daemon(config_name, log_to_stderr=verbose, start_sync=True)
+        start_maestral_daemon(config_name, log_to_stderr=verbose)
     else:
         cli.echo("Starting Maestral...", nl=False)
 

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -528,7 +528,7 @@ existing_config_option = click.option(
     "-v",
     is_flag=True,
     default=False,
-    help="Print log messages to stdout when started with '-f, --foreground' flag.",
+    help="Print log messages to stderr.",
 )
 @config_option
 @convert_py_errors
@@ -605,7 +605,7 @@ def start(foreground: bool, verbose: bool, config_name: str) -> None:
     t.start()
 
     if foreground:
-        start_maestral_daemon(config_name, log_to_stdout=verbose, start_sync=True)
+        start_maestral_daemon(config_name, log_to_stderr=verbose, start_sync=True)
     else:
         cli.echo("Starting Maestral...", nl=False)
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -87,8 +87,6 @@ __all__ = [
 ]
 
 
-logger = logging.getLogger(__name__)
-
 # type definitions
 LocalError = Union[MaestralApiError, OSError]
 WriteErrorType = Type[
@@ -198,6 +196,8 @@ class DropboxClient:
 
         self.config_name = config_name
         self.auth = OAuth2Session(config_name)
+
+        self._logger = logging.getLogger(__name__)
 
         self._timeout = timeout
         self._session = session or create_session()
@@ -959,7 +959,7 @@ class DropboxClient:
 
         # Keep track of last longpoll, back off if requested by API.
         if res.backoff:
-            logger.debug("Backoff requested for %s sec", res.backoff)
+            self._logger.debug("Backoff requested for %s sec", res.backoff)
             self._backoff_until = time.time() + res.backoff + 5.0
         else:
             self._backoff_until = 0

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -4,7 +4,6 @@ This module contains the default configuration and state values and functions to
 existing config or state instances for a specified config_name.
 """
 
-import logging
 import threading
 from typing import Dict
 
@@ -13,8 +12,8 @@ from .base import get_conf_path, get_data_path
 from .user import UserConfig, DefaultsType
 
 
-logger = logging.getLogger(__name__)
 CONFIG_DIR_NAME = "maestral"
+
 
 # =============================================================================
 #  Defaults

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -418,8 +418,9 @@ def start_maestral_daemon(
     import asyncio
     from . import notify
     from .main import Maestral
-    from .logging import scoped_logger
+    from .logging import scoped_logger, setup_logging
 
+    setup_logging(config_name, log_to_stderr)
     dlogger = scoped_logger(__name__, config_name)
 
     if threading.current_thread() is not threading.main_thread():

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -449,27 +449,6 @@ def start_maestral_daemon(
 
         from rubicon.objc.eventloop import EventLoopPolicy  # type: ignore
 
-        # Clean up any pending tasks before we change the event loop policy.
-        # This is necessary if previous code has run an asyncio loop.
-
-        loop = asyncio.get_event_loop()
-        try:
-            # Python 3.7 and higher
-            all_tasks = asyncio.all_tasks(loop)
-        except AttributeError:
-            # Python 3.6
-            all_tasks = asyncio.Task.all_tasks(loop)
-        pending_tasks = [t for t in all_tasks if not t.done()]
-
-        for task in pending_tasks:
-            task.cancel()
-
-        loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
-        loop.close()
-
-        logger.debug("Integrating with CFEventLoop")
-
-        # Set new event loop policy.
         asyncio.set_event_loop_policy(EventLoopPolicy())
 
     # Get the default event loop.

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -432,7 +432,7 @@ def start_maestral_daemon(
     lock = maestral_lock(config_name)
 
     if lock.acquire():
-        dlogger.debug("Acquired daemon lock")
+        dlogger.debug("Acquired daemon lock: %s", lock.path)
     else:
         raise RuntimeError("Maestral daemon is already running")
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -400,7 +400,7 @@ def wait_for_startup(config_name: str, timeout: float = 5) -> None:
 
 
 def start_maestral_daemon(
-    config_name: str = "maestral", log_to_stdout: bool = False, start_sync: bool = False
+    config_name: str = "maestral", log_to_stderr: bool = False, start_sync: bool = False
 ) -> None:
     """
     Starts the Maestral daemon with event loop in the current thread. Startup is race
@@ -414,7 +414,7 @@ def start_maestral_daemon(
     use input such as clicked notifications, etc, and potentially allows showing a GUI.
 
     :param config_name: The name of the Maestral configuration to use.
-    :param log_to_stdout: If ``True``, write logs to stdout.
+    :param log_to_stderr: If ``True``, write logs to stderr.
     :param start_sync: If ``True``, start syncing once the daemon has started. If the
         ``start_sync`` call fails, an error will be logged but not raised.
     :raises RuntimeError: if a daemon for the given ``config_name`` is already running.
@@ -501,7 +501,7 @@ def start_maestral_daemon(
     ExposedMaestral.stop_sync = oneway(ExposedMaestral.stop_sync)
     ExposedMaestral.shutdown_daemon = oneway(ExposedMaestral.shutdown_daemon)
 
-    maestral_daemon = ExposedMaestral(config_name, log_to_stdout=log_to_stdout)
+    maestral_daemon = ExposedMaestral(config_name, log_to_stderr=log_to_stderr)
 
     if start_sync:
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -416,7 +416,6 @@ def start_maestral_daemon(
     """
 
     import asyncio
-    from . import notify
     from .main import Maestral
     from .logging import scoped_logger, setup_logging
 
@@ -501,13 +500,12 @@ def start_maestral_daemon(
 
     if start_sync:
 
+        dlogger.debug("Starting sync")
+
         try:
             maestral_daemon.start_sync()
-        except Exception as exc:
-            title = getattr(exc, "title", "Failed to start sync")
-            message = getattr(exc, "message", "Please inspect the logs")
-            dlogger.error(title, exc_info=True)
-            maestral_daemon.sync.notify(title, message, level=notify.ERROR)
+        except Exception:
+            dlogger.error("Could not start sync", exc_info=True)
 
     try:
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -51,6 +51,7 @@ __all__ = [
     "get_maestral_pid",
     "sockpath_for_config",
     "lockpath_for_config",
+    "wait_for_startup",
     "is_running",
     "freeze_support",
     "start_maestral_daemon",
@@ -367,7 +368,7 @@ def is_running(config_name: str) -> bool:
     return maestral_lock(config_name).locked()
 
 
-def _wait_for_startup(config_name: str, timeout: float) -> None:
+def wait_for_startup(config_name: str, timeout: float = 5) -> None:
     """
     Waits until we can communicate with the maestral daemon for ``config_name``.
 
@@ -596,7 +597,7 @@ def start_maestral_daemon_process(
     )
 
     try:
-        _wait_for_startup(config_name, timeout=timeout)
+        wait_for_startup(config_name)
     except Exception as exc:
         logger.debug("Could not communicate with daemon", exc_info_tuple(exc))
 

--- a/src/maestral/logging.py
+++ b/src/maestral/logging.py
@@ -55,12 +55,16 @@ class EncodingSafeLogRecord(logging.LogRecord):
     a :class:`UnicodeEncodeError` under many circumstances (printing to stdout, etc).
     """
 
+    _msg: Optional[str] = None
+
     def getMessage(self) -> str:
         """
         Formats the log message and replaces all surrogate escapes with "�".
         """
-        msg = super().getMessage()
-        return sanitize_string(msg)
+        if not self._msg:
+            self._msg = sanitize_string(super().getMessage())
+
+        return self._msg
 
 
 logging.setLogRecordFactory(EncodingSafeLogRecord)

--- a/src/maestral/logging.py
+++ b/src/maestral/logging.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """This module defines custom logging records and handlers."""
 
-import logging
-from collections import deque
+import os
 import concurrent.futures
+import logging
+from logging.handlers import RotatingFileHandler
+from collections import deque
 from concurrent.futures import Future
-from typing import Deque, Optional, List
+from typing import Deque, Optional, List, Tuple, Union
 
 try:
     from concurrent.futures import InvalidStateError  # type: ignore
@@ -20,21 +22,21 @@ try:
 except ImportError:
     journal = None
 
+from .config import MaestralConfig
 from .utils import sanitize_string
+from .utils.appdirs import get_log_path
 
 
 __all__ = [
-    "EncodingSafeLogRecord",
     "CachedHandler",
-    "SdNotificationHandler",
-    "safe_journal_sender",
+    "setup_logging",
     "scoped_logger",
 ]
 
 
-if journal:
+def safe_journal_sender(MESSAGE: str, **kwargs) -> None:
 
-    def safe_journal_sender(MESSAGE: str, **kwargs) -> None:
+    if journal:
 
         MESSAGE = sanitize_string(MESSAGE)
 
@@ -43,12 +45,6 @@ if journal:
                 kwargs[key] = sanitize_string(value)
 
         journal.send(MESSAGE, **kwargs)
-
-
-else:
-
-    def safe_journal_sender(MESSAGE: str, **kwargs) -> None:
-        pass
 
 
 class EncodingSafeLogRecord(logging.LogRecord):
@@ -187,3 +183,93 @@ def scoped_logger(module_name: str, config_name: str = "maestral") -> logging.Lo
     """
 
     return logging.getLogger(scoped_logger_name(module_name, config_name))
+
+
+def setup_logging(
+    config_name: str, log_to_stderr: bool = True
+) -> Tuple[
+    RotatingFileHandler,
+    Union[logging.StreamHandler, logging.NullHandler],
+    SdNotificationHandler,
+    Union["journal.JournalHandler", logging.NullHandler],
+]:
+    """
+    Sets up logging handlers for the given config name. The following handlers are
+    installed for the root logger:
+
+    * RotatingFileHandler: Writes logs to the appropriate log file for the config. Log
+      level is determined by the config value.
+    * StreamHandler: Writes logs to stderr. Log level is determined by the config value.
+      This will be replaced by a null handler if ``log_to_stderr`` is ``False``.
+    * SdNotificationHandler: Sends all log messages of level INFO and higher to the
+      NOTIFY_SOCKET if provided as an environment variable. The log level is fixed.
+    * JournalHandler: Writes logs to the systemd journal. Log level is determined by the
+      config value. Will be replaced by a null handler if not started as a systemd
+      service or if python-systemd is not installed.
+
+    Any previous loggers are cleared.
+
+    :param config_name: The config name.
+    :param log_to_stderr: Whether to log to stderr.
+    :returns: (log_handler_file, log_handler_stream, log_handler_sd, log_handler_journal)
+    """
+
+    conf = MaestralConfig(config_name)
+
+    # Get log level from config or fallback to DEBUG level if config file is corrupt.
+    log_level = conf.get("app", "log_level", logging.DEBUG)
+
+    root_logger = scoped_logger("maestral", config_name)
+    root_logger.setLevel(min(log_level, logging.INFO))
+
+    root_logger.handlers = []  # clean up any previous handlers
+
+    log_fmt_long = logging.Formatter(
+        fmt="%(asctime)s %(module)s %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    log_fmt_short = logging.Formatter(fmt="%(message)s")
+
+    # Log to file.
+    log_file_path = get_log_path("maestral", f"{config_name}.log")
+    log_handler_file = RotatingFileHandler(
+        log_file_path, maxBytes=10 ** 7, backupCount=1
+    )
+    log_handler_file.setFormatter(log_fmt_long)
+    log_handler_file.setLevel(log_level)
+    root_logger.addHandler(log_handler_file)
+
+    # Log to systemd journal when running as systemd service.
+    log_handler_journal: Union["journal.JournalHandler", logging.NullHandler]
+
+    if journal and os.getenv("INVOCATION_ID"):
+        log_handler_journal = journal.JournalHandler(
+            SYSLOG_IDENTIFIER="maestral",
+            sender_function=safe_journal_sender,
+        )
+    else:
+        log_handler_journal = logging.NullHandler()
+
+    log_handler_journal.setFormatter(log_fmt_short)
+    log_handler_journal.setLevel(log_level)
+    root_logger.addHandler(log_handler_journal)
+
+    # Log to NOTIFY_SOCKET when launched as systemd notify service.
+    log_handler_sd = SdNotificationHandler()
+    log_handler_sd.setFormatter(log_fmt_short)
+    log_handler_sd.setLevel(logging.INFO)
+    root_logger.addHandler(log_handler_sd)
+
+    # Log to stderr if requested.
+
+    log_handler_stream: Union[logging.StreamHandler, logging.NullHandler]
+
+    if log_to_stderr:
+        log_handler_stream = logging.StreamHandler()
+    else:
+        log_handler_stream = logging.NullHandler()
+    log_handler_stream.setFormatter(log_fmt_long)
+    log_handler_stream.setLevel(log_level)
+    root_logger.addHandler(log_handler_stream)
+
+    return log_handler_file, log_handler_stream, log_handler_sd, log_handler_journal

--- a/src/maestral/logging.py
+++ b/src/maestral/logging.py
@@ -28,6 +28,7 @@ __all__ = [
     "CachedHandler",
     "SdNotificationHandler",
     "safe_journal_sender",
+    "scoped_logger",
 ]
 
 
@@ -159,3 +160,30 @@ class SdNotificationHandler(logging.Handler):
         :param record: Log record.
         """
         self.notifier.notify(f"STATUS={record.message}")
+
+
+def scoped_logger_name(module_name: str, config_name: str = "maestral") -> str:
+    """
+    Returns a logger name for the module ``module_name``, scoped to the given config.
+
+    :param module_name: Module name.
+    :param config_name: Config name.
+    :returns: Scoped logger name.
+    """
+
+    if config_name == "maestral":
+        return module_name
+    else:
+        return f"{config_name}-{module_name}"
+
+
+def scoped_logger(module_name: str, config_name: str = "maestral") -> logging.Logger:
+    """
+    Returns a logger for the module ``module_name``, scoped to the given config.
+
+    :param module_name: Module name.
+    :param config_name: Config name.
+    :returns: Logger instances scoped to the config.
+    """
+
+    return logging.getLogger(scoped_logger_name(module_name, config_name))

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -108,13 +108,13 @@ class Maestral:
 
     :param config_name: Name of maestral configuration to run. Must not contain any
         whitespace. If the given config file does exist, it will be created.
-    :param log_to_stdout: If ``True``, Maestral will print log messages to stdout.
-        When started as a systemd services, this can result in duplicate log messages.
-        Defaults to ``False``.
+    :param log_to_stderr: If ``True``, Maestral will print log messages to stderr.
+        When started as a systemd services, this can result in duplicate log messages
+        in the systemd journal. Defaults to ``False``.
     """
 
     def __init__(
-        self, config_name: str = "maestral", log_to_stdout: bool = False
+        self, config_name: str = "maestral", log_to_stderr: bool = False
     ) -> None:
 
         self._config_name = validate_config_name(config_name)
@@ -123,7 +123,7 @@ class Maestral:
 
         # set up logging
         self._logger = scoped_logger(__name__, config_name)
-        self._log_to_stdout = log_to_stdout
+        self._log_to_stderr = log_to_stderr
         self._setup_logging()
 
         # set up sync infrastructure
@@ -218,7 +218,7 @@ class Maestral:
     def _setup_logging(self) -> None:
         """
         Sets up logging to log files, status and error properties, desktop notifications,
-        the systemd journal if available, and to stdout if requested.
+        the systemd journal if available, and to stderr if requested.
         """
         self._root_logger = scoped_logger("maestral", self.config_name)
         (
@@ -226,7 +226,7 @@ class Maestral:
             self._log_handler_stream,
             self._log_handler_sd,
             self._log_handler_journal,
-        ) = setup_logging(self.config_name, log_to_stderr=self._log_to_stdout)
+        ) = setup_logging(self.config_name, self._log_to_stderr)
 
         log_fmt_short = logging.Formatter(fmt="%(message)s")
 
@@ -369,7 +369,7 @@ class Maestral:
 
     @property
     def log_level(self) -> int:
-        """Log level for log files, stdout and the systemd journal."""
+        """Log level for log files, stderr and the systemd journal."""
         return self._conf.get("app", "log_level")
 
     @log_level.setter

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -56,7 +56,12 @@ from .errors import (
     UnsupportedFileTypeForDiff,
 )
 from .config import MaestralConfig, MaestralState, validate_config_name
-from .logging import CachedHandler, SdNotificationHandler, safe_journal_sender
+from .logging import (
+    CachedHandler,
+    SdNotificationHandler,
+    safe_journal_sender,
+    scoped_logger,
+)
 from .utils import get_newer_version
 from .utils.path import (
     is_child,
@@ -77,9 +82,6 @@ from .constants import IDLE, PAUSED, CONNECTING, FileStatus, GITHUB_RELEASES_API
 
 
 __all__ = ["Maestral"]
-
-
-logger = logging.getLogger(__name__)
 
 
 # ======================================================================================
@@ -134,6 +136,7 @@ class Maestral:
         self._state = MaestralState(self._config_name)
 
         # set up logging
+        self._logger = scoped_logger(__name__, config_name)
         self._log_to_stdout = log_to_stdout
         self._setup_logging()
 
@@ -209,12 +212,12 @@ class Maestral:
         try:
             self.client.dbx.auth_token_revoke()
         except (ConnectionError, MaestralApiError):
-            logger.debug("Could not invalidate token with Dropbox", exc_info=True)
+            self._logger.debug("Could not invalidate token with Dropbox", exc_info=True)
 
         try:
             self.client.auth.delete_creds()
         except KeyringAccessError:
-            logger.debug("Could not remove token from keyring", exc_info=True)
+            self._logger.debug("Could not remove token from keyring", exc_info=True)
 
         # clean up config + state
         self.sync.clear_index()
@@ -224,7 +227,7 @@ class Maestral:
         self.sync._load_cached_config()  # reload cached config values
         delete(self.sync.database_path)
 
-        logger.info("Unlinked Dropbox account.")
+        self._logger.info("Unlinked Dropbox account.")
 
     def _setup_logging(self) -> None:
         """
@@ -232,15 +235,14 @@ class Maestral:
         the systemd journal if available, and to stdout if requested.
         """
 
-        self._logger = logging.getLogger("maestral")
-        self._logger.setLevel(min(self.log_level, logging.INFO))
+        self._root_logger = scoped_logger("maestral", self.config_name)
+        self._root_logger.setLevel(min(self.log_level, logging.INFO))
 
         # clean up any previous handlers
-        # TODO: use namespaced handlers for config?
-        self._logger.handlers = []
+        self._root_logger.handlers = []
 
         log_fmt_long = logging.Formatter(
-            fmt="%(asctime)s %(name)s %(levelname)s: %(message)s",
+            fmt="%(asctime)s %(module)s %(levelname)s: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
         log_fmt_short = logging.Formatter(fmt="%(message)s")
@@ -248,13 +250,11 @@ class Maestral:
         # log to file
         log_file_path = get_log_path("maestral", f"{self._config_name }.log")
         self.log_handler_file = logging.handlers.RotatingFileHandler(
-            log_file_path,
-            maxBytes=10 ** 7,
-            backupCount=1,
+            log_file_path, maxBytes=10 ** 7, backupCount=1
         )
         self.log_handler_file.setFormatter(log_fmt_long)
         self.log_handler_file.setLevel(self.log_level)
-        self._logger.addHandler(self.log_handler_file)
+        self._root_logger.addHandler(self.log_handler_file)
 
         # log to journal when launched from systemd
         if journal and os.getenv("INVOCATION_ID"):
@@ -264,7 +264,7 @@ class Maestral:
             )
             self.log_handler_journal.setFormatter(log_fmt_short)
             self.log_handler_journal.setLevel(self.log_level)
-            self._logger.addHandler(self.log_handler_journal)
+            self._root_logger.addHandler(self.log_handler_journal)
         else:
             self.log_handler_journal = None
 
@@ -273,7 +273,7 @@ class Maestral:
             self.log_handler_sd = SdNotificationHandler()
             self.log_handler_sd.setFormatter(log_fmt_short)
             self.log_handler_sd.setLevel(logging.INFO)
-            self._logger.addHandler(self.log_handler_sd)
+            self._root_logger.addHandler(self.log_handler_sd)
         else:
             self.log_handler_sd = None
 
@@ -282,18 +282,18 @@ class Maestral:
         self.log_handler_stream = logging.StreamHandler(sys.stderr)
         self.log_handler_stream.setFormatter(log_fmt_long)
         self.log_handler_stream.setLevel(level)
-        self._logger.addHandler(self.log_handler_stream)
+        self._root_logger.addHandler(self.log_handler_stream)
 
         # log to cached handlers for status and error APIs
         self._log_handler_info_cache = CachedHandler(maxlen=1)
         self._log_handler_info_cache.setFormatter(log_fmt_short)
         self._log_handler_info_cache.setLevel(logging.INFO)
-        self._logger.addHandler(self._log_handler_info_cache)
+        self._root_logger.addHandler(self._log_handler_info_cache)
 
         self._log_handler_error_cache = CachedHandler()
         self._log_handler_error_cache.setFormatter(log_fmt_short)
         self._log_handler_error_cache.setLevel(logging.ERROR)
-        self._logger.addHandler(self._log_handler_error_cache)
+        self._root_logger.addHandler(self._log_handler_error_cache)
 
     # ==== methods to access config and saved state ====================================
 
@@ -403,15 +403,15 @@ class Maestral:
 
                     # apply changes
                     for path in added_excluded_items:
-                        logger.info("Excluded %s", path)
+                        self._logger.info("Excluded %s", path)
                         self._remove_after_excluded(path)
 
                     for path in added_included_items:
                         if not self.sync.is_excluded_by_user(path):
-                            logger.info("Included %s", path)
+                            self._logger.info("Included %s", path)
                             self.monitor.added_item_queue.put(path)
 
-                    logger.info(IDLE)
+                    self._logger.info(IDLE)
 
                 finally:
                     self.sync.sync_lock.release()
@@ -429,7 +429,7 @@ class Maestral:
     @log_level.setter
     def log_level(self, level_num: int) -> None:
         """Setter: log_level."""
-        self._logger.setLevel(min(level_num, logging.INFO))
+        self._root_logger.setLevel(min(level_num, logging.INFO))
         self.log_handler_file.setLevel(level_num)
         if self.log_handler_journal:
             self.log_handler_journal.setLevel(level_num)
@@ -941,7 +941,7 @@ class Maestral:
 
         self._check_linked()
 
-        logger.info(f"Restoring '{dbx_path} to {rev}'")
+        self._logger.info(f"Restoring '{dbx_path} to {rev}'")
 
         res = self.client.restore(dbx_path, rev)
         return dropbox_stone_to_dict(res)
@@ -1042,8 +1042,8 @@ class Maestral:
             )
 
         if self.sync.is_excluded_by_user(dbx_path):
-            logger.info("%s was already excluded", dbx_path)
-            logger.info(IDLE)
+            self._logger.info("%s was already excluded", dbx_path)
+            self._logger.info(IDLE)
             return
 
         if self.sync.sync_lock.acquire(blocking=False):
@@ -1061,8 +1061,8 @@ class Maestral:
 
                 self._remove_after_excluded(dbx_path)
 
-                logger.info("Excluded %s", dbx_path)
-                logger.info(IDLE)
+                self._logger.info("Excluded %s", dbx_path)
+                self._logger.info(IDLE)
             finally:
                 self.sync.sync_lock.release()
 
@@ -1126,8 +1126,8 @@ class Maestral:
             )
 
         if not self.sync.is_excluded_by_user(dbx_path):
-            logger.info("'%s' is already included, nothing to do", dbx_path)
-            logger.info(IDLE)
+            self._logger.info("'%s' is already included, nothing to do", dbx_path)
+            self._logger.info(IDLE)
             return
 
         # ---- update excluded items list ----------------------------------------------
@@ -1169,10 +1169,10 @@ class Maestral:
                 # ---- download item from Dropbox --------------------------------------
 
                 if excluded_parent:
-                    logger.info("Included '%s' and parent directories", dbx_path)
+                    self._logger.info("Included '%s' and parent directories", dbx_path)
                     self.monitor.added_item_queue.put(excluded_parent)
                 else:
-                    logger.info("Included '%s'", dbx_path)
+                    self._logger.info("Included '%s'", dbx_path)
                     self.monitor.added_item_queue.put(dbx_path)
             finally:
                 self.sync.sync_lock.release()
@@ -1216,7 +1216,7 @@ class Maestral:
         self._check_linked()
         self._check_dropbox_dir()
 
-        logger.info("Moving Dropbox folder...")
+        self._logger.info("Moving Dropbox folder...")
 
         # input checks
         old_path = self.sync.dropbox_path
@@ -1224,7 +1224,7 @@ class Maestral:
 
         try:
             if osp.samefile(old_path, new_path):
-                logger.info(f'Dropbox folder moved to "{new_path}"')
+                self._logger.info(f'Dropbox folder moved to "{new_path}"')
                 return
         except FileNotFoundError:
             pass
@@ -1245,7 +1245,7 @@ class Maestral:
         # update config file and client
         self.sync.dropbox_path = new_path
 
-        logger.info(f'Dropbox folder moved to "{new_path}"')
+        self._logger.info(f'Dropbox folder moved to "{new_path}"')
 
         # resume syncing
         if was_syncing:
@@ -1493,7 +1493,7 @@ class Maestral:
     def _update_from_pre_v1_3_2(self) -> None:
 
         if self._conf.get("app", "keyring") == "keyring.backends.OS_X.Keyring":
-            logger.info("Migrating keyring after update from pre v1.3.2")
+            self._logger.info("Migrating keyring after update from pre v1.3.2")
             self._conf.set("app", "keyring", "keyring.backends.macOS.Keyring")
 
     # ==== period async jobs ===========================================================

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -309,29 +309,6 @@ class SyncMonitor:
 
         self._logger.info(PAUSED)
 
-    def connection_monitor(self) -> None:
-        """
-        Monitors the connection to Dropbox servers. Pauses syncing when the connection
-        is lost and resumes syncing when reconnected and syncing has not been paused by
-        the user.
-        """
-
-        while self._connection_helper_running:
-
-            connected = check_connection("www.dropbox.com")
-
-            if connected != self.connected:
-                # Log the status change.
-                self._logger.info(CONNECTED if connected else CONNECTING)
-
-            if connected:
-                if not self.running.is_set() and self.autostart.is_set():
-                    self.start()
-
-            self.connected = connected
-
-            time.sleep(self.connection_check_interval)
-
     def reset_sync_state(self) -> None:
         """Resets all saved sync state. Settings are not affected."""
 
@@ -363,6 +340,29 @@ class SyncMonitor:
             self.start()
 
     # ---- thread methods --------------------------------------------------------------
+
+    def connection_monitor(self) -> None:
+        """
+        Monitors the connection to Dropbox servers. Pauses syncing when the connection
+        is lost and resumes syncing when reconnected and syncing has not been paused by
+        the user.
+        """
+
+        while self._connection_helper_running:
+
+            connected = check_connection("www.dropbox.com")
+
+            if connected != self.connected:
+                # Log the status change.
+                self._logger.info(CONNECTED if connected else CONNECTING)
+
+            if connected:
+                if not self.running.is_set() and self.autostart.is_set():
+                    self.start()
+
+            self.connected = connected
+
+            time.sleep(self.connection_check_interval)
 
     def download_worker(
         self,

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -36,9 +36,8 @@ from typing import (
 
 # external imports
 import click
-import dropbox  # type: ignore
 from pathspec import PathSpec
-from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata  # type: ignore
+from dropbox.files import Metadata, DeletedMetadata, FileMetadata, FolderMetadata, WriteMode, ListFolderResult  # type: ignore
 from watchdog.events import FileSystemEventHandler  # type: ignore
 from watchdog.events import (
     EVENT_TYPE_CREATED,
@@ -2329,10 +2328,10 @@ class SyncEngine:
 
             if not local_entry:
                 # file is new to us, let Dropbox rename it if something is in the way
-                mode = dropbox.files.WriteMode.add
+                mode = WriteMode.add
             elif local_entry.is_directory:
                 # try to overwrite the destination, this will fail...
-                mode = dropbox.files.WriteMode.overwrite
+                mode = WriteMode.overwrite
             else:
                 # file has been modified, update remote if matching rev,
                 # create conflict otherwise
@@ -2341,7 +2340,7 @@ class SyncEngine:
                     "already tracking it",
                     event.dbx_path,
                 )
-                mode = dropbox.files.WriteMode.update(local_entry.rev)
+                mode = WriteMode.update(local_entry.rev)
             try:
                 md_new = client.upload(
                     event.local_path,
@@ -2423,11 +2422,11 @@ class SyncEngine:
                 '"%s" appears to have been modified but cannot ' "find old revision",
                 event.dbx_path,
             )
-            mode = dropbox.files.WriteMode.add
+            mode = WriteMode.add
         elif local_entry.is_directory:
-            mode = dropbox.files.WriteMode.overwrite
+            mode = WriteMode.overwrite
         else:
-            mode = dropbox.files.WriteMode.update(local_entry.rev)
+            mode = WriteMode.update(local_entry.rev)
 
         try:
             md_new = client.upload(
@@ -3155,9 +3154,7 @@ class SyncEngine:
         except (FileNotFoundError, NotADirectoryError):
             return -1.0
 
-    def _clean_remote_changes(
-        self, changes: dropbox.files.ListFolderResult
-    ) -> dropbox.files.ListFolderResult:
+    def _clean_remote_changes(self, changes: ListFolderResult) -> ListFolderResult:
         """
         Takes remote file events since last sync and cleans them up so that there is
         only a single event per path.

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1553,8 +1553,6 @@ class SyncEngine:
             try:
                 events, local_cursor = self._get_local_changes_while_inactive()
 
-                self._logger.debug("Retrieved fsevents:\n%s", pf_repr(events))
-
                 events = self._clean_local_events(events)
                 sync_events = [
                     SyncEvent.from_file_system_event(e, self) for e in events
@@ -1653,6 +1651,8 @@ class SyncEngine:
             "Local indexing completed in %s sec", time.time() - snapshot_time
         )
 
+        self._logger.debug("Retrieved local changes:\n%s", pf_repr(changes))
+
         return changes, snapshot_time
 
     def wait_for_local_changes(self, timeout: float = 40) -> bool:
@@ -1714,7 +1714,7 @@ class SyncEngine:
             except Empty:
                 break
 
-        self._logger.debug("Retrieved fsevents:\n%s", pf_repr(events))
+        self._logger.debug("Retrieved local file events:\n%s", pf_repr(events))
 
         events = self._clean_local_events(events)
         sync_events = [SyncEvent.from_file_system_event(e, self) for e in events]
@@ -2002,8 +2002,6 @@ class SyncEngine:
 
             for split_events in child_deleted_events.values():
                 cleaned_events.difference_update(split_events)
-
-        self._logger.debug("Cleaned up fsevents:\n%s", pf_repr(cleaned_events))
 
         return list(cleaned_events)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -6,13 +6,13 @@ import sys
 import os
 import os.path as osp
 from stat import S_ISDIR
-import logging
 import time
 import random
 import uuid
 import urllib.parse
 import enum
 import sqlite3
+import logging
 from pprint import pformat
 from threading import Event, Condition, RLock, current_thread
 from concurrent.futures import ThreadPoolExecutor
@@ -94,6 +94,7 @@ from .database import (
     ItemType,
     ChangeType,
 )
+from .logging import scoped_logger
 from .utils import removeprefix, sanitize_string, exc_info_tuple
 from .utils.caches import LRUCache
 from .utils.integration import (
@@ -128,9 +129,6 @@ __all__ = [
     "HashCacheEntry",
     "SyncEngine",
 ]
-
-
-logger = logging.getLogger(__name__)
 
 umask = os.umask(0o22)
 os.umask(umask)
@@ -479,6 +477,7 @@ class SyncEngine:
         self.client = client
         self.config_name = self.client.config_name
         self.fs_events = FSEventHandler()
+        self._logger = scoped_logger(__name__, self.config_name)
 
         self.sync_lock = RLock()
         self._db_lock = RLock()
@@ -651,7 +650,7 @@ class SyncEngine:
         with self.sync_lock:
             self._state.set("sync", "cursor", cursor)
 
-        logger.debug("Remote cursor saved: %s", cursor)
+        self._logger.debug("Remote cursor saved: %s", cursor)
 
     @property
     def local_cursor(self) -> float:
@@ -666,7 +665,7 @@ class SyncEngine:
             self._local_cursor = last_sync
             self._state.set("sync", "lastsync", last_sync)
 
-        logger.debug("Local cursor saved: %s", last_sync)
+        self._logger.debug("Local cursor saved: %s", last_sync)
 
     @property
     def last_change(self) -> float:
@@ -718,7 +717,7 @@ class SyncEngine:
         self.clear_index()
         self.clear_sync_history()
 
-        logger.debug("Sync state reset")
+        self._logger.debug("Sync state reset")
 
     # ==== index management ============================================================
 
@@ -1046,7 +1045,7 @@ class SyncEngine:
             with open(self.mignore_path) as f:
                 spec = f.read()
         except OSError as err:
-            logger.debug(
+            self._logger.debug(
                 f"Could not load mignore rules from {self.mignore_path}: {err}"
             )
             spec = ""
@@ -1134,7 +1133,7 @@ class SyncEngine:
                 except OSError as exc:
                     # Can occur on file system's that don't support POSIX permissions
                     # such as NTFS mounted without the permissions option.
-                    logger.debug("Cannot set permissions: errno %s", exc.errno)
+                    self._logger.debug("Cannot set permissions: errno %s", exc.errno)
                 return f.name
         except OSError as err:
             raise CacheDirError(
@@ -1401,12 +1400,14 @@ class SyncEngine:
         if cpu_usage > self._max_cpu_percent:
 
             thread_name = current_thread().name
-            logger.debug(f"{thread_name}: {cpu_usage}% CPU usage - throttling")
+            self._logger.debug(f"{thread_name}: {cpu_usage}% CPU usage - throttling")
 
             while cpu_usage > self._max_cpu_percent:
                 cpu_usage = cpu_usage_percent(0.5 + 2 * random.random())
 
-            logger.debug(f"{thread_name}: {cpu_usage}% CPU usage - end throttling")
+            self._logger.debug(
+                f"{thread_name}: {cpu_usage}% CPU usage - end throttling"
+            )
 
     def cancel_sync(self) -> None:
         """
@@ -1421,7 +1422,7 @@ class SyncEngine:
 
         self._cancel_requested.clear()
 
-        logger.info("Sync aborted")
+        self._logger.info("Sync aborted")
 
     def busy(self) -> bool:
         """
@@ -1462,7 +1463,7 @@ class SyncEngine:
             # use sanitised path so that the error can be printed to the terminal, etc
             file_name = sanitize_string(osp.basename(err.dbx_path))
 
-            logger.info("Could not sync %s", file_name, exc_info=True)
+            self._logger.info("Could not sync %s", file_name, exc_info=True)
 
             def callback():
                 if err.local_path:
@@ -1525,7 +1526,7 @@ class SyncEngine:
 
         if new_exc:
             if log_errors:
-                logger.error(title, exc_info=exc_info_tuple(new_exc))
+                self._logger.error(title, exc_info=exc_info_tuple(new_exc))
                 self.notifier.notify(title, msg, level=notify.ERROR)
             else:
                 raise new_exc
@@ -1548,13 +1549,13 @@ class SyncEngine:
 
         with self.sync_lock:
 
-            logger.info("Indexing local changes...")
+            self._logger.info("Indexing local changes...")
 
             try:
                 events, local_cursor = self._get_local_changes_while_inactive()
 
-                if logger.getEffectiveLevel() <= logging.DEBUG:
-                    logger.debug("Retrieved local changes:\n%s", pformat(events))
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug("Retrieved fsevents:\n%s", pformat(events))
 
                 events = self._clean_local_events(events)
                 sync_events = [
@@ -1566,9 +1567,9 @@ class SyncEngine:
 
             if len(sync_events) > 0:
                 self.apply_local_changes(sync_events)
-                logger.debug("Uploaded local changes while inactive")
+                self._logger.debug("Uploaded local changes while inactive")
             else:
-                logger.debug("No local changes while inactive")
+                self._logger.debug("No local changes while inactive")
 
             self.local_cursor = local_cursor
 
@@ -1650,7 +1651,9 @@ class SyncEngine:
                     event = FileDeletedEvent(local_path)
                 changes.append(event)
 
-        logger.debug("Local indexing completed in %s sec", time.time() - snapshot_time)
+        self._logger.debug(
+            "Local indexing completed in %s sec", time.time() - snapshot_time
+        )
 
         return changes, snapshot_time
 
@@ -1662,7 +1665,9 @@ class SyncEngine:
         :returns: ``True`` if changes are available, ``False`` otherwise.
         """
 
-        logger.debug("Waiting for local changes since cursor: %s", self.local_cursor)
+        self._logger.debug(
+            "Waiting for local changes since cursor: %s", self.local_cursor
+        )
 
         return self.fs_events.wait_for_event(timeout)
 
@@ -1711,8 +1716,8 @@ class SyncEngine:
             except Empty:
                 break
 
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug("Retrieved local file events:\n%s", pformat(events))
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug("Retrieved fsevents:\n%s", pformat(events))
 
         events = self._clean_local_events(events)
         sync_events = [SyncEvent.from_file_system_event(e, self) for e in events]
@@ -1752,7 +1757,7 @@ class SyncEngine:
         # apply deleted events first, folder moved events second
         # neither event type requires an actual upload
         if deleted:
-            logger.info("Uploading deletions...")
+            self._logger.info("Uploading deletions...")
 
         with ThreadPoolExecutor(
             max_workers=self._num_threads,
@@ -1762,14 +1767,14 @@ class SyncEngine:
 
             n_items = len(deleted)
             for n, r in enumerate(res):
-                throttled_log(logger, f"Deleting {n + 1}/{n_items}...")
+                throttled_log(self._logger, f"Deleting {n + 1}/{n_items}...")
                 results.append(r)
 
         if dir_moved:
-            logger.info("Moving folders...")
+            self._logger.info("Moving folders...")
 
         for event in dir_moved:
-            logger.info(f"Moving {event.dbx_path_from}...")
+            self._logger.info(f"Moving {event.dbx_path_from}...")
             r = self._create_remote_entry(event)
             results.append(r)
 
@@ -1782,7 +1787,7 @@ class SyncEngine:
 
             n_items = len(other)
             for n, r in enumerate(res):
-                throttled_log(logger, f"Syncing ↑ {n + 1}/{n_items}")
+                throttled_log(self._logger, f"Syncing ↑ {n + 1}/{n_items}")
                 results.append(r)
 
         self._clean_history()
@@ -1814,8 +1819,8 @@ class SyncEngine:
             else:
                 events_filtered.append(event)
 
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug("Filtered local file events:\n%s", pformat(events_filtered))
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug("Filtered fsevents:\n%s", pformat(events_filtered))
 
         return events_filtered, events_excluded
 
@@ -2002,8 +2007,8 @@ class SyncEngine:
             for split_events in child_deleted_events.values():
                 cleaned_events.difference_update(split_events)
 
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            logger.debug("Cleaned up local file events:\n%s", pformat(cleaned_events))
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug("Cleaned up fsevents:\n%s", pformat(cleaned_events))
 
         return list(cleaned_events)
 
@@ -2064,7 +2069,7 @@ class SyncEngine:
 
                 self.rescan(local_path_cc)
 
-            logger.info(
+            self._logger.info(
                 'Case conflict: renamed "%s" to "%s"', event.local_path, local_path_cc
             )
 
@@ -2098,7 +2103,7 @@ class SyncEngine:
 
                 self.rescan(local_path_cc)
 
-            logger.info(
+            self._logger.info(
                 'Selective sync conflict: renamed "%s" to "%s"',
                 event.local_path,
                 local_path_cc,
@@ -2245,7 +2250,7 @@ class SyncEngine:
             # will force conflict resolution on download in case of intermittent
             # changes.
             self.remove_node_from_index(event.dbx_path)
-            logger.info(
+            self._logger.info(
                 'Upload conflict: renamed "%s" to "%s"',
                 event.dbx_path,
                 md_to_new.path_display,
@@ -2253,7 +2258,9 @@ class SyncEngine:
 
         else:
             self._update_index_recursive(md_to_new, client)
-            logger.debug('Moved "%s" to "%s" on Dropbox', dbx_path_from, event.dbx_path)
+            self._logger.debug(
+                'Moved "%s" to "%s" on Dropbox', dbx_path_from, event.dbx_path
+            )
 
         return md_to_new
 
@@ -2295,7 +2302,7 @@ class SyncEngine:
             try:
                 md_new = client.make_dir(event.dbx_path, autorename=False)
             except FolderConflictError:
-                logger.debug(
+                self._logger.debug(
                     'No conflict for "%s": the folder already exists', event.local_path
                 )
                 try:
@@ -2329,7 +2336,7 @@ class SyncEngine:
             else:
                 # file has been modified, update remote if matching rev,
                 # create conflict otherwise
-                logger.debug(
+                self._logger.debug(
                     '"%s" appears to have been created but we are '
                     "already tracking it",
                     event.dbx_path,
@@ -2344,7 +2351,7 @@ class SyncEngine:
                     sync_event=event,
                 )
             except NotFoundError:
-                logger.debug(
+                self._logger.debug(
                     'Could not upload "%s": the item does not exist', event.local_path
                 )
                 return None
@@ -2363,7 +2370,7 @@ class SyncEngine:
             # will force conflict resolution on download in case of intermittent
             # changes.
             self.remove_node_from_index(event.dbx_path)
-            logger.debug(
+            self._logger.debug(
                 'Upload conflict: renamed "%s" to "%s"',
                 event.dbx_path,
                 md_new.path_lower,
@@ -2371,7 +2378,7 @@ class SyncEngine:
         else:
             # everything went well, update index
             self.update_index_from_dbx_metadata(md_new, client)
-            logger.debug('Created "%s" on Dropbox', event.dbx_path)
+            self._logger.debug('Created "%s" on Dropbox', event.dbx_path)
 
         return md_new
 
@@ -2402,7 +2409,7 @@ class SyncEngine:
             if event.content_hash == md_old.content_hash:
                 # file hashes are identical, do not upload
                 self.update_index_from_dbx_metadata(md_old, client)
-                logger.debug(
+                self._logger.debug(
                     'Modification of "%s" detected but file content is '
                     "the same as on Dropbox",
                     event.dbx_path,
@@ -2412,7 +2419,7 @@ class SyncEngine:
         local_entry = self.get_index_entry(event.dbx_path)
 
         if not local_entry:
-            logger.debug(
+            self._logger.debug(
                 '"%s" appears to have been modified but cannot ' "find old revision",
                 event.dbx_path,
             )
@@ -2431,7 +2438,7 @@ class SyncEngine:
                 sync_event=event,
             )
         except NotFoundError:
-            logger.debug(
+            self._logger.debug(
                 'Could not upload "%s": the item does not exist', event.dbx_path
             )
             return None
@@ -2449,7 +2456,7 @@ class SyncEngine:
             # Delete revs of old path but don't set revs for new path here. This will
             # force conflict resolution on download in case of intermittent changes.
             self.remove_node_from_index(event.dbx_path)
-            logger.debug(
+            self._logger.debug(
                 'Upload conflict: renamed "%s" to "%s"',
                 event.dbx_path,
                 md_new.path_lower,
@@ -2457,7 +2464,7 @@ class SyncEngine:
         else:
             # everything went well, save new revs
             self.update_index_from_dbx_metadata(md_new, client)
-            logger.debug('Uploaded modified "%s" to Dropbox', md_new.path_lower)
+            self._logger.debug('Uploaded modified "%s" to Dropbox', md_new.path_lower)
 
         return md_new
 
@@ -2481,7 +2488,7 @@ class SyncEngine:
             self.ensure_dropbox_folder_present()
 
         if self.is_excluded_by_user(event.dbx_path):
-            logger.debug(
+            self._logger.debug(
                 'Not deleting "%s": is excluded by selective sync', event.dbx_path
             )
             return None
@@ -2491,14 +2498,14 @@ class SyncEngine:
         md = client.get_metadata(event.dbx_path, include_deleted=True)
 
         if event.is_directory and isinstance(md, FileMetadata):
-            logger.debug(
+            self._logger.debug(
                 'Expected folder at "%s" but found a file instead, checking '
                 "which one is newer",
                 md.path_display,
             )
             # don't delete a remote file if it was modified since last sync
             if md.server_modified.timestamp() >= self.get_last_sync(event.dbx_path):
-                logger.debug(
+                self._logger.debug(
                     'Skipping deletion: remote item "%s" has been modified '
                     "since last sync",
                     md.path_display,
@@ -2512,7 +2519,7 @@ class SyncEngine:
             # TODO: Delete the folder if its children did not change since last sync.
             #   Is there a way of achieving this without listing the folder or listing
             #   all changes and checking when they occurred?
-            logger.debug(
+            self._logger.debug(
                 'Skipping deletion: expected file at "%s" but found a '
                 "folder instead",
                 md.path_display,
@@ -2527,13 +2534,13 @@ class SyncEngine:
                 event.dbx_path, parent_rev=local_rev if event.is_file else None
             )
         except NotFoundError:
-            logger.debug(
+            self._logger.debug(
                 'Could not delete "%s": the item no longer exists on Dropbox',
                 event.dbx_path,
             )
             md_deleted = None
         except PathError:
-            logger.debug(
+            self._logger.debug(
                 'Could not delete "%s": the item has been changed ' "since last sync",
                 event.dbx_path,
             )
@@ -2567,7 +2574,7 @@ class SyncEngine:
 
         client = client or self.client
 
-        logger.info(f"Syncing ↓ {dbx_path}")
+        self._logger.info(f"Syncing ↓ {dbx_path}")
 
         with self.sync_lock:
 
@@ -2624,7 +2631,7 @@ class SyncEngine:
                     idx += len(res.entries)
 
                     if idx > 0:
-                        logger.info(f"Indexing {idx}...")
+                        self._logger.info(f"Indexing {idx}...")
 
                     res.entries.sort(key=lambda x: x.path_lower.count("/"))
 
@@ -2667,14 +2674,14 @@ class SyncEngine:
 
         client = client or self.client
 
-        logger.debug("Waiting for remote changes since cursor:\n%s", last_cursor)
+        self._logger.debug("Waiting for remote changes since cursor:\n%s", last_cursor)
         has_changes = client.wait_for_remote_changes(last_cursor, timeout=timeout)
 
         # For for 2 sec. This delay is typically only necessary folders are shared /
         # un-shared with other Dropbox accounts.
         time.sleep(2)
 
-        logger.debug("Detected remote changes: %s", has_changes)
+        self._logger.debug("Detected remote changes: %s", has_changes)
         return has_changes
 
     def download_sync_cycle(self, client: Optional[DropboxClient] = None) -> None:
@@ -2705,11 +2712,11 @@ class SyncEngine:
             is_indexing = not self._state.get("sync", "did_finish_indexing")
 
             if is_indexing and idx == 0:
-                logger.info("Indexing remote Dropbox")
+                self._logger.info("Indexing remote Dropbox")
             elif is_indexing:
-                logger.info("Resuming indexing")
+                self._logger.info("Resuming indexing")
             else:
-                logger.info("Fetching remote changes")
+                self._logger.info("Fetching remote changes")
 
             changes_iter = self.list_remote_changes_iterator(self.remote_cursor, client)
 
@@ -2719,7 +2726,7 @@ class SyncEngine:
                 idx += len(changes)
 
                 if idx > 0:
-                    logger.info(f"Indexing {idx}...")
+                    self._logger.info(f"Indexing {idx}...")
 
                 downloaded = self.apply_remote_changes(changes)
 
@@ -2741,7 +2748,7 @@ class SyncEngine:
             self._state.set("sync", "indexing_counter", 0)
 
             if idx > 0:
-                logger.info(IDLE)
+                self._logger.info(IDLE)
 
             self._clear_caches()
 
@@ -2768,22 +2775,22 @@ class SyncEngine:
         else:
             # Pick up where we left off. This may be an interrupted indexing /
             # pagination through changes or a completely new set of changes.
-            logger.debug("Fetching remote changes since cursor: %s", last_cursor)
+            self._logger.debug("Fetching remote changes since cursor: %s", last_cursor)
             changes_iter = client.list_remote_changes_iterator(last_cursor)
 
         for changes in changes_iter:
 
-            if logger.getEffectiveLevel() <= logging.DEBUG:
+            if self._logger.isEnabledFor(logging.DEBUG):
                 # Prevent allocating large strings if log level is larger than debug.
-                logger.debug(
+                self._logger.debug(
                     "Listed remote changes:\n%s", entries_repr(changes.entries)
                 )
 
             clean_changes = self._clean_remote_changes(changes)
 
-            if logger.getEffectiveLevel() <= logging.DEBUG:
+            if self._logger.isEnabledFor(logging.DEBUG):
                 # Prevent allocating large strings if log level is larger than debug.
-                logger.debug(
+                self._logger.debug(
                     "Cleaned remote changes:\n%s", entries_repr(clean_changes.entries)
                 )
 
@@ -2792,7 +2799,7 @@ class SyncEngine:
                 SyncEvent.from_dbx_metadata(md, self) for md in clean_changes.entries
             ]
 
-            logger.debug("Converted remote changes to SyncEvents")
+            self._logger.debug("Converted remote changes to SyncEvents")
 
             yield sync_events, changes.cursor
 
@@ -2850,7 +2857,7 @@ class SyncEngine:
 
         # apply deleted items
         if deleted:
-            logger.info("Applying deletions...")
+            self._logger.info("Applying deletions...")
         for level in sorted(deleted):
             items = deleted[level]
             with ThreadPoolExecutor(
@@ -2861,12 +2868,12 @@ class SyncEngine:
 
                 n_items = len(items)
                 for n, r in enumerate(res):
-                    throttled_log(logger, f"Deleting {n + 1}/{n_items}...")
+                    throttled_log(self._logger, f"Deleting {n + 1}/{n_items}...")
                     results.append(r)
 
         # create local folders, start with top-level and work your way down
         if folders:
-            logger.info("Creating folders...")
+            self._logger.info("Creating folders...")
         for level in sorted(folders):
             items = folders[level]
             with ThreadPoolExecutor(
@@ -2877,7 +2884,7 @@ class SyncEngine:
 
                 n_items = len(items)
                 for n, r in enumerate(res):
-                    throttled_log(logger, f"Creating folder {n + 1}/{n_items}...")
+                    throttled_log(self._logger, f"Creating folder {n + 1}/{n_items}...")
                     results.append(r)
 
         # apply created files
@@ -2888,7 +2895,7 @@ class SyncEngine:
 
             n_items = len(files)
             for n, r in enumerate(res):
-                throttled_log(logger, f"Syncing ↓ {n + 1}/{n_items}")
+                throttled_log(self._logger, f"Syncing ↓ {n + 1}/{n_items}")
                 results.append(r)
 
         self._clean_history()
@@ -3024,7 +3031,7 @@ class SyncEngine:
         if event.rev == local_rev:
             # Local change has the same rev. The local item (or deletion) must be newer
             # and not yet synced or identical to the remote state. Don't overwrite.
-            logger.debug(
+            self._logger.debug(
                 'Equal revs for "%s": local item is the same or newer '
                 "than on Dropbox",
                 event.dbx_path,
@@ -3034,26 +3041,30 @@ class SyncEngine:
         elif event.content_hash == self.get_local_hash(event.local_path):
             # Content hashes are equal, therefore items are identical. Folders will
             # have a content hash of 'folder'.
-            logger.debug('Equal content hashes for "%s": no conflict', event.dbx_path)
+            self._logger.debug(
+                'Equal content hashes for "%s": no conflict', event.dbx_path
+            )
             return Conflict.Identical
         elif any(
             is_equal_or_child(p, event.dbx_path.lower()) for p in self.upload_errors
         ):
             # Local version could not be uploaded due to a sync error. Do not over-
             # write unsynced changes but declare a conflict.
-            logger.debug('Unresolved upload error for "%s": conflict', event.dbx_path)
+            self._logger.debug(
+                'Unresolved upload error for "%s": conflict', event.dbx_path
+            )
             return Conflict.Conflict
         elif not self._ctime_newer_than_last_sync(event.local_path):
             # Last change time of local item (recursive for folders) is older than
             # the last time the item was synced. Remote must be newer.
-            logger.debug(
+            self._logger.debug(
                 'Local item "%s" has no unsynced changes: remote item is newer',
                 event.dbx_path,
             )
             return Conflict.RemoteNewer
         elif event.is_deleted:
             # Remote item was deleted but local item has been modified since then.
-            logger.debug(
+            self._logger.debug(
                 'Local item "%s" has unsynced changes and remote was '
                 "deleted: local item is newer",
                 event.dbx_path,
@@ -3061,7 +3072,7 @@ class SyncEngine:
             return Conflict.LocalNewerOrIdentical
         else:
             # Both remote and local items have unsynced changes: conflict.
-            logger.debug(
+            self._logger.debug(
                 'Local item "%s" has unsynced local changes: conflict',
                 event.dbx_path,
             )
@@ -3305,7 +3316,7 @@ class SyncEngine:
                 with convert_api_errors(local_path=new_local_path):
                     move(local_path, new_local_path, raise_error=True)
 
-            logger.debug(
+            self._logger.debug(
                 'Download conflict: renamed "%s" to "%s"', local_path, new_local_path
             )
             self.rescan(new_local_path)
@@ -3345,7 +3356,7 @@ class SyncEngine:
         self.update_index_from_sync_event(event)
         self._save_local_hash(event.local_path, event.content_hash, mtime)
 
-        logger.debug('Created local file "%s"', event.dbx_path)
+        self._logger.debug('Created local file "%s"', event.dbx_path)
 
         return event
 
@@ -3381,7 +3392,7 @@ class SyncEngine:
                 with convert_api_errors(local_path=new_local_path):
                     move(event.local_path, new_local_path, raise_error=True)
 
-            logger.debug(
+            self._logger.debug(
                 'Download conflict: renamed "%s" to "%s"',
                 event.local_path,
                 new_local_path,
@@ -3409,7 +3420,7 @@ class SyncEngine:
 
         self.update_index_from_sync_event(event)
 
-        logger.debug('Created local folder "%s"', event.dbx_path)
+        self._logger.debug('Created local folder "%s"', event.dbx_path)
 
         return event
 
@@ -3441,11 +3452,11 @@ class SyncEngine:
 
         if not exc:
             self.update_index_from_sync_event(event)
-            logger.debug('Deleted local item "%s"', event.dbx_path)
+            self._logger.debug('Deleted local item "%s"', event.dbx_path)
             return event
         elif isinstance(exc, (FileNotFoundError, NotADirectoryError)):
             self.update_index_from_sync_event(event)
-            logger.debug('Deletion failed: "%s" not found', event.dbx_path)
+            self._logger.debug('Deletion failed: "%s" not found', event.dbx_path)
             return None
         else:
             raise os_to_maestral_error(exc)
@@ -3475,7 +3486,7 @@ class SyncEngine:
                 entry.dbx_path_cased = event.dbx_path
                 self._db_manager_index.update(entry)
 
-            logger.debug('Renamed "%s" to "%s"', local_path_old, event.local_path)
+            self._logger.debug('Renamed "%s" to "%s"', local_path_old, event.local_path)
 
     def rescan(self, local_path: str) -> None:
         """
@@ -3486,7 +3497,7 @@ class SyncEngine:
         :param local_path: Path to rescan.
         """
 
-        logger.debug('Rescanning "%s"', local_path)
+        self._logger.debug('Rescanning "%s"', local_path)
 
         if osp.isfile(local_path):
             self.fs_events.queue_event(FileModifiedEvent(local_path))

--- a/src/maestral/utils/integration.py
+++ b/src/maestral/utils/integration.py
@@ -10,7 +10,6 @@ import enum
 import resource
 import socket
 import time
-import logging
 from pathlib import Path
 from typing import Union, Tuple
 
@@ -23,8 +22,6 @@ __all__ = [
     "check_connection",
 ]
 
-
-logger = logging.getLogger(__name__)
 
 CPU_COUNT = os.cpu_count() or 1  # os.cpu_count can return None
 LINUX_POWER_SUPPLY_PATH = "/sys/class/power_supply"
@@ -205,5 +202,4 @@ def check_connection(hostname: str, timeout: int = 2) -> bool:
         s.close()
         return True
     except Exception:
-        logger.debug("Connection error", exc_info=True)
         return False

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from dropbox.files import WriteMode, FileMetadata
 
-from maestral.main import Maestral, logger
+from maestral.main import Maestral
 from maestral.errors import NotFoundError, FileConflictError
 from maestral.client import convert_api_errors
 from maestral.config import remove_configuration
@@ -29,7 +29,6 @@ resources = os.path.dirname(__file__) + "/resources"
 
 fsevents_logger = logging.getLogger("fsevents")
 fsevents_logger.setLevel(logging.DEBUG)
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/linked/test_main.py
+++ b/tests/linked/test_main.py
@@ -11,7 +11,6 @@ import pytest
 
 from maestral.errors import NotFoundError, UnsupportedFileTypeForDiff, SharedLinkError
 from maestral.main import FileStatus, IDLE
-from maestral.main import logger as maestral_logger
 from maestral.utils.path import delete
 from maestral.utils.integration import get_inotify_limits
 
@@ -37,7 +36,7 @@ def test_status_properties(m):
     assert not m.sync_errors
     assert not m.fatal_errors
 
-    maestral_logger.info("test message")
+    m._root_logger.info("test message")
     assert m.status == "test message"
 
 

--- a/tests/offline/conftest.py
+++ b/tests/offline/conftest.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from maestral.main import Maestral, logger
+from maestral.main import Maestral
 from maestral.sync import SyncEngine
 from maestral.fsevents import Observer
 from maestral.client import DropboxClient
@@ -16,12 +16,10 @@ from maestral.utils.appdirs import get_home_dir
 from maestral.utils.path import delete
 
 
-logger.setLevel(logging.DEBUG)
-
-
 @pytest.fixture
 def m():
     m = Maestral("test-config")
+    m.log_level = logging.DEBUG
     m._conf.save()
     yield m
     remove_configuration(m.config_name)

--- a/tests/offline/test_cli.py
+++ b/tests/offline/test_cli.py
@@ -5,10 +5,10 @@ import logging
 from click.testing import CliRunner
 
 from maestral.cli import main
-from maestral.main import logger
 from maestral.autostart import AutoStart
 from maestral.notify import level_number_to_name, level_name_to_number
 from maestral.daemon import MaestralProxy, start_maestral_daemon_process, Start
+from maestral.logging import scoped_logger
 
 
 def test_help():
@@ -206,6 +206,7 @@ def test_log_level(m):
 
 def test_log_show(m):
     # log a message
+    logger = scoped_logger("maestral", m.config_name)
     logger.info("Hello from pytest!")
     runner = CliRunner()
     result = runner.invoke(main, ["log", "show", "-c", m.config_name])
@@ -216,6 +217,7 @@ def test_log_show(m):
 
 def test_log_clear(m):
     # log a message
+    logger = scoped_logger("maestral", m.config_name)
     logger.info("Hello from pytest!")
     runner = CliRunner()
     result = runner.invoke(main, ["log", "show", "-c", m.config_name])
@@ -227,7 +229,7 @@ def test_log_clear(m):
     result = runner.invoke(main, ["log", "clear", "-c", m.config_name])
     assert result.exit_code == 0, result.output
 
-    with open(m.log_handler_file.stream.name) as f:
+    with open(m._log_handler_file.stream.name) as f:
         log_content = f.read()
 
     assert log_content == ""


### PR DESCRIPTION
This PR scopes loggers by config name instead of using global loggers. This prevents interference when running different Maestral instances in the same process.

It also initialises logging early during the daemon startup so that startup logs will now be properly written to the log file and journal.