### PR TITLE
Performance improvement to ignores

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -277,8 +277,6 @@ class FSEventHandler(FileSystemEventHandler):
             for ignore in new_ignores:
                 ignore.ttl = time.time() + self.ignore_timeout
 
-            self.expire_ignored_events()
-
     def expire_ignored_events(self) -> None:
         """Removes all expired ignore entries."""
 
@@ -297,6 +295,12 @@ class FSEventHandler(FileSystemEventHandler):
         """
 
         for ignore in self._ignored_events.copy():
+
+            # check for expired events
+            if ignore.ttl and ignore.ttl < time.time():
+                self._ignored_events.discard(ignore)
+                continue
+
             ignore_event = ignore.event
             recursive = ignore.recursive
 


### PR DESCRIPTION
This PR improves the performance of managing local event ignores.

1. Ignores are stored in a set instead of a list.
2. Expired ignores are only pruned after a completed sync cycle instead of when exiting the `FSEvents.ignore` context. The increase in memory usage should be small since only recursive ignores are kept after the corresponding event was recorded.