### PR TITLE
Clone both `dbx` and `dbx_base` SDKs

### DIFF
--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -398,6 +398,9 @@ class DropboxClient:
         if self._dbx:
             client._dbx = self._dbx.clone(session=session)
 
+        if self._dbx_base:
+            client._dbx_base = self._dbx_base.clone(session=session)
+
         return client
 
     def clone_with_new_session(self) -> "DropboxClient":


### PR DESCRIPTION
This PR improves the process of cloning the Dropbox client with a new session by cloning both the base client and the root namespaced client. This reduces unnecessary keyring access calls.