### PR TITLE
Optimise temp file creation

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1073,7 +1073,7 @@ class SyncEngine:
         """
 
         retries = 0
-        max_retries = 100
+        max_retries = 10
 
         while not osp.isdir(self.file_cache_path):
             try:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1100,6 +1100,7 @@ class SyncEngine:
                     "Exceeded maximum number of retries",
                 )
 
+            time.sleep(0.01)
             retries += 1
 
     def clean_cache_dir(self, raise_error: bool = True) -> None:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1065,7 +1065,7 @@ class SyncEngine:
             )
             raise NoDropboxDirError(title, msg)
 
-    def _ensure_cache_dir_present(self) -> None:
+    def ensure_cache_dir_present(self) -> None:
         """
         Checks for or creates a directory at :attr:`file_cache_path`.
 
@@ -1130,7 +1130,7 @@ class SyncEngine:
 
     def _new_tmp_file(self) -> str:
         """Returns a new temporary file name in our cache directory."""
-        self._ensure_cache_dir_present()
+        self.ensure_cache_dir_present()
         try:
             with NamedTemporaryFile(dir=self.file_cache_path, delete=False) as f:
                 try:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1077,12 +1077,16 @@ class SyncEngine:
 
         while not osp.isdir(self.file_cache_path):
             try:
-                # this will raise FileExistsError if file_cache_path
-                # exists but is a file instead of a directory
+                # This will raise FileExistsError if file_cache_path
+                # exists but is a file instead of a directory.
                 os.makedirs(self.file_cache_path, exist_ok=True)
+                return
             except FileExistsError:
-                # remove the file that's in our way
+                # Remove the file that's in our way, retry creation.
                 self.clean_cache_dir()
+            except NotADirectoryError:
+                # Ensure that parent directories exist as expected.
+                self.ensure_dropbox_folder_present()
             except OSError as err:
                 raise CacheDirError(
                     f"Cannot create cache directory: {err.strerror}",


### PR DESCRIPTION
This PR improved error handling when creating temporary files for downloads:

1. If we cannot create a temporary file because the cache dir cannot be found, call `SyncEngine.ensure_dropbox_folder_present()`.
2. Retry creation of temp file up to 10 times.
3. Reduce number of retries for creation of cache dir from 100 to 10 times.
