### PR TITLE
Daemon startup improvements

### DIFF
--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -70,6 +70,7 @@ IS_WATCHDOG = WATCHDOG_USEC and (
 
 URI = "PYRO:maestral.{0}@{1}"
 Pyro5.config.THREADPOOL_SIZE_MIN = 2
+Pyro5.config.COMMTIMEOUT = 8
 
 
 def freeze_support() -> None:
@@ -450,11 +451,10 @@ def start_maestral_daemon(
         # Clean up old socket.
         try:
             os.remove(sockpath)
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
             pass
 
-        # Expose maestral as Pyro server. Convert management
-        # methods to one way calls so that they don't block.
+        # Expose maestral as Pyro server.
 
         dlogger.debug("Creating Pyro daemon")
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -322,7 +322,7 @@ def is_running(config_name: str) -> bool:
     return maestral_lock(config_name).locked()
 
 
-def wait_for_startup(config_name: str, timeout: float = 5) -> None:
+def wait_for_startup(config_name: str, timeout: float = 10) -> None:
     """
     Waits until we can communicate with the maestral daemon for ``config_name``.
 
@@ -496,7 +496,7 @@ def start_maestral_daemon(
 
 
 def start_maestral_daemon_process(
-    config_name: str = "maestral", timeout: int = 5
+    config_name: str = "maestral", timeout: int = 10
 ) -> Start:
     """
     Starts the Maestral daemon in a new process by calling :func:`start_maestral_daemon`.

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -382,6 +382,9 @@ def start_maestral_daemon(
 
     dlogger.info("Starting daemon")
 
+    # Acquire PID lock file.
+    lock = maestral_lock(config_name)
+
     try:
 
         # ==== Process and thread management ===========================================
@@ -391,9 +394,6 @@ def start_maestral_daemon(
             raise RuntimeError("Must run daemon in main thread")
 
         dlogger.debug("Environment:\n%s", pformat(os.environ.copy()))
-
-        # Acquire PID lock file.
-        lock = maestral_lock(config_name)
 
         if lock.acquire():
             dlogger.debug("Acquired daemon lock: %r", lock.path)
@@ -493,6 +493,8 @@ def start_maestral_daemon(
         if NOTIFY_SOCKET:
             # Notify systemd that we are shutting down.
             sd_notifier.notify("STOPPING=1")
+
+        lock.release()
 
 
 def start_maestral_daemon_process(

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -323,7 +323,7 @@ def is_running(config_name: str) -> bool:
     return maestral_lock(config_name).locked()
 
 
-def wait_for_startup(config_name: str, timeout: float = 10) -> None:
+def wait_for_startup(config_name: str, timeout: float = 20) -> None:
     """
     Waits until we can communicate with the maestral daemon for ``config_name``.
 
@@ -498,7 +498,7 @@ def start_maestral_daemon(
 
 
 def start_maestral_daemon_process(
-    config_name: str = "maestral", timeout: int = 10
+    config_name: str = "maestral", timeout: float = 20
 ) -> Start:
     """
     Starts the Maestral daemon in a new process by calling :func:`start_maestral_daemon`.
@@ -556,7 +556,7 @@ def start_maestral_daemon_process(
 
 
 def stop_maestral_daemon_process(
-    config_name: str = "maestral", timeout: float = 10
+    config_name: str = "maestral", timeout: float = 20
 ) -> Stop:
     """Stops a maestral daemon process by finding its PID and shutting it down.
 

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -147,7 +147,7 @@ def proxy(m):
 # helper functions
 
 
-def wait_for_idle(m: Maestral, minimum: int = 5):
+def wait_for_idle(m: Maestral, minimum: int = 10):
     """Blocks until Maestral instance is idle for at least `minimum` sec."""
 
     t0 = time.time()

--- a/tests/linked/test_cli.py
+++ b/tests/linked/test_cli.py
@@ -53,11 +53,16 @@ def test_pause_resume(proxy):
     wait_for_idle(proxy)
 
     assert result.exit_code == 0
-    assert proxy.paused
+
+    timeout = 20
+    t0 = time.time()
+
+    while not proxy.paused:
+        time.sleep(0.5)
+        if time.time() - t0 > timeout:
+            raise AssertionError("Daemon did not pause")
 
     result = runner.invoke(main, ["resume", "-c", proxy.config_name])
-
-    wait_for_idle(proxy)
 
     assert result.exit_code == 0
     assert not proxy.paused

--- a/tests/linked/test_cli.py
+++ b/tests/linked/test_cli.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import os
 import time
 
@@ -30,7 +29,6 @@ def wait_for_idle(m: MaestralProxy, minimum: int = 2):
             m.status_change_longpoll(timeout=minimum)
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_start_stop(proxy):
 
     config_name = proxy.config_name

--- a/tests/offline/test_cli.py
+++ b/tests/offline/test_cli.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import sys
 import logging
 
-import pytest
 from click.testing import CliRunner
 
 from maestral.cli import main
@@ -32,7 +30,6 @@ def test_invalid_config(m):
     )
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_start(config_name):
 
     res = start_maestral_daemon_process(config_name, timeout=20)
@@ -46,7 +43,6 @@ def test_start(config_name):
     assert "already running" in result.output
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_stop(config_name):
 
     res = start_maestral_daemon_process(config_name, timeout=20)
@@ -147,7 +143,6 @@ def test_excluded_remove(m):
     assert "Daemon must be running to download folders." in result.output
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_notify_level(config_name):
 
     start_maestral_daemon_process(config_name, timeout=20)
@@ -175,7 +170,6 @@ def test_notify_level(config_name):
     assert isinstance(result.exception, SystemExit)
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_notify_snooze(config_name):
 
     start_maestral_daemon_process(config_name, timeout=20)

--- a/tests/offline/test_daemon.py
+++ b/tests/offline/test_daemon.py
@@ -142,7 +142,6 @@ def test_locking_multiprocess(tmp_path):
 # daemon lifecycle tests
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_lifecycle(config_name):
 
     # start daemon process
@@ -166,7 +165,6 @@ def test_lifecycle(config_name):
 # proxy tests
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_connection(config_name):
 
     # start daemon process
@@ -197,7 +195,6 @@ def test_fallback(config_name):
         assert isinstance(m._m, Maestral)
 
 
-@pytest.mark.flaky(reruns=5, condition=sys.platform == "darwin")
 def test_remote_exceptions(config_name):
 
     # start daemon process


### PR DESCRIPTION
* Tweak timeouts for daemon startup.
* Release lock explicitly before daemon exit.
* Don't rerun flaky tests.