### PR TITLE
Improve symlink handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest --cov=maestral --cov-report=xml tests/offline
+          python -m pytest --cov=maestral --cov-report=xml tests/offline
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   notification. Previously, only clicking on the "Show" button of the notification
   would open the file browser.
 * Removed update notifications by the CLI.
+* Proper symlink handling: Remote items which are symlinks will now be synced as symlinks
+  instead of empty files. Local symlinks will no longer be followed during indexing or
+  silently ignored when syncing. Instead, attempting to upload a symlink will raise an
+  error because uploading symlinks is not currently supported by the public Dropbox API.
 
 #### Fixed:
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -674,7 +674,7 @@ class DropboxClient:
 
         with convert_api_errors(dbx_path=dbx_path, local_path=local_path):
 
-            stat = os.stat(local_path, follow_symlinks=False)
+            stat = os.lstat(local_path)
 
             # Dropbox SDK takes naive datetime in UTC/
             mtime_dt = datetime.utcfromtimestamp(stat.st_mtime)

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -60,6 +60,7 @@ from .errors import (
     NotAFolderError,
     IsAFolderError,
     FileSizeError,
+    SymlinkError,
     OutOfMemoryError,
     BadInputError,
     DropboxAuthError,
@@ -1337,6 +1338,10 @@ def os_to_maestral_error(
         err_cls = FileSizeError  # subclass of SyncError
         title = "Could not download file"
         text = "The file size too large."
+    elif exc.errno == errno.ELOOP:
+        err_cls = SymlinkError  # subclass of SyncError
+        title = "Cannot upload symlink"
+        text = "Symlinks are not currently supported by the public Dropbox API."
     elif exc.errno == errno.ENOSPC:
         err_cls = InsufficientSpaceError  # subclass of SyncError
         title = "Could not download file"

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -76,7 +76,7 @@ from .errors import (
 from .config import MaestralState
 from .constants import DROPBOX_APP_KEY
 from .utils import natural_size, chunks, clamp
-from .utils.path import fs_max_lengths_for_path
+from .utils.path import fs_max_lengths_for_path, opener_no_symlink
 
 if TYPE_CHECKING:
     from .database import SyncEvent
@@ -620,7 +620,7 @@ class DropboxClient:
 
             chunksize = 2 ** 13
 
-            with open(local_path, "wb") as f:
+            with open(local_path, "wb", opener=opener_no_symlink) as f:
                 with contextlib.closing(http_resp):
                     for c in http_resp.iter_content(chunksize):
                         f.write(c)
@@ -634,7 +634,7 @@ class DropboxClient:
             # Enforce client_modified < server_modified.
             timestamp = min(client_mod.timestamp(), server_mod.timestamp(), time.time())
             # Set mtime of downloaded file.
-            os.utime(local_path, (time.time(), timestamp))
+            os.utime(local_path, (time.time(), timestamp), follow_symlinks=False)
 
         return md
 
@@ -663,14 +663,13 @@ class DropboxClient:
 
         with convert_api_errors(dbx_path=dbx_path, local_path=local_path):
 
-            size = osp.getsize(local_path)
+            stat = os.stat(local_path, follow_symlinks=False)
 
             # Dropbox SDK takes naive datetime in UTC/
-            mtime = osp.getmtime(local_path)
-            mtime_dt = datetime.utcfromtimestamp(mtime)
+            mtime_dt = datetime.utcfromtimestamp(stat.st_mtime)
 
-            if size <= chunk_size:
-                with open(local_path, "rb") as f:
+            if stat.st_size <= chunk_size:
+                with open(local_path, "rb", opener=opener_no_symlink) as f:
                     md = self.dbx.files_upload(
                         f.read(), dbx_path, client_modified=mtime_dt, **kwargs
                     )
@@ -681,7 +680,7 @@ class DropboxClient:
                 # Note: We currently do not support resuming interrupted uploads.
                 # Dropbox keeps upload sessions open for 48h so this could be done in
                 # the future.
-                with open(local_path, "rb") as f:
+                with open(local_path, "rb", opener=opener_no_symlink) as f:
                     data = f.read(chunk_size)
                     session_start = self.dbx.files_upload_session_start(data)
                     uploaded = f.tell()
@@ -699,7 +698,7 @@ class DropboxClient:
                     while True:
                         try:
 
-                            if size - f.tell() <= chunk_size:
+                            if stat.st_size - f.tell() <= chunk_size:
                                 # Finish upload session and return metadata.
                                 data = f.read(chunk_size)
                                 md = self.dbx.files_upload_session_finish(

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -478,6 +478,7 @@ class IndexEntry(Model):
         "_last_sync",
         "_rev",
         "_content_hash",
+        "_symlink_target",
     ]
 
     __tablename__ = "'index'"
@@ -515,15 +516,25 @@ class IndexEntry(Model):
     ``None`` if not yet calculated.
     """
 
+    symlink_target = Column(SqlPath())
+    """
+    If the file is a symlink, its target path. This should only be set for files.
+    """
+
     @property
     def is_file(self) -> bool:
-        """Returns True for file changes"""
+        """Returns True for files"""
         return self.item_type == ItemType.File
 
     @property
     def is_directory(self) -> bool:
-        """Returns True for folder changes"""
+        """Returns True for folders"""
         return self.item_type == ItemType.Folder
+
+    @property
+    def is_symlink(self) -> bool:
+        """Returns True for symlinks"""
+        return self.symlink_target is not None
 
     def __repr__(self):
         return (

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -103,6 +103,7 @@ class SyncEvent(Model):
         "_local_path_from",
         "_rev",
         "_content_hash",
+        "_symlink_target",
         "_change_type",
         "_change_dbid",
         "_change_user_name",
@@ -183,6 +184,11 @@ class SyncEvent(Model):
     """
     A hash representing the file content. Will be ``'folder'`` for folders and ``None``
     for deletions. Set for both local and remote changes.
+    """
+
+    symlink_target = Column(SqlPath())
+    """
+    If the file is a symlink, its target path. This should only be set for files.
     """
 
     change_type = Column(SqlEnum(ChangeType), nullable=False)
@@ -294,6 +300,7 @@ class SyncEvent(Model):
             size = 0
             rev = None
             hash_str = None
+            symlink_target = None
             dbx_id = None
             change_dbid = None
 
@@ -312,6 +319,7 @@ class SyncEvent(Model):
             size = 0
             rev = "folder"
             hash_str = "folder"
+            symlink_target = None
             dbx_id = md.id
             change_time = None
             change_dbid = None
@@ -320,6 +328,7 @@ class SyncEvent(Model):
             item_type = ItemType.File
             rev = md.rev
             hash_str = md.content_hash
+            symlink_target = md.symlink_info.target if md.symlink_info else None
             dbx_id = md.id
             size = md.size
             change_time = md.client_modified.replace(tzinfo=timezone.utc).timestamp()
@@ -348,6 +357,7 @@ class SyncEvent(Model):
             local_path=sync_engine.to_local_path_from_cased(dbx_path_cased),
             rev=rev,
             content_hash=hash_str,
+            symlink_target=symlink_target,
             change_type=change_type,
             change_time=change_time,
             change_dbid=change_dbid,
@@ -394,7 +404,7 @@ class SyncEvent(Model):
         stat: Optional[os.stat_result]
 
         try:
-            stat = os.stat(to_path)
+            stat = os.stat(to_path, follow_symlinks=False)
         except OSError:
             stat = None
 
@@ -410,10 +420,15 @@ class SyncEvent(Model):
                 change_time = stat.st_birthtime  # type: ignore
             except AttributeError:
                 change_time = None
+            symlink_target = None
         else:
             item_type = ItemType.File
             change_time = stat.st_ctime if stat else None
             size = stat.st_size if stat else 0
+            try:
+                symlink_target = os.readlink(event.src_path)
+            except OSError:
+                symlink_target = None
 
         dbx_path = sync_engine.to_dbx_path(to_path)
         dbx_path_lower = normalize(dbx_path)
@@ -438,6 +453,7 @@ class SyncEvent(Model):
             dbx_path_from_lower=dbx_path_from_lower,
             local_path_from=from_path,
             content_hash=content_hash,
+            symlink_target=symlink_target,
             change_type=change_type,
             change_time=change_time,
             change_dbid=change_dbid,

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -277,11 +277,15 @@ class SyncEvent(Model):
         return self.direction == SyncDirection.Down
 
     def __repr__(self):
-        return (
-            f"<{self.__class__.__name__}(direction={self.direction.name}, "
-            f"change_type={self.change_type.name}, item_type={self.item_type}, "
-            f"dbx_path='{self.dbx_path}')>"
-        )
+
+        properties = ["direction", "change_type", "item_type", "dbx_path"]
+
+        if self.change_type is ChangeType.Moved:
+            properties.append("dbx_path_from")
+
+        prop_str = ", ".join(f"{p}={getattr(self, p)}" for p in properties)
+
+        return f"<{self.__class__.__name__}({prop_str})>"
 
     @classmethod
     def from_dbx_metadata(cls, md: Metadata, sync_engine: "SyncEngine") -> "SyncEvent":

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -120,6 +120,10 @@ class FileReadError(SyncError):
     """Raised when reading a local file failed."""
 
 
+class SymlinkError(SyncError):
+    """Raised when we cannot sync a symlink."""
+
+
 # ==== errors which are not related to a specific sync event ===========================
 
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1433,6 +1433,10 @@ class SyncEngine:
             if basename.startswith("~") and basename.endswith(".tmp"):
                 return True
 
+        # Is a child of a symlinked path:
+        if osp.realpath(dirname) != dirname:
+            return True
+
         return False
 
     def is_excluded_by_user(self, dbx_path_lower: str) -> bool:
@@ -1844,7 +1848,7 @@ class SyncEngine:
 
         for event in sync_events:
 
-            if self.is_excluded(event.dbx_path) or self.is_mignore(event):
+            if self.is_excluded(event.local_path) or self.is_mignore(event):
                 continue
 
             if event.is_deleted:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -859,6 +859,10 @@ class SyncEngine:
             self._db_manager_hash_cache.clear_cache()
             return None
         except OSError as err:
+
+            if err.errno == errno.ENAMETOOLONG:
+                return None
+
             raise os_to_maestral_error(err)
 
         if S_ISDIR(stat.st_mode):
@@ -897,6 +901,11 @@ class SyncEngine:
         except OSError as err:
 
             if err.errno == errno.EINVAL:
+                # File is not a symlink.
+                return None
+
+            if err.errno == errno.ENAMETOOLONG:
+                # Path cannot exist on this filesystem.
                 return None
 
             raise os_to_maestral_error(err)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3259,7 +3259,6 @@ class SyncEngine:
         """
 
         local_rev = self.get_local_rev(event.dbx_path_lower)
-        local_symlink_target = self.get_local_symlink_target(event.local_path)
 
         if event.rev == local_rev:
             # Local change has the same rev. The local item (or deletion) must be newer
@@ -3271,10 +3270,9 @@ class SyncEngine:
             )
             return Conflict.LocalNewerOrIdentical
 
-        elif (
-            event.content_hash == self.get_local_hash(event.local_path)
-            and event.symlink_target == local_symlink_target
-        ):
+        elif event.content_hash == self.get_local_hash(
+            event.local_path
+        ) and event.symlink_target == self.get_local_symlink_target(event.local_path):
             # Content hashes are equal, therefore items are identical. Folders will
             # have a content hash of 'folder'.
             self._logger.debug(

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3550,8 +3550,13 @@ class SyncEngine:
             # Ignore FileDeletedEvent when replacing old file.
             ignore_events.append(FileDeletedEvent(local_path))
 
+        is_symlink = event.symlink_target is not None
+
+        if is_symlink:
+            ignore_events.append(DirMovedEvent(tmp_fname, local_path))
+
         # Move the downloaded file to its destination.
-        with self.fs_events.ignore(*ignore_events):
+        with self.fs_events.ignore(*ignore_events, recursive=is_symlink):
             with convert_api_errors(dbx_path=event.dbx_path, local_path=local_path):
                 stat = os.stat(tmp_fname, follow_symlinks=False)
                 move(

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -952,6 +952,7 @@ class SyncEngine:
                     last_sync=self._get_ctime(event.local_path),
                     rev=event.rev,
                     content_hash=event.content_hash,
+                    symlink_target=event.symlink_target,
                 )
 
                 self._db_manager_index.update(entry)
@@ -976,10 +977,14 @@ class SyncEngine:
 
             else:
 
+                symlink_target: Optional[str] = None
+
                 if isinstance(md, FileMetadata):
                     rev = md.rev
                     hash_str = md.content_hash
                     item_type = ItemType.File
+                    if md.symlink_info:
+                        symlink_target = md.symlink_info.target
                 else:
                     rev = "folder"
                     hash_str = "folder"
@@ -997,6 +1002,7 @@ class SyncEngine:
                     last_sync=None,
                     rev=rev,
                     content_hash=hash_str,
+                    symlink_target=symlink_target,
                 )
 
                 self._db_manager_index.update(entry)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -846,7 +846,7 @@ class SyncEngine:
         """
 
         try:
-            stat = os.stat(local_path, follow_symlinks=False)
+            stat = os.lstat(local_path)
         except (FileNotFoundError, NotADirectoryError):
             # Remove all cache entries for local_path and return None.
             with self._database_access():
@@ -3338,7 +3338,7 @@ class SyncEngine:
         with convert_api_errors():  # Catch OSErrors.
 
             try:
-                stat = os.stat(local_path, follow_symlinks=False)
+                stat = os.lstat(local_path)
             except (FileNotFoundError, NotADirectoryError):
                 # Don't check ctime for deleted items (os won't give stat info)
                 # but confirm absence from index.
@@ -3380,7 +3380,7 @@ class SyncEngine:
         """
 
         try:
-            stat = os.stat(local_path, follow_symlinks=False)
+            stat = os.lstat(local_path)
             if S_ISDIR(stat.st_mode):
                 ctime = stat.st_ctime
                 with os.scandir(local_path) as it:
@@ -3634,7 +3634,7 @@ class SyncEngine:
         # Move the downloaded file to its destination.
         with self.fs_events.ignore(*ignore_events, recursive=is_symlink):
             with convert_api_errors(dbx_path=event.dbx_path, local_path=local_path):
-                stat = os.stat(tmp_fname, follow_symlinks=False)
+                stat = os.lstat(tmp_fname)
                 move(
                     tmp_fname,
                     local_path,

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1460,10 +1460,6 @@ class SyncEngine:
             if basename.startswith("~") and basename.endswith(".tmp"):
                 return True
 
-        # Is a child of a symlinked path:
-        if osp.realpath(dirname) != dirname:
-            return True
-
         return False
 
     def is_excluded_by_user(self, dbx_path_lower: str) -> bool:

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -24,6 +24,41 @@ def _path_components(path: str) -> List[str]:
 
 Path = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
 
+# ==== path relationships ==============================================================
+
+
+def is_child(path: str, parent: str) -> bool:
+    """
+    Checks if ``path`` semantically is inside ``parent``. Neither path needs to
+    refer to an actual item on the drive. This function is case-sensitive.
+
+    :param path: Item path.
+    :param parent: Parent path.
+    :returns: Whether ``path`` semantically lies inside ``parent``.
+    """
+
+    parent = parent.rstrip(osp.sep) + osp.sep
+    path = path.rstrip(osp.sep)
+
+    return path.startswith(parent)
+
+
+def is_equal_or_child(path: str, parent: str) -> bool:
+    """
+    Checks if ``path`` semantically is inside ``parent`` or equals ``parent``. Neither
+    path needs to refer to an actual item on the drive. This function is case-sensitive.
+
+    :param path: Item path.
+    :param parent: Parent path.
+    :returns: ``True`` if ``path`` semantically lies inside ``parent`` or
+        ``path == parent``.
+    """
+
+    return is_child(path, parent) or path == parent
+
+
+# ==== case sensitivity and normalization ==============================================
+
 
 def normalize_case(string: str) -> str:
     """
@@ -92,36 +127,6 @@ def is_fs_case_sensitive(path: str) -> bool:
         return True
     else:
         return not osp.samefile(path, check_path)
-
-
-def is_child(path: str, parent: str) -> bool:
-    """
-    Checks if ``path`` semantically is inside ``parent``. Neither path needs to
-    refer to an actual item on the drive. This function is case-sensitive.
-
-    :param path: Item path.
-    :param parent: Parent path.
-    :returns: Whether ``path`` semantically lies inside ``parent``.
-    """
-
-    parent = parent.rstrip(osp.sep) + osp.sep
-    path = path.rstrip(osp.sep)
-
-    return path.startswith(parent)
-
-
-def is_equal_or_child(path: str, parent: str) -> bool:
-    """
-    Checks if ``path`` semantically is inside ``parent`` or equals ``parent``. Neither
-    path needs to refer to an actual item on the drive. This function is case-sensitive.
-
-    :param path: Item path.
-    :param parent: Parent path.
-    :returns: ``True`` if ``path`` semantically lies inside ``parent`` or
-        ``path == parent``.
-    """
-
-    return is_child(path, parent) or path == parent
 
 
 def equivalent_path_candidates(
@@ -290,6 +295,9 @@ def generate_cc_name(path: str, suffix: str = "conflicting copy") -> str:
     return osp.join(dirname, cc_candidate)
 
 
+# ==== higher level file operations ====================================================
+
+
 def delete(path: str, raise_error: bool = False) -> Optional[OSError]:
     """
     Deletes a file or folder at ``path``.
@@ -401,6 +409,9 @@ def walk(
                 return
             else:
                 raise
+
+
+# ==== miscellaneous utilities =========================================================
 
 
 def content_hash(

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -177,9 +177,15 @@ def assert_synced(m: Maestral):
 
         remote_hash = e.content_hash if isinstance(e, FileMetadata) else "folder"
         local_hash = m.sync.get_local_hash(local_path)
+        local_symlink_target = m.sync.get_local_symlink_target(local_path)
 
         assert local_hash, f"'{e.path_display}' not found locally"
         assert local_hash == remote_hash, f'different content for "{e.path_display}"'
+
+        if isinstance(e, FileMetadata) and e.symlink_info:
+            assert (
+                e.symlink_info.target == local_symlink_target
+            ), f'different symlink targets for "{e.path_display}"'
 
     # Assert that all local items are present on server.
     for path in local_snapshot.paths:

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import uuid
 
 import pytest
-from watchdog.utils.dirsnapshot import DirectorySnapshot
 from dropbox.files import WriteMode, FileMetadata
 
 from maestral.main import Maestral
@@ -17,6 +16,7 @@ from maestral.utils.path import (
     delete,
     to_existing_unnormalized_path,
     is_child,
+    walk,
 )
 from maestral.utils.appdirs import get_home_dir
 from maestral.daemon import MaestralProxy
@@ -165,35 +165,32 @@ def assert_synced(m: Maestral):
     """Asserts that the `local_folder` and `remote_folder` are synced."""
 
     listing = m.client.list_folder("/", recursive=True)
-    local_snapshot = DirectorySnapshot(m.dropbox_path)
 
     # Assert that all items from server are present locally with the same content hash.
-    for e in listing.entries:
+    for md in listing.entries:
 
-        if m.sync.is_excluded_by_user(e.path_lower):
+        if m.sync.is_excluded_by_user(md.path_lower):
             continue
 
-        local_path = m.to_local_path(e.path_display)
+        local_path = m.to_local_path(md.path_display)
 
-        remote_hash = e.content_hash if isinstance(e, FileMetadata) else "folder"
+        remote_hash = md.content_hash if isinstance(md, FileMetadata) else "folder"
         local_hash = m.sync.get_local_hash(local_path)
         local_symlink_target = m.sync.get_local_symlink_target(local_path)
 
-        assert local_hash, f"'{e.path_display}' not found locally"
-        assert local_hash == remote_hash, f'different content for "{e.path_display}"'
+        assert local_hash, f"'{md.path_display}' not found locally"
+        assert local_hash == remote_hash, f'different content for "{md.path_display}"'
 
-        if isinstance(e, FileMetadata) and e.symlink_info:
+        if isinstance(md, FileMetadata) and md.symlink_info:
             assert (
-                e.symlink_info.target == local_symlink_target
-            ), f'different symlink targets for "{e.path_display}"'
+                md.symlink_info.target == local_symlink_target
+            ), f'different symlink targets for "{md.path_display}"'
 
     # Assert that all local items are present on server.
-    for path in local_snapshot.paths:
-        if not m.sync.is_excluded(path) and is_child(path, m.dropbox_path):
-            if not m.sync.is_excluded(path):
-                dbx_path = m.sync.to_dbx_path_lower(path)
-                has_match = any(e for e in listing.entries if e.path_lower == dbx_path)
-                assert has_match, f'local item "{path}" does not exist on dbx'
+    for path, _ in walk(m.dropbox_path, m.sync._scandir_with_ignore):
+        dbx_path = m.sync.to_dbx_path_lower(path)
+        has_match = any(md for md in listing.entries if md.path_lower == dbx_path)
+        assert has_match, f'local item "{path}" does not exist on dbx'
 
     # Check that our index is correct.
     for index_entry in m.sync.get_index():

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -1154,6 +1154,40 @@ def test_unknown_path_encoding(m, capsys):
     assert_no_errors(m)
 
 
+def test_symlink_error(m):
+
+    dbx_path = m.test_folder_dbx + "/link"
+    local_path = m.test_folder_local + "/link"
+
+    os.symlink("to_nowhere", local_path)
+    wait_for_idle(m)
+
+    assert len(m.fatal_errors) == 0
+    assert len(m.sync_errors) == 1
+    assert m.sync_errors[0]["local_path"] == local_path
+    assert m.sync_errors[0]["type"] == "SymlinkError"
+    assert normalize(dbx_path) in m.sync.upload_errors
+
+
+def test_symlink_indexing_error(m):
+
+    m.stop_sync()
+
+    dbx_path = m.test_folder_dbx + "/link"
+    local_path = m.test_folder_local + "/link"
+
+    os.symlink("to_nowhere", local_path)
+
+    m.start_sync()
+    wait_for_idle(m)
+
+    assert len(m.fatal_errors) == 0
+    assert len(m.sync_errors) == 1
+    assert m.sync_errors[0]["local_path"] == local_path
+    assert m.sync_errors[0]["type"] == "SymlinkError"
+    assert normalize(dbx_path) in m.sync.upload_errors
+
+
 def test_dropbox_dir_delete_during_sync(m):
 
     delete(m.dropbox_path)

--- a/tests/offline/test_cleaning_events.py
+++ b/tests/offline/test_cleaning_events.py
@@ -247,7 +247,6 @@ def test_nested_events(sync):
     group="local-event-processing",
     min_time=0.1,
     max_time=5,
-    min_rounds=4,
 )
 def test_performance(sync, benchmark):
 


### PR DESCRIPTION
This PR improves symlink handling:

1. Downloading remote symlinks is now properly supported. The symlink will be created locally instead of just a stub file.
2. Uploading local symlinks now raises a `SymlinkError` since this is not (yet) supported by the public Dropbox API.
3. Conflict resolution now takes into account symlink targets.
4. Symlink targets are stored in our index.
5. Local file system access now never follows symlinks.