### PR TITLE
CLI documentation link update

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ By default, the Dropbox folder names will contain the capitalised config-name in
 In the above case, this will be "Dropbox (Personal)" and "Dropbox (Work)".
 
 A full documentation of the CLI is available on the
-[website](https://samschott.github.io/maestral/cli/).
+[website](https://maestral.app/cli).
 
 ## Contribute
 


### PR DESCRIPTION
The CLI documentation link redirects to https://maestral.app/cli/ (with an ending slash), which gives a "page not found" error. https://maestral.app/cli works. It could probably be also solved by modifying the redirection.