### PR TITLE
Improve handling of exotic OSErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Improved error message in the CLI when setting a config value fails because the new 
   value has the wrong type.
 * Migrated the Linux GUI from PyQt5 to PyQt6.
+* Improved handling of more exotic file system or device related errors when opening
+  local files.
 
 #### Fixed:
 
@@ -26,11 +28,11 @@
 * Fixed an issue where the Linux / Qt GUI would hang indefinitely after unlinking.
 * Fixed an issue where moving / removing the local Dropbox folder during a download 
   could lead to unhandled exceptions instead of useful error messages.
-* Fixes handling of 503 and other raw HTTP errors from the Dropbox SDK, for instance
+* Fixed handling of 503 and other raw HTTP errors from the Dropbox SDK, for instance
   when Dropbox servers have temporary outages or are undergoing planned maintenance.
-* Fixes periodic connection checking for connections over proxy using
+* Fixed periodic connection checking for connections over proxy using
   `http_proxy` environment variable.
-* Fixes an issue where some uploaded items would not register as synced after aborting
+* Fixed an issue where some uploaded items would not register as synced after aborting
   or pausing during an upload sync.
 
 #### Removed:

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1198,15 +1198,12 @@ def os_to_maestral_error(
         err_cls = InsufficientSpaceError  # subclass of SyncError
         title = "Could not download file"
         text = "There is not enough space left on the selected drive."
-    elif exc.errno == errno.EFAULT:
-        err_cls = FileReadError  # subclass of SyncError
-        title = "Could not upload file"
-        text = "An error occurred while reading the file content."
     elif exc.errno == errno.ENOMEM:
         err_cls = OutOfMemoryError  # subclass of MaestralApiError
         text = "Out of memory. Please reduce the number of memory consuming processes."
     else:
-        return exc
+        err_cls = FileReadError
+        text = f"Could not access file. Errno {exc.errno}: {os.strerror(exc.errno)}."
 
     local_path = local_path or exc.filename
 


### PR DESCRIPTION
This PR improves handling of exotic OSErrors such as device or file system related errors. Instead of raising an unexpected error, a sync issue is created if the error relates to a specific sync event. This will allow other sync jobs to continue while informing the user of the specific file where the error was encountered.

Fixes #437.