### PR TITLE
Inode-based hash cache

### DIFF
--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -462,7 +462,7 @@ class IndexEntry(Model):
 
     __tablename__ = "'index'"
 
-    dbx_path_lower = Column(SqlPath(), nullable=False, primary_key=True)
+    dbx_path_lower = Column(SqlPath(), primary_key=True)
     """
     Dropbox path of the item in lower case. This acts as a primary key for the SQLites
     database since there can only be one entry per case-insensitive Dropbox path.
@@ -515,11 +515,14 @@ class IndexEntry(Model):
 class HashCacheEntry(Model):
     """Represents an entry in our cache of content hashes"""
 
-    __slots__ = ["_local_path", "_hash_str", "_mtime"]
+    __slots__ = ["_inode", "_local_path", "_hash_str", "_mtime"]
 
     __tablename__ = "hash_cache"
 
-    local_path = Column(SqlPath(), nullable=False, primary_key=True)
+    inode = Column(SqlInt(), primary_key=True)
+    """The inode of the item."""
+
+    local_path = Column(SqlPath(), nullable=False)
     """The local path of the item."""
 
     hash_str = Column(SqlString())
@@ -527,6 +530,6 @@ class HashCacheEntry(Model):
 
     mtime = Column(SqlFloat())
     """
-    The mtime of the item just before the hash was computed. When the current ctime is
+    The mtime of the item just before the hash was computed. When the current mtime is
     newer, the hash will need to be recalculated.
     """

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1453,6 +1453,8 @@ class Maestral:
             self._update_from_pre_v1_4_5()
         if Version(updated_from) < Version("1.4.8"):
             self._update_from_pre_v1_4_8()
+        if Version(updated_from) < Version("1.5.3.dev0"):
+            self._update_from_pre_v1_5_3()
 
         self._state.set("app", "updated_scripts_completed", __version__)
 
@@ -1508,7 +1510,16 @@ class Maestral:
                 value = self._state.get(sections["old"], key)
                 self._state.set(sections["new"], key, value)
 
-    # ==== Periodic async jobs ===========================================================
+    def _update_from_pre_v1_5_3(self) -> None:
+
+        self._logger.info("Clearing hash cache after update from pre v1.5.3.dev0")
+
+        db_path = get_data_path("maestral", f"{self.config_name}.db")
+        db = Database(db_path, check_same_thread=False)
+        db.execute("DROP TABLE hash_cache")
+        db.close()
+
+    # ==== Periodic async jobs =========================================================
 
     def _schedule_task(self, coro: Awaitable) -> None:
         """Schedules a task in our asyncio loop."""

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -126,6 +126,7 @@ class Column(property):
     :param unique: If ``True``, sets a unique constraint on the column.
     :param primary_key: If ``True``, marks this column as a primary key column.
         Currently, only a single primary key column is supported.
+    :param index: If ``True``, create an index on this column.
     :param default: Default value for the column. Set to :class:`NoDefault` if no
         default value should be used. Note than None / NULL is a valid default for an
         SQLite column.
@@ -137,6 +138,7 @@ class Column(property):
         nullable: bool = True,
         unique: bool = False,
         primary_key: bool = False,
+        index: bool = False,
         default: DefaultColumnValueType = None,
     ):
         super().__init__(fget=self._fget, fset=self._fset)
@@ -145,6 +147,7 @@ class Column(property):
         self.nullable = nullable
         self.unique = unique
         self.primary_key = primary_key
+        self.index = index
 
         self.default: DefaultColumnValueType
 
@@ -357,6 +360,12 @@ class Manager:
         sql = f"CREATE TABLE {self.model.__tablename__} ({column_defs_str});"
 
         self.db.executescript(sql)
+
+        for column in columns(self.model):
+            if column.index:
+                idx_name = f"idx_{self.model.__tablename__}_{column.name}"
+                sql = f"CREATE INDEX {idx_name} ON {self.model.__tablename__} ({column.name});"
+                self.db.executescript(sql)
 
     def clear_cache(self) -> None:
         """Clears our cache."""


### PR DESCRIPTION
Maestral saves content hashes of local files in a SQLite database table. This acts as a cache to avoid repeatedly calculating content hashes of the same file if it has not been modified. To avoid returning outdated hashes, the mtime is stored together with the hash and compared against the current mtime of the file. If the mtime is different, the hash is recalculated.

The primary key for the table currently is the local file path. This can lead to incorrect hashes being returned from the cache if a local file was replaced by another file with the same mtime.

This PR uses the inode as the primary key instead and still checks for equal mtimes. This guards both against different files with the same mtime and different files with the same inode (inode recycling).

The local path is still stored in the database table to clear cache entries when a file is deleted (we currently don't get inodes from file system events). For better performance an index is created on the `local_path` column.