### PR TITLE
Fix passing relative paths to `maestral move-dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   on case-insensitive file systems such as APFS on macOS.
 * Fixes an issue which could result in sync errors not being cleared after the successful
   sync of an item under some circumstances.
+* Relative passed to `maestral move-dir` are now interpreted relative to the working
+  directory where the command is run instead of the working directory of the sync daemon.
 
 ## v1.5.2
 

--- a/src/maestral/cli.py
+++ b/src/maestral/cli.py
@@ -1427,6 +1427,7 @@ def move_dir(new_path: str, config_name: str) -> None:
     from .daemon import MaestralProxy
 
     new_path = new_path or select_dbx_path_dialog(config_name)
+    new_path = osp.realpath(osp.expanduser(new_path))
 
     with MaestralProxy(config_name, fallback=True) as m:
         m.move_dropbox_directory(new_path)

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1215,8 +1215,8 @@ class Maestral:
         was_syncing = self.running
         self.stop_sync()
 
-        # Move folder from old location or create a new one if no old folder exists.
         if osp.isdir(old_path):
+            # Will also create ancestors of new_path if required.
             shutil.move(old_path, new_path)
         else:
             os.makedirs(new_path)


### PR DESCRIPTION
Relative passed to `maestral move-dir` are now interpreted relative to the working directory where the command is run instead of the working directory of the sync daemon. Fixes #594.