### PR TITLE
Improve cleaning local events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Changed:
 
+* Improved performance when processing local file events.
 * Improved error messages when the system keyring cannot be accessed despite being
   unlocked, for example because the executable (app bundle or Python) has an invalid
   signature.
@@ -27,6 +28,8 @@
   when Dropbox servers have temporary outages or are undergoing planned maintenance.
 * Fixes periodic connection checking for connections over proxy using
   `http_proxy` environment variable.
+* Fixes an issue where some uploaded items would not register as synced after aborting
+  or pausing during an upload sync.
 
 #### Removed:
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ dev_requires = [
     "mypy",
     "pre-commit",
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
     "pytest-rerunfailures",
     "types-pkg_resources",

--- a/tests/offline/test_cleaning_events.py
+++ b/tests/offline/test_cleaning_events.py
@@ -52,7 +52,7 @@ def test_single_file_events(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_single_path_cases(sync):
@@ -78,7 +78,7 @@ def test_single_path_cases(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_move_events(sync):
@@ -88,7 +88,7 @@ def test_move_events(sync):
         FileCreatedEvent(ipath(1)),
         FileMovedEvent(ipath(1), ipath(2)),
         # moved + deleted -> deleted
-        FileMovedEvent(ipath(1), ipath(4)),
+        FileMovedEvent(ipath(3), ipath(4)),
         FileDeletedEvent(ipath(4)),
         # moved + moved back -> modified
         FileMovedEvent(ipath(5), ipath(6)),
@@ -103,7 +103,7 @@ def test_move_events(sync):
         # created + moved -> created
         FileCreatedEvent(ipath(2)),
         # moved + deleted -> deleted
-        FileDeletedEvent(ipath(1)),
+        FileDeletedEvent(ipath(3)),
         # moved + moved back -> modified
         FileModifiedEvent(ipath(5)),
         # moved + moved -> deleted + created
@@ -113,7 +113,7 @@ def test_move_events(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_gedit_save(sync):
@@ -131,7 +131,7 @@ def test_gedit_save(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_macos_safe_save(sync):
@@ -147,7 +147,7 @@ def test_macos_safe_save(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_msoffice_created(sync):
@@ -165,7 +165,7 @@ def test_msoffice_created(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_type_changes(sync):
@@ -189,7 +189,7 @@ def test_type_changes(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_type_changes_difficult(sync):
@@ -218,7 +218,7 @@ def test_type_changes_difficult(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_nested_events(sync):
@@ -244,7 +244,7 @@ def test_nested_events(sync):
     ]
 
     cleaned_events = sync._clean_local_events(file_events)
-    assert set(cleaned_events) == set(res)
+    assert cleaned_events == res
 
 
 def test_performance(sync):


### PR DESCRIPTION
This PR improves cleaning local file events:

1. We reduce the number of iterations over all file events by a factor of 3, therefore speeding up event cleanup by 3x.
2. We preserve the order of events during cleanup.
3. We upload local changes in order of folder hierarchy and sorted by occurrence within each level.

The last two changes fix an issue when interrupting / pausing during an upload sync: If items are not synced in-order, a remote item `folder/subfolder/item` could be synced before `folder/subfolder`, therefore creating the remove item `folder/subfolder` as a side-effect without creating an entry for it in our local index. This is typically not a problem unless the sync is aborted before we actually process `folder/subfolder`. In this case, we have "uploaded" a remote item without remembering it. This can lead to potential inconsistencies in futures sync jobs.

This PR also uses `pytest-benchmark` to benchmark the performance of cleaning up local file events.