### PR TITLE
Fix IndexError when passing a relative path to `is_excluded`

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1345,8 +1345,8 @@ class SyncEngine:
         temporary files as well as caches used by Dropbox or Maestral. `is_excluded`
         accepts both local and Dropbox paths.
 
-        :param path: Can be either absolute or relative to the Dropbox folder. Does not
-            need to be normalized
+        :param path: Can be an absolute path, a path relative to the Dropbox folder or
+            just a file name. Does not need to be normalized.
         :returns: Whether the path is excluded from syncing.
         """
 
@@ -1360,7 +1360,9 @@ class SyncEngine:
             return True
 
         # in excluded dirs?
-        if dirname.split("/", 2)[1] in EXCLUDED_DIR_NAMES:
+        root_dir = next(iter(part for part in dirname.split("/", 2) if part), "")
+
+        if root_dir in EXCLUDED_DIR_NAMES:
             return True
 
         if "~" in basename:  # is temporary file?


### PR DESCRIPTION
This PR fixes #413.

`SyncEngine.is_excluded()` is called most of the time with paths that start with a leading "/", either absolute paths on the local drive or "absolute" paths with respect to the Dropbox root. However, it may occasionally be called with file names without a leading "/", in particular when getting the ctime of a local folder:

https://github.com/SamSchott/maestral/blob/d149f8074f9effa9797c401feedf4a291056b332/src/maestral/sync.py#L3148-L3158

This would previously lead to an index error when getting the directory name.