### PR TITLE
Fix handling of http errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   selecting a new location would lead to duplicate menu entries in the status bar menu.
 * Fixed an issue where moving / removing the local Dropbox folder during a download 
   could lead to unhandled exceptions instead of useful error messages.
+* Fixes handling of 503 and other raw HTTP errors from the Dropbox SDK, for instance
+  when Dropbox servers have temporary outages or are undergoing planned maintenance.
 
 #### Removed:
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1547,7 +1547,7 @@ def dropbox_to_maestral_error(
         # See https://github.com/dropbox/dropbox-sdk-python/issues/360
         # and https://github.com/SamSchott/maestral/issues/388.
 
-        if exc.request is not None and exc.request.status_code >= 500:
+        if exc.response is not None and exc.response.status_code >= 500:
             err_cls = DropboxServerError
             title = "Dropbox server error"
             text = (

--- a/tests/linked/test_client.py
+++ b/tests/linked/test_client.py
@@ -3,9 +3,11 @@
 import os
 
 import pytest
+import requests
 from dropbox.files import FolderMetadata
 
-from maestral.errors import NotFoundError, PathError
+from maestral.client import convert_api_errors
+from maestral.errors import NotFoundError, PathError, DropboxServerError
 from maestral.utils.path import normalize
 
 from .conftest import resources
@@ -58,3 +60,12 @@ def test_batch_methods(m, batch_size, force_async):
         assert res[i].path_lower == normalize(folders[i])
 
     assert isinstance(res[20], NotFoundError)
+
+
+def test_server_error():
+
+    with pytest.raises(DropboxServerError):
+
+        with convert_api_errors():
+            r = requests.get("https://httpstat.us/503")
+            r.raise_for_status()


### PR DESCRIPTION
Fixes #432 by correctly reading any error status codes from the HTTP response (instead of the request itself).