### PR TITLE
Update interprocess lock for fasteners 0.16.1

### DIFF
--- a/tests/offline/test_daemon.py
+++ b/tests/offline/test_daemon.py
@@ -102,6 +102,10 @@ def test_locking_multiprocess():
     lock = Lock.singleton(lock_name)
     assert not lock.locked()
 
+    # try to release lock, will fail because it is not acquired
+    with pytest.raises(RuntimeError):
+        lock.release()
+
     # acquire lock from different process
 
     cmd = (


### PR DESCRIPTION
fasteners 0.16.1 has a couple of API changes which we need to adapt to:

1. It no longer tracks if our own process acquired the lock. We need this information to determine the PID of the locking process (only if we are the locking process) and therefore track this ourselves now.
2. It no longer raises a `RuntimeError` when trying to release a lock which another process acquired and which we therefore cannot release. We raise this error ourselves now.