### PR TITLE
Migrate config and state keys

### DIFF
--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -22,20 +22,18 @@ CONFIG_DIR_NAME = "maestral"
 # =============================================================================
 
 DEFAULTS_CONFIG: DefaultsType = {
-    "main": {
-        "path": "",  # dropbox folder location
-        "excluded_items": [],  # files and folders excluded from sync
-    },
-    "account": {
+    "auth": {
         "account_id": "",  # dropbox account id, must match the saved account key
+        "keyring": "automatic",  # keychain backend to use for credential storage
     },
     "app": {
         "notification_level": 15,  # desktop notification level, default: FILECHANGE
         "log_level": 20,  # log level for journal and file, default: INFO
         "update_notification_interval": 60 * 60 * 24 * 7,  # default: weekly
-        "keyring": "automatic",  # keychain backend to use for credential storage
     },
     "sync": {
+        "path": "",  # dropbox folder location
+        "excluded_items": [],  # files and folders excluded from sync
         "reindex_interval": 60 * 60 * 24 * 14,  # default: every fortnight
         "max_cpu_percent": 20.0,  # max usage target per cpu core, default: 20%
         "keep_history": 60 * 60 * 24 * 7,  # default: one week
@@ -52,6 +50,8 @@ DEFAULTS_STATE: DefaultsType = {
         "type": "",
         "usage": "",
         "usage_type": "",  # private vs business
+    },
+    "auth": {
         "token_access_type": "",  # will be updated on completed OAuth
     },
     "app": {  # app state
@@ -112,7 +112,6 @@ def _get_conf(
                 defaults=defaults,
                 version=CONF_VERSION,
                 backup=True,
-                remove_obsolete=True,
             )
         except OSError:
             conf = UserConfig(
@@ -120,7 +119,6 @@ def _get_conf(
                 defaults=defaults,
                 version=CONF_VERSION,
                 backup=True,
-                remove_obsolete=True,
                 load=False,
             )
 

--- a/src/maestral/config/user.py
+++ b/src/maestral/config/user.py
@@ -151,7 +151,7 @@ class UserConfig(DefaultsConfig):
 
                 # Remove deprecated options if major version has changed.
                 if remove_obsolete and version.major > old_version.major:
-                    self._remove_deprecated_options()
+                    self.remove_deprecated_options()
 
                 # Set new version number.
                 self.set_version(version, save=False)
@@ -214,7 +214,7 @@ class UserConfig(DefaultsConfig):
             except cp.MissingSectionHeaderError:
                 logger.error("File contains no section headers.")
 
-    def _remove_deprecated_options(self) -> None:
+    def remove_deprecated_options(self) -> None:
         """
         Remove options which are present in the file but not in defaults.
         """

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -535,11 +535,11 @@ class SyncEngine:
 
     def _load_cached_config(self) -> None:
 
-        self._dropbox_path = self._conf.get("main", "path")
+        self._dropbox_path = self._conf.get("sync", "path")
         self._mignore_path = osp.join(self._dropbox_path, MIGNORE_FILE)
         self._file_cache_path = osp.join(self._dropbox_path, FILE_CACHE)
 
-        self._excluded_items = self._conf.get("main", "excluded_items")
+        self._excluded_items = self._conf.get("sync", "excluded_items")
         self._max_cpu_percent = self._conf.get("sync", "max_cpu_percent") * CPU_COUNT
         self._local_cursor = self._state.get("sync", "lastsync")
 
@@ -567,7 +567,7 @@ class SyncEngine:
             self._dropbox_path = path
             self._mignore_path = osp.join(self._dropbox_path, MIGNORE_FILE)
             self._file_cache_path = osp.join(self._dropbox_path, FILE_CACHE)
-            self._conf.set("main", "path", path)
+            self._conf.set("sync", "path", path)
 
     @property
     def database_path(self) -> str:
@@ -597,7 +597,7 @@ class SyncEngine:
         with self.sync_lock:
             clean_list = self.clean_excluded_items_list(folder_list)
             self._excluded_items = clean_list
-            self._conf.set("main", "excluded_items", clean_list)
+            self._conf.set("sync", "excluded_items", clean_list)
 
     @staticmethod
     def clean_excluded_items_list(folder_list: List[str]) -> List[str]:
@@ -632,7 +632,7 @@ class SyncEngine:
     def max_cpu_percent(self, percent: float) -> None:
         """Setter: max_cpu_percent."""
         self._max_cpu_percent = percent
-        self._conf.set("app", "max_cpu_percent", percent // CPU_COUNT)
+        self._conf.set("sync", "max_cpu_percent", percent // CPU_COUNT)
 
     # ==== sync state ==================================================================
 

--- a/tests/offline/config/conftest.py
+++ b/tests/offline/config/conftest.py
@@ -1,15 +1,30 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
-from maestral.config.main import DEFAULTS_CONFIG, CONF_VERSION
+from packaging.version import Version
 from maestral.config.user import UserConfig
+
+
+DEFAULTS_CONFIG = {
+    "auth": {
+        "account_id": "12345",
+        "keyring": "automatic",
+    },
+    "sync": {
+        "path": "/Users/Leslie/Dropbox (Maestral)",
+        "excluded_items": ["/Photos"],
+        "upload": True,
+        "download": True,
+    },
+}
+
+CONF_VERSION = Version("1.0.0")
 
 
 @pytest.fixture
 def config(tmp_path):
 
-    config_path = tmp_path / "test-update-config.ini"
+    config_path = tmp_path / "test-config.ini"
 
     # Create an initial config on disk.
     conf = UserConfig(

--- a/tests/offline/config/test_user.py
+++ b/tests/offline/config/test_user.py
@@ -5,8 +5,9 @@ import configparser as cp
 import pytest
 
 from packaging.version import Version
-from maestral.config.main import DEFAULTS_CONFIG, CONF_VERSION
 from maestral.config.user import UserConfig
+
+from .conftest import DEFAULTS_CONFIG, CONF_VERSION
 
 
 def test_config_creation(config):
@@ -20,13 +21,7 @@ def test_config_creation(config):
     assert config.get_version() == CONF_VERSION
 
 
-def test_get_option(config):
-
-    # Test getting existing config values.
-    assert config.get("main", "path", "/test/path") == DEFAULTS_CONFIG["main"]["path"]
-
-    config.set("main", "excluded_items", ["a", "b", "c"])
-    assert config.get("main", "excluded_items") == ["a", "b", "c"]
+def test_get_failures(config):
 
     # Check getting non-existing config options.
     with pytest.raises(cp.NoOptionError):
@@ -42,20 +37,20 @@ def test_get_option(config):
 def test_set_option(config):
 
     # Test setting valid config values of different types.
-    config.set("main", "path", "/test/path")
-    config.set("main", "excluded_items", ["a", "b", "c"])
+    config.set("sync", "path", "/test/path")
+    config.set("sync", "excluded_items", ["a", "b", "c"])
     config.set("new_section", "new_option", {"a", "b", "c"})
 
-    assert config.get("main", "path") == "/test/path"
-    assert config.get("main", "excluded_items") == ["a", "b", "c"]
+    assert config.get("sync", "path") == "/test/path"
+    assert config.get("sync", "excluded_items") == ["a", "b", "c"]
     assert config.get("new_section", "new_option") == {"a", "b", "c"}
 
     # Check setting invalid config values.
     with pytest.raises(ValueError):
-        config.set("main", "path", 1234)
+        config.set("sync", "path", 1234)
 
     with pytest.raises(ValueError):
-        config.set("main", "excluded_items", "path")
+        config.set("sync", "excluded_items", "path")
 
 
 def test_update(config):
@@ -63,17 +58,17 @@ def test_update(config):
     old_version = CONF_VERSION
 
     # Modify some values.
-    config.set("account", "account_id", "my id")
-    config.set("main", "path", "/path/to/folder")
+    config.set("auth", "account_id", "my id")
+    config.set("sync", "path", "/path/to/folder")
 
     # Remove a default config option.
-    del DEFAULTS_CONFIG["main"]["path"]
+    del DEFAULTS_CONFIG["sync"]["path"]
 
     # Add a default config option.
-    DEFAULTS_CONFIG["main"]["new_option"] = "brand new"
+    DEFAULTS_CONFIG["sync"]["new_option"] = "brand new"
 
     # Modify some default config options.
-    DEFAULTS_CONFIG["account"]["account_id"] = "another id"
+    DEFAULTS_CONFIG["auth"]["account_id"] = "another id"
     DEFAULTS_CONFIG["sync"]["upload"] = False
 
     # Create a new instance with modified defaults.
@@ -91,8 +86,8 @@ def test_update(config):
 
         # Check that the config was updated properly.
 
-        assert conf.get("account", "account_id") == "my id"
-        assert conf.get("main", "new_option") == "brand new"
+        assert conf.get("auth", "account_id") == "my id"
+        assert conf.get("sync", "new_option") == "brand new"
 
         with pytest.raises(cp.NoOptionError):
-            conf.get("main", "path")
+            conf.get("sync", "path")

--- a/tests/offline/utils/test_appdirs.py
+++ b/tests/offline/utils/test_appdirs.py
@@ -21,7 +21,7 @@ def test_macos_dirs(monkeypatch):
     home = get_home_dir()
 
     assert get_conf_path(create=False) == home + "/Library/Application Support"
-    assert get_cache_path(create=False) == get_conf_path(create=False)
+    assert get_cache_path(create=False) == home + "/Library/Caches"
     assert get_data_path(create=False) == get_conf_path(create=False)
     assert get_runtime_path(create=False) == get_conf_path(create=False)
     assert get_log_path(create=False) == home + "/Library/Logs"


### PR DESCRIPTION
This PR reorganises the sections of the config and state files as follows:

1. Config file:
  * `account_id` and `keyring` moved to `auth` section
  * `path` and `excluded_items` moved to `sync` section

2. State file:
 * `token_access_type` moved to `auth` section