### PR TITLE
Fix move to existing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   due to a missing packaged library.
 * Fixes an issue which prevented the `maestral gui` command from working with the macOS
   app bundle.
+* Fixes an issue where moving a local file to overwrite another file, for example with mv
+  in the terminal, could generate an incorrect conflicting copy during upload sync.
 
 ## v1.5.2
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2338,8 +2338,8 @@ class SyncEngine:
             # If not on Dropbox, e.g., because its old name was invalid,
             # create it instead of moving it.
             self._logger.debug(
-                "Could not move '%s' -> '%s' on Dropbox, source does not exists. "
-                "Creating '%s' instead",
+                'Could not move "%s" -> "%s" on Dropbox, source does not exists. '
+                'Creating "%s" instead',
                 event.dbx_path_from,
                 event.dbx_path,
                 event.dbx_path,

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -270,6 +270,34 @@ def test_mignore(m):
     assert not m.fatal_errors
 
 
+def test_move_to_existing_file(m):
+
+    # create two local files
+
+    path0 = m.test_folder_local + "/file0.txt"
+    path1 = m.test_folder_local + "/file1.txt"
+
+    with open(path0, "a") as f:
+        f.write("c0")
+
+    with open(path1, "a") as f:
+        f.write("c1")
+
+    wait_for_idle(m)
+
+    # move file0 to file1
+
+    shutil.move(path0, path1)
+
+    wait_for_idle(m)
+
+    # check that move was successful
+
+    assert_synced(m)
+    assert_exists(m, m.test_folder_dbx, "file1.txt")
+    assert_child_count(m, m.test_folder_dbx, 1)
+
+
 # ==== test conflict resolution ========================================================
 
 


### PR DESCRIPTION
Fixes #570. When a local moves overwrites an existing file, the existing file will now be correctly replaced on Dropbox servers. This is done by removing the remote file first, if its rev matches the local file (i.e., if it has no un-synced changes which would be lost).