### PR TITLE
Improvements to filestatus API

### DIFF
--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -543,6 +543,9 @@ class Maestral:
         except ValueError:
             return FileStatus.Unwatched.value
 
+        if dbx_path == "/":
+            return FileStatus.Synced.value
+
         sync_event = self.manager.activity.get(local_path)
 
         if sync_event and sync_event.direction == SyncDirection.Up:

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from functools import wraps
 from queue import Empty, Queue
 from threading import Event, RLock, Thread
-from typing import Iterator, Optional, cast, List, Type, TypeVar, Callable, Any
+from typing import Iterator, Optional, cast, Dict, List, Type, TypeVar, Callable, Any
 
 # local imports
 from . import __url__
@@ -126,9 +126,9 @@ class SyncManager:
         self._conf.set("sync", "reindex_interval", interval)
 
     @property
-    def activity(self) -> List[SyncEvent]:
+    def activity(self) -> Dict[str, SyncEvent]:
         """Returns a list all items queued for or currently syncing."""
-        return list(self.sync.syncing)
+        return self.sync.syncing
 
     @property
     def history(self) -> List[SyncEvent]:


### PR DESCRIPTION
* Return file status for root folder instead of just unwatched (fixes #389).
* Determine file status recursively for folders: if any of the containing files is being synced, this is now reflected in the file status for the parent folders.