### PR TITLE
Improve connection check

### DIFF
--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -15,6 +15,7 @@ from typing import Iterator, Optional, cast, Dict, List, TypeVar, Callable, Any
 
 # external imports
 from dropbox.common import TeamRootInfo, UserRootInfo
+from dropbox.session import API_HOST
 
 # local imports
 from . import __url__
@@ -49,9 +50,10 @@ from .utils.path import move, delete, is_equal_or_child, is_child, normalize
 
 __all__ = ["SyncManager"]
 
+DROPBOX_API_HOSTNAME = "https://" + API_HOST
+
 
 FT = TypeVar("FT", bound=Callable[..., Any])
-
 
 malloc_trim: Optional[Callable]
 
@@ -168,7 +170,7 @@ class SyncManager:
         if self.running.is_set():
             return
 
-        if not check_connection("www.dropbox.com"):
+        if not check_connection(DROPBOX_API_HOSTNAME):
             # Schedule autostart when connection becomes available.
             self.autostart.set()
             self._logger.info(CONNECTING)
@@ -592,7 +594,7 @@ class SyncManager:
 
         while self._connection_helper_running:
 
-            connected = check_connection("www.dropbox.com")
+            connected = check_connection(DROPBOX_API_HOSTNAME)
 
             if connected != self.connected:
                 # Log the status change.

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -170,7 +170,7 @@ class SyncManager:
         if self.running.is_set():
             return
 
-        if not check_connection(DROPBOX_API_HOSTNAME):
+        if not check_connection(DROPBOX_API_HOSTNAME, logger=self._logger):
             # Schedule autostart when connection becomes available.
             self.autostart.set()
             self._logger.info(CONNECTING)

--- a/src/maestral/utils/integration.py
+++ b/src/maestral/utils/integration.py
@@ -9,8 +9,9 @@ import enum
 import resource
 import requests
 import time
+import logging
 from pathlib import Path
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional
 from urllib.parse import urlparse
 
 __all__ = [
@@ -188,12 +189,16 @@ def cpu_usage_percent(interval: float = 0.1) -> float:
         return round(single_cpu_percent, 1)
 
 
-def check_connection(hostname: str, timeout: int = 2) -> bool:
+def check_connection(
+    hostname: str, timeout: int = 2, logger: Optional[logging.Logger] = None
+) -> bool:
     """
     A low latency check for an internet connection.
 
     :param hostname: Hostname to use for connection check.
     :param timeout: Timeout in seconds for connection check.
+    :param logger: If provided, log output for connection failures will be logged to
+        this logger with the level DEBUG.
     :returns: Connection availability.
     """
     if urlparse(hostname).scheme not in ["http", "https"]:
@@ -202,4 +207,6 @@ def check_connection(hostname: str, timeout: int = 2) -> bool:
         requests.head(hostname, timeout=timeout)
         return True
     except Exception:
+        if logger:
+            logger.debug("Could not reach %s", hostname, exc_info=True)
         return False


### PR DESCRIPTION
1. Use Dropbox API host (https://api.dropboxapi.com) instead of website (http://www.dropbox.com) for connection check.
2. Log connection error tracebacks on the first failed attempt or when a connection is lost. See #583 why this is helpful.