### PR TITLE
Daemon shutdown improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     "pathspec>=0.5.8",
     "Pyro5>=5.10",
     "requests>=2.16.2",
-    "rubicon-objc>=0.4.0;sys_platform=='darwin'",
+    "rubicon-objc>=0.4.1;sys_platform=='darwin'",
     "sdnotify>=0.3.2",
     "setuptools",
     "survey>=3.4.3,<4.0",

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -488,10 +488,7 @@ def start_maestral_daemon(
             for s in signals:
                 loop.add_signal_handler(s, maestral_daemon.shutdown_daemon)
 
-            async def main():
-                await maestral_daemon.shutdown_complete
-
-            asyncio.run(main())
+            loop.run_until_complete(maestral_daemon.shutdown_complete)
 
             for socket in daemon.sockets:
                 loop.remove_reader(socket.fileno())

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -386,6 +386,8 @@ def start_maestral_daemon(
     dlogger = scoped_logger(__name__, config_name)
     sd_notifier = sdnotify.SystemdNotifier()
 
+    loop: Optional[asyncio.AbstractEventLoop] = None
+
     dlogger.info("Starting daemon")
 
     try:
@@ -499,6 +501,8 @@ def start_maestral_daemon(
     except Exception as exc:
         dlogger.error(exc.args[0], exc_info=True)
     finally:
+        if loop:
+            loop.close()
 
         if NOTIFY_SOCKET:
             # Notify systemd that we are shutting down.

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -25,7 +25,7 @@ from types import TracebackType
 # external imports
 import Pyro5  # type: ignore
 from Pyro5.errors import CommunicationError  # type: ignore
-from Pyro5.api import Daemon, Proxy, expose, oneway, register_dict_to_class  # type: ignore
+from Pyro5.api import Daemon, Proxy, expose, register_dict_to_class  # type: ignore
 import sdnotify  # type: ignore
 from fasteners import InterProcessLock  # type: ignore
 
@@ -447,7 +447,7 @@ def start_maestral_daemon(
             dlogger.debug("WATCHDOG_PID = %s", WATCHDOG_PID)
             loop.create_task(periodic_watchdog())
 
-        # ==== Pyro5 server setup ======================================================
+        # ==== Run Maestral as Pyro server =============================================
 
         # Get socket for config name.
         sockpath = sockpath_for_config(config_name)
@@ -464,14 +464,7 @@ def start_maestral_daemon(
 
         dlogger.debug("Creating Pyro daemon")
 
-        ExposedMaestral = expose(Maestral)
-
-        ExposedMaestral.start_sync = oneway(ExposedMaestral.start_sync)
-        ExposedMaestral.stop_sync = oneway(ExposedMaestral.stop_sync)
-
-        # ==== Run Maestral and respond to signals + requests ==========================
-
-        maestral_daemon = ExposedMaestral(config_name, log_to_stderr=log_to_stderr)
+        maestral_daemon = expose(Maestral)(config_name, log_to_stderr=log_to_stderr)
 
         if start_sync:
             dlogger.debug("Starting sync")

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1392,6 +1392,10 @@ class Maestral:
         for task in self._tasks:
             task.cancel()
 
+        self._loop.run_until_complete(
+            asyncio.gather(*self._tasks, return_exceptions=True)
+        )
+
         self._pool.shutdown(wait=False)
 
         if self._loop.is_running():

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1392,11 +1392,7 @@ class Maestral:
         for task in self._tasks:
             task.cancel()
 
-        self._loop.run_until_complete(
-            asyncio.gather(*self._tasks, return_exceptions=True)
-        )
-
-        self._pool.shutdown(wait=False)
+        self._pool.shutdown()
 
         if self._loop.is_running():
             self._loop.call_soon_threadsafe(self.shutdown_complete.set_result, True)

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1383,7 +1383,8 @@ class Maestral:
 
     def shutdown_daemon(self) -> None:
         """
-        Stop the event loop. This will also shut down the pyro daemon if running.
+        Stop syncing and clean up our asyncio tasks. Set a result for the
+        :attr:`shutdown_complete` future.
         """
 
         self.stop_sync()


### PR DESCRIPTION
This PR simplifies the way we shut down the daemon. Instead of calling `Maestral.shutdown_daemon()` directly via Pyro5, we send SIGTERM to the daemon process and rely on the signal handler to invoke `Maestral.shutdown_daemon()`.

This has the advantage that, if the daemon process has become completely unresponsive, the remote `Maestral.shutdown_daemon()` call would block while sending SIGTERM will just fail to stop the process and can be followed up by SIGKILL after a timeout.

This change means that we need to know the daemon's PID. This is currently obtained by finding the process which has a write lock on the lock file, using ctypes calls which may fail on the some platforms. In this case, `maestral stop` will report "failed" and the user must manually stop the process.

This PR also simplifies the asyncio loop cleanup by using the higher level API `asyncio.run()`.

Do not merge before https://github.com/beeware/rubicon-objc/issues/202 has been fixed.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
