### PR TITLE
Perform connection check using head request if http_proxy ist set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   could lead to unhandled exceptions instead of useful error messages.
 * Fixes handling of 503 and other raw HTTP errors from the Dropbox SDK, for instance
   when Dropbox servers have temporary outages or are undergoing planned maintenance.
+* Fixes periodic connection checking for connections over proxy using
+  `http_proxy` environment variable.
 
 #### Removed:
 

--- a/src/maestral/utils/integration.py
+++ b/src/maestral/utils/integration.py
@@ -8,10 +8,11 @@ import os
 import platform
 import enum
 import resource
-import socket
+import requests
 import time
 from pathlib import Path
 from typing import Union, Tuple
+from urllib.parse import urlparse
 
 __all__ = [
     "get_ac_state",
@@ -196,10 +197,10 @@ def check_connection(hostname: str, timeout: int = 2) -> bool:
     :param timeout: Timeout in seconds for connection check.
     :returns: Connection availability.
     """
+    if urlparse(hostname).scheme not in ["http", "https"]:
+        hostname = "http://" + hostname
     try:
-        host = socket.gethostbyname(hostname)
-        s = socket.create_connection(address=(host, 80), timeout=timeout)
-        s.close()
+        requests.head(hostname, timeout=timeout)
         return True
     except Exception:
         return False


### PR DESCRIPTION
I guess this is an edge case, but I was trying to run maestral's cli on a server where connections are only possible through a proxy. The Python SDK from Dropbox uses the `requests` python package which handles environment variables like `http_proxy` or similar accordingly.

Maestral's `check_connection` function uses sockets to establish a connection with `dropbox.com` over Port 80 which was not possible on my machine. This PR uses a `HEAD` request (which uses the `*_proxy` environment variables) if `http_proxy` is set and uses the existing socket method otherwise.