### PR TITLE
Improve exception handling during upload sync

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,8 @@ codecov:
 coverage:
   status:
     project:
-      threshold: 5%
+      default:
+        threshold: 5%
     patch:
-      threshold: 5%
+      default:
+        threshold: 5%

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1207,6 +1207,8 @@ def os_to_maestral_error(
     else:
         return exc
 
+    local_path = local_path or exc.filename
+
     maestral_exc = err_cls(title, text, dbx_path=dbx_path, local_path=local_path)
     maestral_exc.__cause__ = exc
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -514,13 +514,8 @@ def start_maestral_daemon(
     maestral_daemon = ExposedMaestral(config_name, log_to_stderr=log_to_stderr)
 
     if start_sync:
-
         dlogger.debug("Starting sync")
-
-        try:
-            maestral_daemon.start_sync()
-        except Exception:
-            dlogger.error("Could not start sync", exc_info=True)
+        maestral_daemon.start_sync()
 
     try:
 

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -24,6 +24,7 @@ from watchdog.events import (
 )
 
 # local imports
+from .errors import SyncError
 from .utils.orm import Model, Column, SqlEnum, SqlInt, SqlString, SqlFloat, SqlPath
 
 if TYPE_CHECKING:
@@ -375,6 +376,11 @@ class SyncEvent(Model):
         except OSError:
             stat = None
 
+        try:
+            content_hash = sync_engine.get_local_hash(to_path)
+        except SyncError:
+            content_hash = None
+
         if event.is_directory:
             item_type = ItemType.Folder
             size = 0
@@ -401,7 +407,7 @@ class SyncEvent(Model):
             local_path=to_path,
             dbx_path_from=sync_engine.to_dbx_path(from_path) if from_path else None,
             local_path_from=from_path,
-            content_hash=sync_engine.get_local_hash(to_path),
+            content_hash=content_hash,
             change_type=change_type,
             change_time=change_time,
             change_dbid=change_dbid,

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -908,14 +908,7 @@ class Maestral:
     def start_sync(self) -> None:
         """
         Creates syncing threads and starts syncing.
-
-        :raises NotLinkedError: if no Dropbox account is linked.
-        :raises NoDropboxDirError: if local Dropbox folder is not set up.
         """
-
-        self._check_linked()
-        self._check_dropbox_dir()
-
         self.manager.start()
 
     def stop_sync(self) -> None:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1070,7 +1070,7 @@ class SyncEngine:
         """
 
         if not osp.isdir(self.dropbox_path):
-            title = "Dropbox folder has been moved or deleted"
+            title = "Dropbox folder missing"
             msg = (
                 "Please move the Dropbox folder back to its original location "
                 "or restart Maestral to set up a new folder."

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3575,12 +3575,15 @@ class SyncEngine:
             )
             self._db_manager_history.clear_cache()
 
-    def _scandir_with_mignore(self, path: str) -> List:
-        return [
-            f
-            for f in os.scandir(path)
-            if not self._is_mignore_path(self.to_dbx_path(f.path), f.is_dir())
-        ]
+    def _scandir_with_mignore(
+        self, path: Union[str, os.PathLike]
+    ) -> Iterator[os.DirEntry]:
+
+        with os.scandir(path) as it:
+            for entry in it:
+                dbx_path = self.to_dbx_path(entry.path)
+                if not self._is_mignore_path(dbx_path, entry.is_dir()):
+                    yield entry
 
 
 # ======================================================================================

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -349,7 +349,8 @@ def move(
 
 
 def walk(
-    root: str, listdir: Callable[[str], Iterable[Union[str, os.DirEntry]]] = os.scandir
+    root: Union[str, os.PathLike],
+    listdir: Callable[[Union[str, os.PathLike]], Iterable[os.DirEntry]] = os.scandir,
 ) -> Iterator[Tuple[str, os.stat_result]]:
     """
     Iterates recursively over the content of a folder.

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -317,8 +317,6 @@ def test_local_indexing_error(m):
     m.start_sync()
     wait_for_idle(m)
 
-    breakpoint()
-
     # check for fatal errors
     assert len(m.fatal_errors) == 1
     assert m.fatal_errors[0]["local_path"] == subfolder

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -301,6 +301,29 @@ def test_local_indexing(m):
     assert not m.fatal_errors
 
 
+def test_local_indexing_error(m):
+    """Tests handling of PermissionError during local indexing."""
+
+    shutil.copytree(resources + "/test_folder", m.test_folder_local + "/test_folder")
+    wait_for_idle(m)
+
+    m.stop_sync()
+    wait_for_idle(m, 1)
+
+    # change permissions of local folder
+    subfolder = m.test_folder_local + "/test_folder/sub_folder_2"
+    os.chmod(subfolder, 0o000)
+
+    m.start_sync()
+    wait_for_idle(m)
+
+    breakpoint()
+
+    # check for fatal errors
+    assert len(m.fatal_errors) == 1
+    assert m.fatal_errors[0]["local_path"] == subfolder
+
+
 def test_folder_tree_remote(m):
     """Tests the download sync of a nested remote folder structure."""
 
@@ -709,11 +732,8 @@ def test_mignore(m):
     assert not m.fatal_errors
 
 
-def test_upload_sync_issues(m):
-    """
-    Tests error handling for issues during upload sync. This is done by creating a local
-    folder with a name that ends with a backslash (not allowed by Dropbox).
-    """
+def test_local_path_error(m):
+    """Tests error handling for forbidden file names."""
 
     # paths with backslash are not allowed on Dropbox
     # we create such a local folder and assert that it triggers a sync issue
@@ -733,6 +753,38 @@ def test_upload_sync_issues(m):
     # remove folder with invalid name and assert that sync issue is cleared
 
     delete(test_path_local)
+    wait_for_idle(m)
+
+    assert len(m.sync_errors) == 0
+    assert test_path_dbx not in m.sync.upload_errors
+
+    # check for fatal errors
+    assert not m.fatal_errors
+
+
+def test_local_permission_error(m):
+    """Tests error handling on local PermissionError."""
+
+    test_path_local = m.test_folder_local + "/file"
+    test_path_dbx = "/sync_tests/file"
+
+    m.stop_sync()
+
+    open(test_path_local, "w").close()
+    os.chmod(test_path_local, 0o000)
+
+    m.start_sync()
+    wait_for_idle(m)
+
+    assert len(m.sync_errors) == 1
+    assert m.sync_errors[-1]["local_path"] == test_path_local
+    assert m.sync_errors[-1]["dbx_path"] == test_path_dbx
+    assert m.sync_errors[-1]["type"] == "InsufficientPermissionsError"
+    assert test_path_dbx in m.sync.upload_errors
+
+    # reset file permission
+
+    os.chmod(test_path_local, 0o666)
     wait_for_idle(m)
 
     assert len(m.sync_errors) == 0
@@ -955,7 +1007,7 @@ def test_unknown_path_encoding(m, capsys):
     assert test_path_dbx not in m.sync.upload_errors
 
 
-def test_indexing_performance(m):
+def test_sync_event_conversion_performance(m):
     """
     Tests the performance of converting remote file changes to SyncEvents.
     """


### PR DESCRIPTION
This PR improves exception handling during upload sync:

* Permission errors and other unexpected OSErrors during startup indexing are no longer ignored but result in hard failures. This prevents remote items from being deleted if they cannot be indexed locally due to permission errors etc.
* Simplifies some error handling code.
* Don't raise errors when we cannot create cache dir during init.
* Adds tests for a wider variety of local OSErrors.