### PR TITLE
Improve OSError handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixes an issue where the output of CLI commands would get truncated to 80 chars when
   piped to another command and not attached to an interactive stream such as a terminal.
+* Improve handling of OSErrors when determining the ctime of a local file.
 
 ## v1.5.1
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -121,6 +121,7 @@ from .utils.appdirs import get_data_path
 
 __all__ = [
     "Conflict",
+    "SyncDirection",
     "FSEventHandler",
     "SyncEngine",
 ]

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3226,6 +3226,7 @@ class SyncEngine:
         :param local_path: Absolute path on local drive.
         :returns: Ctime or -1.0.
         """
+
         try:
             stat = os.stat(local_path)
             if S_ISDIR(stat.st_mode):
@@ -3246,6 +3247,8 @@ class SyncEngine:
                 return stat.st_ctime
         except (FileNotFoundError, NotADirectoryError):
             return -1.0
+        except OSError as exc:
+            raise os_to_maestral_error(exc, local_path=local_path)
 
     def _clean_remote_changes(self, changes: ListFolderResult) -> ListFolderResult:
         """

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1310,36 +1310,53 @@ class SyncEngine:
         """Returns ``True`` in case of sync errors, ``False`` otherwise."""
         return len(self.sync_errors) > 0
 
-    def clear_sync_error(
-        self, local_path: Optional[str] = None, dbx_path: Optional[str] = None
-    ) -> None:
+    def clear_sync_error(self, event: SyncEvent) -> None:
         """
-        Clears all sync errors for ``local_path`` or ``dbx_path``.
+        Clears all sync errors after a successful sync event.
 
-        :param local_path: Absolute path on local drive.
-        :param dbx_path: Path relative to Dropbox folder.
+        :param event: Successfully applied sync event.
         """
 
-        if local_path and not dbx_path:
-            dbx_path = self.to_dbx_path(local_path)
-        elif not dbx_path and not local_path:
-            return
+        self.upload_errors.discard(event.dbx_path_lower)
+        self.download_errors.discard(event.dbx_path_lower)
 
-        dbx_path = cast(str, dbx_path)
-        dbx_path_lower = normalize(dbx_path)
+        recursive = event.is_deleted or event.is_moved
 
-        if self.has_sync_errors():
-            for error in self.sync_errors.copy():
-                if error.dbx_path and is_equal_or_child(
-                    normalize(error.dbx_path), dbx_path_lower
-                ):
-                    try:
-                        self.sync_errors.remove(error)
-                    except KeyError:
-                        pass
+        if event.is_moved:
+            self.upload_errors.discard(event.dbx_path_from_lower)
+            self.download_errors.discard(event.dbx_path_from_lower)
 
-        self.upload_errors.discard(dbx_path_lower)
-        self.download_errors.discard(dbx_path_lower)
+        for error in self.sync_errors.copy():
+
+            if not error.dbx_path:
+                continue
+
+            error_path_lower = normalize(error.dbx_path)
+
+            if error_path_lower == event.dbx_path_lower:
+                self.sync_errors.discard(error)
+
+            if recursive and is_child(error_path_lower, event.dbx_path_lower):
+                self.sync_errors.discard(error)
+
+            if event.is_moved and is_child(error_path_lower, event.dbx_path_from_lower):
+                self.sync_errors.discard(error)
+
+        if recursive:
+
+            for path in list(self.upload_errors):
+                if is_child(path, event.dbx_path_lower):
+                    self.upload_errors.discard(path)
+
+                if event.is_moved and is_child(path, event.dbx_path_from_lower):
+                    self.upload_errors.discard(path)
+
+            for path in list(self.download_errors):
+                if is_child(path, event.dbx_path_lower):
+                    self.download_errors.discard(path)
+
+                if event.is_moved and is_child(path, event.dbx_path_from_lower):
+                    self.download_errors.discard(path)
 
     def clear_sync_errors(self) -> None:
         """Clears all sync errors."""
@@ -2198,8 +2215,7 @@ class SyncEngine:
 
         self._slow_down()
 
-        self.clear_sync_error(local_path=event.local_path)
-        self.clear_sync_error(local_path=event.local_path_from)
+        self.clear_sync_error(event)
         event.status = SyncStatus.Syncing
 
         try:
@@ -3325,7 +3341,7 @@ class SyncEngine:
 
         self._slow_down()
 
-        self.clear_sync_error(dbx_path=event.dbx_path)
+        self.clear_sync_error(event)
         event.status = SyncStatus.Syncing
 
         try:

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -1093,9 +1093,7 @@ def test_unknown_path_encoding(m, capsys):
 
 
 def test_sync_event_conversion_performance(m):
-    """
-    Tests the performance of converting remote file changes to SyncEvents.
-    """
+    """Tests the performance of converting remote file changes to SyncEvents."""
 
     # generate tree with 5 entries
     shutil.copytree(resources + "/test_folder", m.test_folder_local + "/test_folder")
@@ -1146,6 +1144,7 @@ def test_invalid_pending_download(m):
 
 
 def test_out_of_order_indexing(m):
+    """Tests applying remote events when children are synced before their parents."""
 
     m.stop_sync()
 

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -21,6 +21,7 @@ from maestral.utils.path import (
     normalize,
     fs_max_lengths_for_path,
 )
+from maestral.errors import PathError
 
 from .conftest import assert_synced, wait_for_idle, resources
 
@@ -868,8 +869,12 @@ def test_long_path_error(m):
     max_path_length, _ = fs_max_lengths_for_path()
 
     # Create a remote folder with a path name longer than locally allowed.
-    test_path = m.test_folder_dbx + "/nested" * (max_path_length // 5)
-    m.client.upload(f"{resources}/file.txt", test_path)
+    test_path = m.test_folder_dbx + "/nested" * (max_path_length // 6)
+
+    try:
+        m.client.upload(f"{resources}/file.txt", test_path)
+    except PathError:
+        pytest.skip(f"Cannot create path with {len(test_path)} chars on Dropbox")
 
     wait_for_idle(m)
 

--- a/tests/offline/test_cli.py
+++ b/tests/offline/test_cli.py
@@ -11,6 +11,9 @@ from maestral.daemon import MaestralProxy, start_maestral_daemon_process, Start
 from maestral.logging import scoped_logger
 
 
+TEST_TIMEOUT = 60
+
+
 def test_help():
     runner = CliRunner()
     result = runner.invoke(main)
@@ -32,7 +35,7 @@ def test_invalid_config(m):
 
 def test_start(config_name):
 
-    res = start_maestral_daemon_process(config_name, timeout=20)
+    res = start_maestral_daemon_process(config_name, timeout=TEST_TIMEOUT)
 
     assert res is Start.Ok
 
@@ -45,7 +48,7 @@ def test_start(config_name):
 
 def test_stop(config_name):
 
-    res = start_maestral_daemon_process(config_name, timeout=20)
+    res = start_maestral_daemon_process(config_name, timeout=TEST_TIMEOUT)
     assert res is Start.Ok
 
     runner = CliRunner()
@@ -145,7 +148,7 @@ def test_excluded_remove(m):
 
 def test_notify_level(config_name):
 
-    start_maestral_daemon_process(config_name, timeout=20)
+    start_maestral_daemon_process(config_name, timeout=TEST_TIMEOUT)
     m = MaestralProxy(config_name)
 
     runner = CliRunner()
@@ -172,7 +175,7 @@ def test_notify_level(config_name):
 
 def test_notify_snooze(config_name):
 
-    start_maestral_daemon_process(config_name, timeout=20)
+    start_maestral_daemon_process(config_name, timeout=TEST_TIMEOUT)
     m = MaestralProxy(config_name)
 
     runner = CliRunner()


### PR DESCRIPTION
This PR improves the handling of some OSErrors:

1. Improves handling of OSErrors when determining the ctime of local files. Fixes #506.
2. Improve error messages when file names or paths are too long.
3. Only recursively clear errors when a successful deletion or move occurs.