### PR TITLE
Update authentication error handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ setup_requires = build
 install_requires =
     click>=8.0.2
     desktop-notifier>=3.3.0
-    dropbox>=10.9.0,<12.0
+    dropbox>=11.26.0,<12.0
     fasteners>=0.15
     importlib_metadata;python_version<'3.8'
     keyring>=22

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1762,6 +1762,9 @@ def dropbox_to_maestral_error(
             "Something went wrong on Dropbox’s end. Please check on status.dropbox.com "
             "if their services are up and running and try again later."
         )
+    # ---- Errors which are passed through by the SDK ----------------------------------
+    elif isinstance(exc, exceptions.HttpError):
+        text = exc.body
 
     maestral_exc = err_cls(title, text, dbx_path=dbx_path, local_path=local_path)
     maestral_exc.__cause__ = exc

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -35,7 +35,6 @@ from dropbox import (
     exceptions,
     async_,
     auth,
-    oauth,
     common,
 )
 from dropbox.common import PathRoot
@@ -1747,39 +1746,6 @@ def dropbox_to_maestral_error(
                 text = "The given namespace does not exist."
             elif error.is_other():
                 text = "An unexpected error occurred with the given namespace."
-
-    # ---- OAuth2 flow errors ----------------------------------------------------------
-    elif isinstance(exc, requests.HTTPError):
-        # HTTPErrors are converted to a DropboxException by the SDK unless they occur
-        # when refreshing the access token. We therefore handle those manually.
-        # See https://github.com/dropbox/dropbox-sdk-python/issues/360
-        # and https://github.com/SamSchott/maestral/issues/388.
-
-        res = exc.response
-
-        if res and res.status_code == 400 and res.json()["error"] == "invalid_grant":
-            err_cls = DropboxAuthError
-            title = "Authentication failed"
-            text = "Please make sure that you entered the correct authentication code."
-
-        else:
-            err_cls = DropboxServerError
-            title = "Dropbox server error"
-            text = (
-                "Something went wrong on Dropbox’s end. Please check on "
-                "https://status.dropbox.com if their services are up and running and "
-                "try again later."
-            )
-
-    elif isinstance(exc, oauth.BadStateException):
-        err_cls = DropboxAuthError
-        title = "Authentication session expired."
-        text = "The authentication session expired. Please try again."
-
-    elif isinstance(exc, oauth.NotApprovedException):
-        err_cls = DropboxAuthError
-        title = "Not approved error"
-        text = "Please grant Maestral access to your Dropbox to start syncing."
 
     # ---- Bad input errors ------------------------------------------------------------
     # Should only occur due to user input from console scripts.

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1717,9 +1717,15 @@ def dropbox_to_maestral_error(
                 err_cls = DropboxAuthError
                 title = "Authentication error"
                 text = "Your user account has been suspended."
+            elif error.is_missing_scope():
+                scope_error = error.get_missing_scope()
+                required_scope = scope_error.required_scope
+                err_cls = InsufficientPermissionsError
+                title = "Insufficient permissions"
+                text = f"Performing this action requires the {required_scope} scope."
             else:
                 # Other tags are invalid_select_admin, invalid_select_user,
-                # missing_scope, route_access_denied. Neither should occur in our SDK
+                # route_access_denied. Neither should occur in our SDK
                 # usage.
                 pass
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -123,7 +123,7 @@ def convert_api_errors(
 
     try:
         yield
-    except (exceptions.DropboxException, ValidationError, requests.HTTPError) as exc:
+    except (exceptions.DropboxException, ValidationError) as exc:
         raise dropbox_to_maestral_error(exc, dbx_path, local_path)
     # Catch connection errors first, they may inherit from OSError.
     except CONNECTION_ERRORS:

--- a/tests/linked/test_client.py
+++ b/tests/linked/test_client.py
@@ -1,11 +1,9 @@
 import os
 
 import pytest
-import requests
 from dropbox.files import FolderMetadata
 
-from maestral.client import convert_api_errors
-from maestral.errors import NotFoundError, PathError, DropboxServerError
+from maestral.errors import NotFoundError, PathError
 from maestral.utils.path import normalize
 
 from .conftest import resources
@@ -58,12 +56,3 @@ def test_batch_methods(m, batch_size, force_async):
         assert res[i].path_lower == normalize(folders[i])
 
     assert isinstance(res[20], NotFoundError)
-
-
-def test_server_error():
-
-    with pytest.raises(DropboxServerError):
-
-        with convert_api_errors():
-            r = requests.get("https://httpstat.us/503")
-            r.raise_for_status()

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -1030,6 +1030,7 @@ def test_long_path_error(m):
     assert normalize(test_path) in m.sync.download_errors
 
 
+@pytest.mark.skip(reason="Test file is no longer flagged as DMCA")
 def test_download_sync_issues(m):
     """
     Tests error handling for issues during download sync. This is done by attempting to

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -4,9 +4,7 @@
 import errno
 
 import pytest
-import requests
 from dropbox import exceptions
-from dropbox import oauth
 from dropbox.files import *
 from dropbox.async_ import *
 from dropbox.users import *
@@ -260,10 +258,13 @@ def test_dropbox_api_to_maestral_error(error, maestral_exc):
         (exceptions.AuthError("", AuthError.expired_access_token), TokenExpiredError),
         (exceptions.AuthError("", AuthError.invalid_access_token), TokenRevokedError),
         (exceptions.AuthError("", AuthError.user_suspended), DropboxAuthError),
+        (
+            exceptions.AuthError(
+                "", AuthError.missing_scope(TokenScopeError(required_scope="test"))
+            ),
+            InsufficientPermissionsError,
+        ),
         (exceptions.AuthError("", AuthError.other), MaestralApiError),
-        (requests.HTTPError(), DropboxServerError),
-        (oauth.BadStateException(), DropboxAuthError),
-        (oauth.NotApprovedException(), DropboxAuthError),
         (exceptions.BadInputError("", ""), BadInputError),
         (exceptions.InternalServerError("", "", ""), DropboxServerError),
         (exceptions.PathRootError("", PathRootError.no_permission), MPRE),


### PR DESCRIPTION
Simplify error handling now that errors when refreshing the access token are correctly handled by the Dropbox SDK. See https://github.com/dropbox/dropbox-sdk-python/pull/407).