### PR TITLE
Fix type hints for client instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ welcome.
 * Fixes an error when running the `diff` CLI command and selecting the local file as the
   base version.  
 * Fixes download links in the update dialog.
+* Fixes an unexpected error which may occur when creating a conflicting copy.
 
 #### Dependencies:
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1261,7 +1261,9 @@ class SyncEngine:
 
         return f"{self.dropbox_path}{dbx_path_cased}"
 
-    def to_local_path(self, dbx_path: str, client=Optional[DropboxClient]) -> str:
+    def to_local_path(
+        self, dbx_path: str, client: Optional[DropboxClient] = None
+    ) -> str:
         """
         Converts a Dropbox path to the corresponding local path. Only the basename must
         be correctly cased, as guaranteed by the Dropbox API for the ``display_path``

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1182,6 +1182,8 @@ class SyncEngine:
         :returns: Correctly cased Dropbox path.
         """
 
+        client = client or self.client
+
         dirname, basename = osp.split(dbx_path)
 
         dirname_cased = self._correct_case_helper(dirname, client)
@@ -1192,17 +1194,12 @@ class SyncEngine:
 
         return path_cased
 
-    def _correct_case_helper(
-        self, dbx_path: str, client: Optional[DropboxClient] = None
-    ) -> str:
+    def _correct_case_helper(self, dbx_path: str, client: DropboxClient) -> str:
         """
         :param dbx_path: Uncased or randomly cased Dropbox path.
-        :param client: Client instance to use. If not given, use the instance provided
-            in the constructor.
+        :param client: Client instance to use.
         :returns: Correctly cased Dropbox path.
         """
-
-        client = client or self.client
 
         # check for root folder
         if dbx_path == "/":
@@ -2266,7 +2263,7 @@ class SyncEngine:
         if md_to_new.path_lower != event.dbx_path.lower():
             # TODO: test this
             # conflicting copy created during upload, mirror remote changes locally
-            local_path_cc = self.to_local_path(md_to_new.path_display)
+            local_path_cc = self.to_local_path(md_to_new.path_display, client)
             event_cls = DirMovedEvent if osp.isdir(event.local_path) else FileMovedEvent
             with self.fs_events.ignore(event_cls(event.local_path, local_path_cc)):
                 with convert_api_errors():
@@ -2384,7 +2381,7 @@ class SyncEngine:
 
         if md_new.path_lower != event.dbx_path.lower():
             # conflicting copy created during upload, mirror remote changes locally
-            local_path_cc = self.to_local_path(md_new.path_display)
+            local_path_cc = self.to_local_path(md_new.path_display, client)
             event_cls = DirMovedEvent if osp.isdir(event.local_path) else FileMovedEvent
             with self.fs_events.ignore(event_cls(event.local_path, local_path_cc)):
                 with convert_api_errors():
@@ -2469,7 +2466,7 @@ class SyncEngine:
 
         if md_new.path_lower != event.dbx_path.lower():
             # conflicting copy created during upload, mirror remote changes locally
-            local_path_cc = self.to_local_path(md_new.path_display)
+            local_path_cc = self.to_local_path(md_new.path_display, client)
             with self.fs_events.ignore(FileMovedEvent(event.local_path, local_path_cc)):
                 try:
                     os.rename(event.local_path, local_path_cc)

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -77,7 +77,7 @@ def test_file_lifecycle(m):
     assert not m.fatal_errors
 
 
-def test_file_conflict(m):
+def test_file_conflict_modified(m):
     """Tests conflicting local vs remote file changes."""
 
     # create a local file
@@ -101,6 +101,34 @@ def test_file_conflict(m):
     # resume syncing and check for conflicting copy
     m.start_sync()
 
+    wait_for_idle(m)
+
+    assert_synced(m)
+    assert_exists(m, "/sync_tests", "file.txt")
+    assert_conflict(m, "/sync_tests", "file.txt")
+    assert_child_count(m, "/sync_tests", 2)
+
+    # check for fatal errors
+    assert not m.fatal_errors
+
+
+def test_file_conflict_created(m):
+    """Tests conflicting local vs remote file creations."""
+
+    m.stop_sync()
+
+    # create a local file
+    shutil.copy(resources + "/file.txt", m.test_folder_local)
+
+    # create different remote file
+    m.client.upload(
+        resources + "/file2.txt",
+        "/sync_tests/file.txt",
+        mode=WriteMode.overwrite,
+    )
+
+    # resume syncing and check for conflicting copy
+    m.start_sync()
     wait_for_idle(m)
 
     assert_synced(m)


### PR DESCRIPTION
This PR closes #395 by fixing typos in the type hints.

It also improved typing for the `client` argument of various `SyncEngine` methods and ensures that the correct client instance is used when renaming local conflicts.