### PR TITLE
Replace deprecated usage of `asyncio.get_event_loop()`

### DIFF
--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -136,7 +136,7 @@ class Maestral:
         self.sync = self.manager.sync
 
         # Schedule background tasks.
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_event_loop_policy().get_event_loop()
         self._tasks: Set[asyncio.Task] = set()
         self._pool = ThreadPoolExecutor(
             thread_name_prefix="maestral-thread-pool",

--- a/src/maestral/notify.py
+++ b/src/maestral/notify.py
@@ -99,7 +99,7 @@ class MaestralDesktopNotifier:
     def __init__(self, config_name: str) -> None:
         self._conf = MaestralConfig(config_name)
         self._snooze = 0.0
-        self._loop = asyncio.get_event_loop()
+        self._loop = asyncio.get_event_loop_policy().get_event_loop()
 
     @property
     def notify_level(self) -> int:


### PR DESCRIPTION
This PR replaces the usage of `asyncio.get_event_loop()` which was deprecated in Python 3.10.