### PR TITLE
Include full team namespace in sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Get short-lived Dropbox token
         # We generate a short-lived auth token which is passed to the test runner as
         # an environment variable. At no point does the test code, potentially from a
-        # malicious PR, get access to a long lived token.
+        # malicious PR, get access to a long-lived token.
         run: |
           auth_result=$(curl https://api.dropbox.com/oauth2/token \
               -d grant_type=refresh_token \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## v1.4.9.dev
 
+#### Added:
+
+* Added support for Dropbox Business accounts with Team Spaces. Shared folders in team
+  spaces will now be synced at the top level, next to the user's personal folder.
+
 #### Fixed:
 
 * Fixed error in CLI command `maestral config-file --clean`.

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -302,6 +302,7 @@ class DropboxClient:
             try:
                 self.update_path_root()
             except ConnectionError:
+                self.auth.delete_creds()
                 return OAuth2Session.ConnectionFailed
 
             self.auth.save_creds()

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1589,10 +1589,10 @@ def dropbox_to_maestral_error(
 
         elif isinstance(error, common.PathRootError):
             if error.is_no_permission():
-                text = "You don't have permission to access this namespace"
+                text = "You don't have permission to access this namespace."
                 err_cls = InsufficientPermissionsError
             elif error.is_invalid_root():
-                text = "Invalid root namespace"
+                text = "Invalid root namespace."
                 err_cls = SyncError
 
     # ---- Authentication errors -------------------------------------------------------
@@ -1635,10 +1635,10 @@ def dropbox_to_maestral_error(
 
         if isinstance(error, common.PathRootError):
             if error.is_no_permission():
-                text = "You don't have permission to access this namespace"
+                text = "You don't have permission to access this namespace."
                 err_cls = PathRootError
             elif error.is_invalid_root():
-                text = "Invalid root namespace"
+                text = "Invalid root namespace."
                 err_cls = PathRootError
 
     # ---- OAuth2 flow errors ----------------------------------------------------------

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1760,6 +1760,8 @@ def _get_write_error_msg(write_error: files.WriteError) -> Tuple[str, WriteError
             "There are too many write operations in your Dropbox. Please "
             "try again later."
         )
+    elif write_error.is_operation_suppressed():
+        text = "This file operation is not allowed at this path."
 
     return text, err_cls
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1632,15 +1632,16 @@ def dropbox_to_maestral_error(
     # ---- Namespace Errors ------------------------------------------------------------
     elif isinstance(exc, exceptions.PathRootError):
         error = exc.error
-        title = "API call failed"
+        err_cls = PathRootError
+        title = "Invalid root namespace"
 
         if isinstance(error, common.PathRootError):
             if error.is_no_permission():
                 text = "You don't have permission to access this namespace."
-                err_cls = PathRootError
             elif error.is_invalid_root():
-                text = "Invalid root namespace."
-                err_cls = PathRootError
+                text = "The given namespace does not exist."
+            elif error.is_other():
+                text = "An unexpected error occurred with the given namespace."
 
     # ---- OAuth2 flow errors ----------------------------------------------------------
     elif isinstance(exc, requests.HTTPError):

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -50,6 +50,9 @@ DEFAULTS_STATE: DefaultsType = {
         "type": "",
         "usage": "",
         "usage_type": "",  # private vs business
+        "path_root_type": "user",  # the root folder type: team or user
+        "path_root_nsid": "",  # the namespace id of the root path
+        "home_path_name": "",  # the name of the user folder if not the root path
     },
     "auth": {
         "token_access_type": "",  # will be updated on completed OAuth

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -52,7 +52,7 @@ DEFAULTS_STATE: DefaultsType = {
         "usage_type": "",  # private vs business
         "path_root_type": "user",  # the root folder type: team or user
         "path_root_nsid": "",  # the namespace id of the root path
-        "home_path_name": "",  # the name of the user folder if not the root path
+        "home_path": "",  # the path of the user folder if not the root path
     },
     "auth": {
         "token_access_type": "",  # will be updated on completed OAuth

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -24,7 +24,7 @@ from watchdog.events import (
 )
 
 # local imports
-from .errors import SyncError
+from .errors import SyncError, NotLinkedError
 from .utils.orm import Model, Column, SqlEnum, SqlInt, SqlString, SqlFloat, SqlPath
 from .utils.path import normalize
 
@@ -370,7 +370,12 @@ class SyncEvent(Model):
             SyncEvent.
         """
 
-        change_dbid = sync_engine.client.account_info.account_id
+        try:
+            change_dbid = sync_engine.client.account_info.account_id
+        except NotLinkedError:
+            # Allow converting events when we are not linked. This is useful for testing.
+            change_dbid = ""
+
         to_path = getattr(event, "dest_path", event.src_path)
         from_path = None
 

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -333,7 +333,7 @@ class SyncEvent(Model):
             else:
                 # file is not a shared folder, therefore
                 # the current user must have added or modified it
-                change_dbid = sync_engine.client.account_id
+                change_dbid = sync_engine.client.account_info.account_id
         else:
             raise RuntimeError(f"Cannot convert {md} to SyncEvent")
 
@@ -370,7 +370,7 @@ class SyncEvent(Model):
             SyncEvent.
         """
 
-        change_dbid = sync_engine.client.account_id
+        change_dbid = sync_engine.client.account_info.account_id
         to_path = getattr(event, "dest_path", event.src_path)
         from_path = None
 

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -201,6 +201,10 @@ class SharedLinkError(MaestralApiError):
     """Raised when creating a shared link fails."""
 
 
+class PathRootError(MaestralApiError):
+    """Raised when making an API call with an invalid path root header."""
+
+
 # connection errors are handled as warnings
 # sync errors only appear in the sync errors list
 # all other errors raise an error dialog in the GUI
@@ -224,6 +228,7 @@ GENERAL_ERRORS = {
     UnsupportedFileTypeForDiff,
     SharedLinkError,
     DropboxConnectionError,
+    PathRootError,
 }
 
 SYNC_ERRORS = {

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -216,7 +216,6 @@ GENERAL_ERRORS = {
     KeyringAccessError,
     NoDropboxDirError,
     InotifyError,
-    RestrictedContentError,
     DatabaseError,
     DropboxAuthError,
     TokenExpiredError,
@@ -245,4 +244,7 @@ SYNC_ERRORS = {
     RestrictedContentError,
     UnsupportedFileError,
     FileSizeError,
+    FileReadError,
+    FileConflictError,
+    FolderConflictError,
 }

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -570,7 +570,7 @@ class SyncManager:
                 self.sync.excluded_items = new_excluded
 
             # Update path root of client.
-            self.client.switch_path_root(root_info.root_namespace_id)
+            self.client.update_path_root(root_info)
             self._save_path_root_info(root_info)
 
             #  Trigger reindex.

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -741,14 +741,15 @@ class SyncManager:
             # Reload mignore rules.
             self.sync.load_mignore_file()
 
+            self.client.get_space_usage()
+
             # Update path root and migrate local folders. This is required when a user
             # joins or leaves a team and their root namespace changes.
-            if self._needs_path_root_update():
-                self.sync.fs_events.disable()
-                self._update_path_root()
-                self.sync.fs_events.enable()
-            else:
-                self._save_path_root_info(self.client.account_info.root_info)
+            self.check_and_update_path_root()
+
+            if not running.is_set():
+                startup_completed.set()
+                return
 
             with self.sync.client.clone_with_new_session() as client:
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2544,6 +2544,20 @@ class SyncEngine:
 
         client = client or self.client
 
+        # We intercept any attempts to delete the home folder here instead of waiting
+        # for an error from the Dropbox API. This allows us to provide a better error
+        # message.
+
+        home_path = self._state.get("account", "home_path")
+
+        if event.dbx_path == home_path:
+            raise SyncError(
+                title="Could not delete item",
+                message="Cannot delete the user's home folder",
+                dbx_path=event.dbx_path,
+                local_path=event.local_path,
+            )
+
         if event.local_path == self.dropbox_path:
             self.ensure_dropbox_folder_present()
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -717,10 +717,11 @@ class SyncEngine:
         if self.busy():
             raise RuntimeError("Cannot reset sync state while syncing.")
 
-        self.remote_cursor = ""
-        self.local_cursor = 0.0
         self.clear_index()
         self.clear_sync_history()
+
+        self._state.reset_to_defaults("sync")
+        self.reload_cached_config()
 
         self._logger.debug("Sync state reset")
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2995,7 +2995,7 @@ class SyncEngine:
         if len(dbid_list) == 1:
             # all files have been modified by the same user
             dbid = dbid_list.pop()
-            if dbid == client.account_id:
+            if dbid == client.account_info.account_id:
                 user_name = "You"
             else:
                 try:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1694,7 +1694,7 @@ class SyncEngine:
                 changes.append(event)
 
         duration = time.time() - snapshot_time
-        self._logger.debug("Local indexing completed in %s sec", duration)
+        self._logger.debug("Local indexing completed in %s sec", round(duration, 4))
         self._logger.debug("Retrieved local changes:\n%s", pf_repr(changes))
 
         return changes, snapshot_time

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2285,14 +2285,17 @@ class SyncEngine:
         # If not on Dropbox, e.g., because its old name was invalid,
         # create it instead of moving it.
         if not md_from_old:
-            if event.is_directory:
-                new_event = DirCreatedEvent(event.local_path)
-            else:
-                new_event = FileCreatedEvent(event.local_path)
 
-            new_sync_event = SyncEvent.from_file_system_event(new_event, self)
+            self._logger.debug(
+                "Could not move '%s' -> '%s' on Dropbox, source does not exists. "
+                "Creating '%s' instead",
+                event.dbx_path_from,
+                event.dbx_path,
+                event.dbx_path,
+            )
 
-            return self._on_local_created(new_sync_event, client)
+            self.rescan(event.local_path)
+            return None
 
         md_to_new = client.move(dbx_path_from, event.dbx_path, autorename=True)
 

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -9,7 +9,6 @@ import uuid
 import pytest
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 from dropbox.files import WriteMode, FileMetadata
-from dropbox.common import TeamRootInfo
 
 from maestral.main import Maestral
 from maestral.errors import NotFoundError, FileConflictError
@@ -76,9 +75,9 @@ def m():
 
     sync_test_folder = "/Sync Tests"
 
-    if isinstance(m.client.account_info.root_info, TeamRootInfo):
-        home_path = m.client.account_info.root_info.home_path
-        sync_test_folder = home_path + sync_test_folder
+    # if isinstance(m.client.account_info.root_info, TeamRootInfo):
+    #     home_path = m.client.account_info.root_info.home_path
+    #     sync_test_folder = home_path + sync_test_folder
 
     m.test_folder_dbx = sync_test_folder
     m.test_folder_local = m.to_local_path(sync_test_folder)
@@ -87,7 +86,11 @@ def m():
         m.client.remove(m.test_folder_dbx)
     except NotFoundError:
         pass
-    m.client.make_dir(m.test_folder_dbx)
+
+    if m.client.is_team_space:
+        m.client.share_dir(m.test_folder_dbx)
+    else:
+        m.client.make_dir(m.test_folder_dbx)
 
     # start syncing
     m.start_sync()

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -116,7 +116,10 @@ def m():
     res = m.client.list_shared_links()
 
     for link in res.links:
-        m.revoke_shared_link(link.url)
+        try:
+            m.revoke_shared_link(link.url)
+        except NotFoundError:
+            pass
 
     # remove creds from system keyring
     m.client.auth.delete_creds()

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -41,7 +41,7 @@ def m():
     m = Maestral(config_name)
     m.log_level = logging.DEBUG
 
-    # link with given token
+    # link with given token and store auth info in keyring for other processes
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
 
@@ -58,10 +58,9 @@ def m():
             "Either access token or refresh token must be given as environment "
             "variable DROPBOX_ACCESS_TOKEN or DROPBOX_REFRESH_TOKEN."
         )
+    m.client.update_path_root()
 
-    # get corresponding Dropbox ID and store in keyring for other processes
-    res = m.client.get_account_info()
-    m.client.auth._account_id = res.account_id
+    m.client.auth._account_id = m.client.account_info.account_id
     m.client.auth.loaded = True
     m.client.auth.save_creds()
 

--- a/tests/linked/test_cli.py
+++ b/tests/linked/test_cli.py
@@ -11,8 +11,6 @@ from maestral.cli import main
 from maestral.constants import IDLE, PAUSED, ERROR
 from maestral.daemon import MaestralProxy
 
-from .conftest import SYNC_TEST_FOLDER
-
 
 if not ("DROPBOX_ACCESS_TOKEN" in os.environ or "DROPBOX_REFRESH_TOKEN" in os.environ):
     pytest.skip("Requires auth token", allow_module_level=True)
@@ -78,7 +76,7 @@ def test_status(proxy):
 def test_filestatus(proxy):
     runner = CliRunner()
 
-    local_path = proxy.to_local_path(SYNC_TEST_FOLDER)
+    local_path = proxy.to_local_path(proxy._test_folder_dbx)
 
     result = runner.invoke(main, ["filestatus", local_path, "-c", proxy.config_name])
 
@@ -100,7 +98,7 @@ def test_history(proxy):
     wait_for_idle(proxy)
 
     # lets make history
-    dbx_path = f"{SYNC_TEST_FOLDER}/new_file.txt"
+    dbx_path = f"{proxy._test_folder_dbx}/new_file.txt"
     local_path = proxy.to_local_path(dbx_path)
 
     with open(local_path, "a") as f:

--- a/tests/offline/conftest.py
+++ b/tests/offline/conftest.py
@@ -19,6 +19,7 @@ from maestral.utils.path import delete
 @pytest.fixture
 def m():
     m = Maestral("test-config")
+    m.client._init_sdk_with_token(refresh_token="fake")
     m.log_level = logging.DEBUG
     m._conf.save()
     yield m

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -220,11 +220,39 @@ def test_get_write_error_msg(error, maestral_exc):
         (ListSharedLinksError.path(LookupError.not_found), NotFoundError),
         (ListSharedLinksError.reset, SharedLinkError),
         (ListSharedLinksError.other, MaestralApiError),
+        (ShareFolderError.no_permission, InsufficientPermissionsError),
+        (ShareFolderError.disallowed_shared_link_policy, InsufficientPermissionsError),
+        (
+            ShareFolderError.team_policy_disallows_member_policy,
+            InsufficientPermissionsError,
+        ),
+        (ShareFolderError.email_unverified, MaestralApiError),
+        (ShareFolderError.bad_path(SharePathError.is_file), FileConflictError),
+        (ShareFolderError.bad_path(SharePathError.inside_shared_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.contains_shared_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.contains_app_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.contains_team_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.is_app_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.inside_app_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.is_public_folder), SyncError),
+        (ShareFolderError.bad_path(SharePathError.inside_public_folder), SyncError),
+        (
+            ShareFolderError.bad_path(
+                SharePathError.already_shared(SharedFolderMetadata())
+            ),
+            FolderConflictError,
+        ),
+        (ShareFolderError.bad_path(SharePathError.invalid_path), SyncError),
+        (ShareFolderError.bad_path(SharePathError.is_osx_package), SyncError),
+        (ShareFolderError.bad_path(SharePathError.inside_osx_package), SyncError),
+        (ShareFolderError.bad_path(SharePathError.is_vault), SyncError),
+        (ShareFolderError.bad_path(SharePathError.is_family), SyncError),
+        (ShareFolderError.other, MaestralApiError),
     ],
 )
 def test_dropbox_api_to_maestral_error(error, maestral_exc):
     converted = dropbox_to_maestral_error(exceptions.ApiError("", error, "", ""))
-    assert isinstance(converted, maestral_exc)
+    assert isinstance(converted, maestral_exc), f"{error} was incorrectly converted"
 
 
 @pytest.mark.parametrize(

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -13,8 +13,35 @@ from dropbox.async_ import *
 from dropbox.users import *
 from dropbox.sharing import *
 from dropbox.auth import *
+from dropbox.common import *
 
-from maestral.errors import *
+from maestral.errors import (
+    MaestralApiError,
+    InvalidDbidError,
+    DropboxAuthError,
+    TokenExpiredError,
+    TokenRevokedError,
+    CursorResetError,
+    BadInputError,
+    OutOfMemoryError,
+    SharedLinkError,
+    SyncError,
+    InsufficientPermissionsError,
+    InsufficientSpaceError,
+    PathError,
+    NotFoundError,
+    ConflictError,
+    IsAFolderError,
+    NotAFolderError,
+    DropboxServerError,
+    RestrictedContentError,
+    UnsupportedFileError,
+    FileSizeError,
+    FileReadError,
+    FileConflictError,
+    FolderConflictError,
+)
+from maestral.errors import PathRootError as MPRE
 from maestral.client import (
     os_to_maestral_error,
     dropbox_to_maestral_error,
@@ -212,6 +239,9 @@ def test_dropbox_api_to_maestral_error(error, maestral_exc):
         (oauth.NotApprovedException(), DropboxAuthError),
         (exceptions.BadInputError("", ""), BadInputError),
         (exceptions.InternalServerError("", "", ""), DropboxServerError),
+        (exceptions.PathRootError("", PathRootError.no_permission), MPRE),
+        (exceptions.PathRootError("", PathRootError.invalid_root(RootInfo())), MPRE),
+        (exceptions.PathRootError("", PathRootError.other), MPRE),
     ],
 )
 def test_dropbox_to_maestral_error(exception, maestral_exc):

--- a/tests/offline/test_manager.py
+++ b/tests/offline/test_manager.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pytest
 from dropbox.users import FullAccount
-from dropbox.common import TeamRootInfo, UserRootInfo
+from dropbox.common import RootInfo, TeamRootInfo, UserRootInfo
 
 from maestral.errors import NoDropboxDirError
 from maestral.utils.appdirs import get_home_dir
@@ -43,11 +43,11 @@ def test_migrate_path_root_user_to_team(m):
             ),
         )
 
-    def switch_path_root(nsid) -> None:
-        m.set_state("account", "path_root_nsid", nsid)
+    def update_path_root(root_info: RootInfo) -> None:
+        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
 
     m.client.get_account_info = get_account_info
-    m.client.switch_path_root = switch_path_root
+    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -58,7 +58,7 @@ def test_migrate_path_root_user_to_team(m):
 
         m.set_state("account", "path_root_type", "user")
         m.set_state("account", "path_root_nsid", "1")
-        m.set_state("account", "home_path_name", "")
+        m.set_state("account", "home_path", "")
 
         # define folder structures before and after migration
 
@@ -94,7 +94,7 @@ def test_migrate_path_root_user_to_team(m):
 
         assert m.get_state("account", "path_root_type") == "team"
         assert m.get_state("account", "path_root_nsid") == new_namespace_id
-        assert m.get_state("account", "home_path_name") == home_path
+        assert m.get_state("account", "home_path") == home_path
 
     finally:
         delete(local_dropbox_dir)
@@ -114,11 +114,11 @@ def test_migrate_path_root_team_to_user(m):
             ),
         )
 
-    def switch_path_root(nsid) -> None:
-        m.set_state("account", "path_root_nsid", nsid)
+    def update_path_root(root_info: RootInfo) -> None:
+        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
 
     m.client.get_account_info = get_account_info
-    m.client.switch_path_root = switch_path_root
+    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -129,7 +129,7 @@ def test_migrate_path_root_team_to_user(m):
 
         m.set_state("account", "path_root_type", "team")
         m.set_state("account", "path_root_nsid", "2")
-        m.set_state("account", "home_path_name", "/John Doe")
+        m.set_state("account", "home_path", "/John Doe")
 
         # define folder structures before and after migration
 
@@ -169,7 +169,7 @@ def test_migrate_path_root_team_to_user(m):
 
         assert m.get_state("account", "path_root_type") == "user"
         assert m.get_state("account", "path_root_nsid") == new_namespace_id
-        assert m.get_state("account", "home_path_name") == ""
+        assert m.get_state("account", "home_path") == ""
 
     finally:
         delete(local_dropbox_dir)
@@ -190,11 +190,11 @@ def test_migrate_path_root_team_to_team(m):
             ),
         )
 
-    def switch_path_root(nsid) -> None:
-        m.set_state("account", "path_root_nsid", nsid)
+    def update_path_root(root_info: RootInfo) -> None:
+        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
 
     m.client.get_account_info = get_account_info
-    m.client.switch_path_root = switch_path_root
+    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -205,7 +205,7 @@ def test_migrate_path_root_team_to_team(m):
 
         m.set_state("account", "path_root_type", "team")
         m.set_state("account", "path_root_nsid", "2")
-        m.set_state("account", "home_path_name", "/John Doe")
+        m.set_state("account", "home_path", "/John Doe")
 
         # define folder structures before and after migration
 
@@ -247,7 +247,7 @@ def test_migrate_path_root_team_to_team(m):
 
         assert m.get_state("account", "path_root_type") == "team"
         assert m.get_state("account", "path_root_nsid") == new_namespace_id
-        assert m.get_state("account", "home_path_name") == "/John Doe"
+        assert m.get_state("account", "home_path") == "/John Doe"
 
     finally:
         delete(local_dropbox_dir)
@@ -269,11 +269,11 @@ def test_migrate_path_root_error(m):
             ),
         )
 
-    def switch_path_root(nsid) -> None:
-        m.set_state("account", "path_root_nsid", nsid)
+    def update_path_root(root_info: RootInfo) -> None:
+        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
 
     m.client.get_account_info = get_account_info
-    m.client.switch_path_root = switch_path_root
+    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -282,7 +282,7 @@ def test_migrate_path_root_error(m):
 
     m.set_state("account", "path_root_type", "user")
     m.set_state("account", "path_root_nsid", "1")
-    m.set_state("account", "home_path_name", "")
+    m.set_state("account", "home_path", "")
 
     # attempt to migrate folder structure without Dropbox dir
 

--- a/tests/offline/test_manager.py
+++ b/tests/offline/test_manager.py
@@ -1,0 +1,290 @@
+import os
+from typing import Dict
+
+import pytest
+from dropbox.users import FullAccount
+from dropbox.common import TeamRootInfo, UserRootInfo
+
+from maestral.errors import NoDropboxDirError
+from maestral.utils.appdirs import get_home_dir
+from maestral.utils.path import generate_cc_name, delete
+
+
+def verify_folder_structure(root: str, structure: Dict[str, Dict]) -> None:
+    for name, children in structure.items():
+        path = os.path.join(root, name)
+        assert os.path.exists(path)
+
+        verify_folder_structure(path, children)
+
+
+def create_folder_structure(root: str, structure: Dict[str, Dict]) -> None:
+
+    for name, children in structure.items():
+        path = os.path.join(root, name)
+        os.makedirs(path)
+
+        create_folder_structure(path, children)
+
+
+def test_migrate_path_root_user_to_team(m):
+
+    new_namespace_id = "2"
+    home_path = "/John Doe"
+
+    # patch client and sync engine
+
+    def get_account_info() -> FullAccount:
+        return FullAccount(
+            root_info=TeamRootInfo(
+                root_namespace_id=new_namespace_id,
+                home_namespace_id="1",
+                home_path=home_path,
+            ),
+        )
+
+    def switch_path_root(nsid) -> None:
+        m.set_state("account", "path_root_nsid", nsid)
+
+    m.client.get_account_info = get_account_info
+    m.client.switch_path_root = switch_path_root
+
+    home = get_home_dir()
+    local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
+    os.makedirs(local_dropbox_dir)
+
+    try:
+        m.sync.dropbox_path = local_dropbox_dir
+
+        m.set_state("account", "path_root_type", "user")
+        m.set_state("account", "path_root_nsid", "1")
+        m.set_state("account", "home_path_name", "")
+
+        # define folder structures before and after migration
+
+        dir_layout_old = {
+            "Documents": {},
+            "Photos": {
+                "March 2019": {},
+            },
+            "John Doe": {},
+            "Personal": {},
+        }
+
+        dir_layout_new = {
+            "John Doe": {
+                "Documents": {},
+                "Photos": {
+                    "March 2019": {},
+                },
+                "John Doe": {},
+                "Personal": {},
+            }
+        }
+
+        # create folder structure before migration
+
+        create_folder_structure(local_dropbox_dir, dir_layout_old)
+
+        # migrate folder structure and verify migration
+
+        m.manager.check_and_update_path_root()
+
+        verify_folder_structure(local_dropbox_dir, dir_layout_new)
+
+        assert m.get_state("account", "path_root_type") == "team"
+        assert m.get_state("account", "path_root_nsid") == new_namespace_id
+        assert m.get_state("account", "home_path_name") == home_path
+
+    finally:
+        delete(local_dropbox_dir)
+
+
+def test_migrate_path_root_team_to_user(m):
+
+    new_namespace_id = "1"
+
+    # patch client and sync engine
+
+    def get_account_info() -> FullAccount:
+        return FullAccount(
+            root_info=UserRootInfo(
+                root_namespace_id=new_namespace_id,
+                home_namespace_id=new_namespace_id,
+            ),
+        )
+
+    def switch_path_root(nsid) -> None:
+        m.set_state("account", "path_root_nsid", nsid)
+
+    m.client.get_account_info = get_account_info
+    m.client.switch_path_root = switch_path_root
+
+    home = get_home_dir()
+    local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
+    os.makedirs(local_dropbox_dir)
+
+    try:
+        m.sync.dropbox_path = local_dropbox_dir
+
+        m.set_state("account", "path_root_type", "team")
+        m.set_state("account", "path_root_nsid", "2")
+        m.set_state("account", "home_path_name", "/John Doe")
+
+        # define folder structures before and after migration
+
+        dir_layout_old = {
+            "John Doe": {
+                "Documents": {},
+                "Photos": {
+                    "March 2019": {},
+                },
+                "John Doe": {},
+                "Personal": {},
+            },
+            "Team folder 1": {},
+            "Team folder 2": {
+                "Subfolder": {},
+            },
+        }
+
+        dir_layout_new = {
+            "Documents": {},
+            "Photos": {
+                "March 2019": {},
+            },
+            "John Doe": {},
+            "Personal": {},
+        }
+
+        # create folder structure before migration
+
+        create_folder_structure(local_dropbox_dir, dir_layout_old)
+
+        # migrate folder structure and verify migration
+
+        m.manager.check_and_update_path_root()
+
+        verify_folder_structure(local_dropbox_dir, dir_layout_new)
+
+        assert m.get_state("account", "path_root_type") == "user"
+        assert m.get_state("account", "path_root_nsid") == new_namespace_id
+        assert m.get_state("account", "home_path_name") == ""
+
+    finally:
+        delete(local_dropbox_dir)
+
+
+def test_migrate_path_root_team_to_team(m):
+
+    new_namespace_id = "3"
+
+    # patch client and sync engine
+
+    def get_account_info() -> FullAccount:
+        return FullAccount(
+            root_info=TeamRootInfo(
+                root_namespace_id=new_namespace_id,
+                home_namespace_id="1",
+                home_path="/John Doe",
+            ),
+        )
+
+    def switch_path_root(nsid) -> None:
+        m.set_state("account", "path_root_nsid", nsid)
+
+    m.client.get_account_info = get_account_info
+    m.client.switch_path_root = switch_path_root
+
+    home = get_home_dir()
+    local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
+    os.makedirs(local_dropbox_dir)
+
+    try:
+        m.sync.dropbox_path = local_dropbox_dir
+
+        m.set_state("account", "path_root_type", "team")
+        m.set_state("account", "path_root_nsid", "2")
+        m.set_state("account", "home_path_name", "/John Doe")
+
+        # define folder structures before and after migration
+
+        dir_layout_old = {
+            "John Doe": {
+                "Documents": {},
+                "Photos": {
+                    "March 2019": {},
+                },
+                "John Doe": {},
+                "Personal": {},
+            },
+            "Team folder 1": {},
+            "Team folder 2": {
+                "Subfolder": {},
+            },
+        }
+
+        dir_layout_new = {
+            "John Doe": {
+                "Documents": {},
+                "Photos": {
+                    "March 2019": {},
+                },
+                "John Doe": {},
+                "Personal": {},
+            },
+        }
+
+        # create folder structure before migration
+
+        create_folder_structure(local_dropbox_dir, dir_layout_old)
+
+        # migrate folder structure and verify migration
+
+        m.manager.check_and_update_path_root()
+
+        verify_folder_structure(local_dropbox_dir, dir_layout_new)
+
+        assert m.get_state("account", "path_root_type") == "team"
+        assert m.get_state("account", "path_root_nsid") == new_namespace_id
+        assert m.get_state("account", "home_path_name") == "/John Doe"
+
+    finally:
+        delete(local_dropbox_dir)
+
+
+def test_migrate_path_root_error(m):
+
+    new_namespace_id = "2"
+    home_path = "/John Doe"
+
+    # patch client and sync engine
+
+    def get_account_info() -> FullAccount:
+        return FullAccount(
+            root_info=TeamRootInfo(
+                root_namespace_id=new_namespace_id,
+                home_namespace_id="1",
+                home_path=home_path,
+            ),
+        )
+
+    def switch_path_root(nsid) -> None:
+        m.set_state("account", "path_root_nsid", nsid)
+
+    m.client.get_account_info = get_account_info
+    m.client.switch_path_root = switch_path_root
+
+    home = get_home_dir()
+    local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
+
+    m.sync.dropbox_path = local_dropbox_dir
+
+    m.set_state("account", "path_root_type", "user")
+    m.set_state("account", "path_root_nsid", "1")
+    m.set_state("account", "home_path_name", "")
+
+    # attempt to migrate folder structure without Dropbox dir
+
+    with pytest.raises(NoDropboxDirError):
+        m.manager.check_and_update_path_root()

--- a/tests/offline/test_manager.py
+++ b/tests/offline/test_manager.py
@@ -3,7 +3,7 @@ from typing import Dict
 
 import pytest
 from dropbox.users import FullAccount
-from dropbox.common import RootInfo, TeamRootInfo, UserRootInfo
+from dropbox.common import TeamRootInfo, UserRootInfo
 
 from maestral.errors import NoDropboxDirError
 from maestral.utils.appdirs import get_home_dir
@@ -43,11 +43,7 @@ def test_migrate_path_root_user_to_team(m):
             ),
         )
 
-    def update_path_root(root_info: RootInfo) -> None:
-        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
-
     m.client.get_account_info = get_account_info
-    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -114,11 +110,7 @@ def test_migrate_path_root_team_to_user(m):
             ),
         )
 
-    def update_path_root(root_info: RootInfo) -> None:
-        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
-
     m.client.get_account_info = get_account_info
-    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -190,11 +182,7 @@ def test_migrate_path_root_team_to_team(m):
             ),
         )
 
-    def update_path_root(root_info: RootInfo) -> None:
-        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
-
     m.client.get_account_info = get_account_info
-    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
@@ -269,11 +257,7 @@ def test_migrate_path_root_error(m):
             ),
         )
 
-    def update_path_root(root_info: RootInfo) -> None:
-        m.set_state("account", "path_root_nsid", root_info.root_namespace_id)
-
     m.client.get_account_info = get_account_info
-    m.client.update_path_root = update_path_root
 
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")


### PR DESCRIPTION
This PR fixes #441. In particular:

1. The root namespace of the user will always be used for syncing. If the root namespace is a team namespace, top level shared folders will be synced if the user has access to them.
2. We gracefully handle when a user joins or leaves a team or switches teams. When joining a team, this is currently done by moving all local "user" files to `Dropbox/User Name` and downloading shared folders to `Dropbox/`. This is reversed when leaving a team. Folders excluded by selective sync are preserved during this migration. Changing team membership will currently trigger a full reindexing but no new download of existing user files.

See https://developers.dropbox.com/dbx-team-files-guide for information on Dropbox Team Spaces.