### PR TITLE
Handle dropbox dir case changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   app bundle.
 * Fixes an issue where moving a local file to overwrite another file, for example with mv
   in the terminal, could generate an incorrect conflicting copy during upload sync.
+* Properly handle when the local Dropbox directory is renamed by changing the casing only
+  on case-insensitive file systems such as APFS on macOS.
 
 ## v1.5.2
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -107,6 +107,7 @@ from .utils.path import (
     delete,
     is_child,
     is_equal_or_child,
+    is_fs_case_sensitive,
     content_hash,
     walk,
     normalize,
@@ -544,6 +545,7 @@ class SyncEngine:
         """
 
         self._dropbox_path = self._conf.get("sync", "path")
+        self._is_fs_case_sensitive = is_fs_case_sensitive(self._dropbox_path)
         self._mignore_path = osp.join(self._dropbox_path, MIGNORE_FILE)
         self._file_cache_path = osp.join(self._dropbox_path, FILE_CACHE)
 
@@ -573,9 +575,15 @@ class SyncEngine:
 
         with self.sync_lock:
             self._dropbox_path = path
+            self._is_fs_case_sensitive = is_fs_case_sensitive(path)
             self._mignore_path = osp.join(self._dropbox_path, MIGNORE_FILE)
             self._file_cache_path = osp.join(self._dropbox_path, FILE_CACHE)
             self._conf.set("sync", "path", path)
+
+    @property
+    def is_fs_case_sensitive(self) -> bool:
+        """Whether the local Dropbox directory lies on a case-sensitive file system."""
+        return self._is_fs_case_sensitive
 
     @property
     def database_path(self) -> str:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1415,8 +1415,7 @@ class SyncEngine:
         self.upload_errors.clear()
         self.download_errors.clear()
 
-    @staticmethod
-    def is_excluded(path: str) -> bool:
+    def is_excluded(self, path: str) -> bool:
         """
         Checks if a file is excluded from sync. Certain file names are always excluded
         from syncing, following the Dropbox support article:
@@ -1439,7 +1438,14 @@ class SyncEngine:
             return True
 
         # Is in excluded dirs?
-        root_dir = next(iter(part for part in dirname.split("/", 2) if part), "")
+
+        try:
+            dbx_dirname = self.to_dbx_path(dirname)
+        except ValueError:
+            # Path is already relative to Dropbox.
+            dbx_dirname = dirname
+
+        root_dir = next(iter(part for part in dbx_dirname.split("/", 2) if part), "")
 
         if root_dir in EXCLUDED_DIR_NAMES:
             return True

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1401,10 +1401,6 @@ class SyncEngine:
         :returns: Whether the path is excluded from syncing.
         """
 
-        # Is root folder?
-        if path in ("/", ""):
-            return True
-
         dirname, basename = osp.split(path)
 
         # Is in excluded files?

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -76,6 +76,10 @@ def is_fs_case_sensitive(path: str) -> bool:
     :param path: Path to check.
     :returns: Whether ``path`` lies on a partition with a case-sensitive file system.
     """
+
+    if path == osp.pathsep:
+        raise ValueError(f"Cannot check '{osp.pathsep}'")
+
     if path.islower():
         check_path = path.upper()
     else:

--- a/tests/linked/test_main.py
+++ b/tests/linked/test_main.py
@@ -450,14 +450,8 @@ def test_inotify_error(m):
         wait_for_idle(m)
         m.start_sync()
 
-        assert len(m.fatal_errors) > 0
-
-        last_error = m.fatal_errors[-1]
-
-        assert last_error["type"] == "InotifyError"
-        assert not m.manager.local_observer_thread.is_alive()
-        assert m.manager.upload_thread.is_alive()
-        assert m.manager.download_thread.is_alive()
+        assert len(m.fatal_errors) == 1
+        assert m.fatal_errors[0]["type"] == "InotifyError"
 
     finally:
         subprocess.check_call(


### PR DESCRIPTION
This PR fixes #555 by properly detecting when the casing of the local Dropbox directory has changed on case-insensitive file systems.