### PR TITLE
Unified database table for sync errors

### DIFF
--- a/src/maestral/config/__init__.py
+++ b/src/maestral/config/__init__.py
@@ -2,12 +2,14 @@ import os
 from typing import List, TypeVar
 
 from .main import MaestralConfig, MaestralState
+from .user import PersistentMutableSet
 from ..utils.appdirs import get_conf_path, get_data_path
 
 
 __all__ = [
     "MaestralConfig",
     "MaestralState",
+    "PersistentMutableSet",
     "list_configs",
     "remove_configuration",
     "validate_config_name",

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -66,8 +66,6 @@ DEFAULTS_STATE: DefaultsType = {
         "last_reindex": 0.0,  # time-stamp of full last reindexing
         "indexing_counter": 0,  # counter for indexing progress between restarts
         "did_finish_indexing": False,  # indicates completed indexing
-        "upload_errors": [],  # failed uploads to retry on next sync
-        "download_errors": [],  # failed downloads to retry on next sync
         "pending_uploads": [],  # incomplete uploads to retry on next sync
         "pending_downloads": [],  # incomplete downloads to retry on next sync
     },
@@ -88,7 +86,7 @@ for section_name, section_values in DEFAULTS_CONFIG.items():
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0.0 to 4.0.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = Version("17.0.0")
+CONF_VERSION = Version("18.0.0")
 
 
 # =============================================================================

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -92,27 +92,6 @@ class SyncEvent(Model):
     :class:`watchdog.events.FileSystemEvent` instance, respectively.
     """
 
-    __slots__ = [
-        "_id",
-        "_direction",
-        "_item_type",
-        "_sync_time",
-        "_dbx_id",
-        "_dbx_path",
-        "_local_path",
-        "_dbx_path_from",
-        "_local_path_from",
-        "_rev",
-        "_content_hash",
-        "_symlink_target",
-        "_change_type",
-        "_change_dbid",
-        "_change_user_name",
-        "_status",
-        "_size",
-        "_completed",
-    ]
-
     __tablename__ = "history"
 
     id = Column(SqlInt(), primary_key=True)
@@ -471,17 +450,6 @@ class SyncEvent(Model):
 class IndexEntry(Model):
     """Represents an entry in our local sync index"""
 
-    __slots__ = [
-        "_dbx_path_lower",
-        "_dbx_path_cased",
-        "_dbx_id",
-        "_item_type",
-        "_last_sync",
-        "_rev",
-        "_content_hash",
-        "_symlink_target",
-    ]
-
     __tablename__ = "'index'"
 
     dbx_path_lower = Column(SqlPath(), primary_key=True, nullable=False)
@@ -546,8 +514,6 @@ class IndexEntry(Model):
 
 class HashCacheEntry(Model):
     """Represents an entry in our cache of content hashes"""
-
-    __slots__ = ["_inode", "_local_path", "_hash_str", "_mtime"]
 
     __tablename__ = "hash_cache"
 

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -576,6 +576,8 @@ class SyncErrorEntry(Model):
     dbx_path_lower = Column(SqlPath(), primary_key=True)
     dbx_path_from = Column(SqlPath())
     dbx_path_from_lower = Column(SqlPath())
+    local_path = Column(SqlPath())
+    local_path_from = Column(SqlPath())
     direction = Column(SqlEnum(SyncDirection), nullable=False)
     title = Column(SqlString())
     message = Column(SqlString())

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -484,7 +484,7 @@ class IndexEntry(Model):
 
     __tablename__ = "'index'"
 
-    dbx_path_lower = Column(SqlPath(), primary_key=True)
+    dbx_path_lower = Column(SqlPath(), primary_key=True, nullable=False)
     """
     Dropbox path of the item in lower case. This acts as a primary key for the SQLites
     database since there can only be one entry per case-insensitive Dropbox path.
@@ -551,7 +551,7 @@ class HashCacheEntry(Model):
 
     __tablename__ = "hash_cache"
 
-    inode = Column(SqlInt(), primary_key=True)
+    inode = Column(SqlInt(), primary_key=True, nullable=False)
     """The inode of the item."""
 
     local_path = Column(SqlPath(), nullable=False)
@@ -573,7 +573,7 @@ class SyncErrorEntry(Model):
     __tablename__ = "sync_errors"
 
     dbx_path = Column(SqlPath(), nullable=False)
-    dbx_path_lower = Column(SqlPath(), primary_key=True)
+    dbx_path_lower = Column(SqlPath(), primary_key=True, nullable=False)
     dbx_path_from = Column(SqlPath())
     dbx_path_from_lower = Column(SqlPath())
     local_path = Column(SqlPath())

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -39,6 +39,8 @@ __all__ = [
     "SyncEvent",
     "IndexEntry",
     "HashCacheEntry",
+    "UploadSyncErrorEntry",
+    "DownloadSyncErrorEntry",
 ]
 
 
@@ -563,4 +565,44 @@ class HashCacheEntry(Model):
     """
     The mtime of the item just before the hash was computed. When the current mtime is
     newer, the hash will need to be recalculated.
+    """
+
+
+class DownloadSyncErrorEntry(Model):
+    """Represents a path with a sync error during download"""
+
+    __tablename__ = "download_errors"
+
+    dbx_path = Column(SqlPath(), nullable=False)
+    """
+    Correctly cased Dropbox path of the item to sync. If the sync represents a move
+    operation, this will be the destination path. Follows the casing from the
+    path_display attribute of Dropbox metadata.
+    """
+
+    dbx_path_lower = Column(SqlPath(), primary_key=True)
+    """
+    Dropbox path of the item to sync. If the sync represents a move operation, this will
+    be the destination path. This is normalised as the path_lower attribute of Dropbox
+    metadata.
+    """
+
+
+class UploadSyncErrorEntry(Model):
+    """Represents a path with a sync error during upload"""
+
+    __tablename__ = "upload_errors"
+
+    dbx_path = Column(SqlPath(), nullable=False)
+    """
+    Correctly cased Dropbox path of the item to sync. If the sync represents a move
+    operation, this will be the destination path. Follows the casing from the
+    path_display attribute of Dropbox metadata.
+    """
+
+    dbx_path_lower = Column(SqlPath(), primary_key=True)
+    """
+    Dropbox path of the item to sync. If the sync represents a move operation, this will
+    be the destination path. This is normalised as the path_lower attribute of Dropbox
+    metadata.
     """

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -39,8 +39,7 @@ __all__ = [
     "SyncEvent",
     "IndexEntry",
     "HashCacheEntry",
-    "UploadSyncErrorEntry",
-    "DownloadSyncErrorEntry",
+    "SyncErrorEntry",
 ]
 
 
@@ -568,41 +567,16 @@ class HashCacheEntry(Model):
     """
 
 
-class DownloadSyncErrorEntry(Model):
-    """Represents a path with a sync error during download"""
+class SyncErrorEntry(Model):
+    """Table of sync errors"""
 
-    __tablename__ = "download_errors"
-
-    dbx_path = Column(SqlPath(), nullable=False)
-    """
-    Correctly cased Dropbox path of the item to sync. If the sync represents a move
-    operation, this will be the destination path. Follows the casing from the
-    path_display attribute of Dropbox metadata.
-    """
-
-    dbx_path_lower = Column(SqlPath(), primary_key=True)
-    """
-    Dropbox path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. This is normalised as the path_lower attribute of Dropbox
-    metadata.
-    """
-
-
-class UploadSyncErrorEntry(Model):
-    """Represents a path with a sync error during upload"""
-
-    __tablename__ = "upload_errors"
+    __tablename__ = "sync_errors"
 
     dbx_path = Column(SqlPath(), nullable=False)
-    """
-    Correctly cased Dropbox path of the item to sync. If the sync represents a move
-    operation, this will be the destination path. Follows the casing from the
-    path_display attribute of Dropbox metadata.
-    """
-
     dbx_path_lower = Column(SqlPath(), primary_key=True)
-    """
-    Dropbox path of the item to sync. If the sync represents a move operation, this will
-    be the destination path. This is normalised as the path_lower attribute of Dropbox
-    metadata.
-    """
+    dbx_path_from = Column(SqlPath())
+    dbx_path_from_lower = Column(SqlPath())
+    direction = Column(SqlEnum(SyncDirection), nullable=False)
+    title = Column(SqlString())
+    message = Column(SqlString())
+    error_type = Column(SqlString())

--- a/src/maestral/database.py
+++ b/src/maestral/database.py
@@ -579,4 +579,4 @@ class SyncErrorEntry(Model):
     direction = Column(SqlEnum(SyncDirection), nullable=False)
     title = Column(SqlString())
     message = Column(SqlString())
-    error_type = Column(SqlString())
+    type = Column(SqlString())

--- a/src/maestral/errors.py
+++ b/src/maestral/errors.py
@@ -23,11 +23,11 @@ class MaestralApiError(Exception):
         GUI to give a short error summary.
     :param message: A more verbose description which can include instructions on how to
         proceed to fix the error.
-    :param dbx_path: Dropbox path of the file that caused the error.
-    :param dbx_path_dst: Dropbox destination path of the file that caused the error.
+    :param dbx_path: Dropbox path of the item that caused the error.
+    :param dbx_path_from: Dropbox origin path of the item that caused the error.
         This should be set for instance when error occurs when moving an item.
-    :param local_path: Local path of the file that caused the error.
-    :param local_path_dst: Local destination path of the file that caused the error.
+    :param local_path: Local path of the item that caused the error.
+    :param local_path_from: Local origin path of the item that caused the error.
         This should be set for instance when error occurs when moving an item.
     """
 
@@ -36,16 +36,16 @@ class MaestralApiError(Exception):
         title: str,
         message: str = "",
         dbx_path: Optional[str] = None,
-        dbx_path_dst: Optional[str] = None,
+        dbx_path_from: Optional[str] = None,
         local_path: Optional[str] = None,
-        local_path_dst: Optional[str] = None,
+        local_path_from: Optional[str] = None,
     ) -> None:
         self.title = title
         self.message = message
         self.dbx_path = dbx_path
-        self.dbx_path_dst = dbx_path_dst
+        self.dbx_path_from = dbx_path_from
         self.local_path = local_path
-        self.local_path_dst = local_path_dst
+        self.local_path_from = local_path_from
 
     def __str__(self) -> str:
         return ". ".join([self.title, self.message])

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -62,9 +62,8 @@ from .utils.path import (
 from .utils.serializer import (
     error_to_dict,
     dropbox_stone_to_dict,
-    sync_event_to_dict,
-    StoneType,
-    ErrorType,
+    orm_type_to_dict,
+    SerializedObjectType,
 )
 from .utils.appdirs import get_cache_path, get_data_path
 from .utils.integration import get_ac_state, ACState
@@ -486,7 +485,7 @@ class Maestral:
             return self._log_handler_info_cache.getLastMessage()
 
     @property
-    def sync_errors(self) -> List[ErrorType]:
+    def sync_errors(self) -> List[SerializedObjectType]:
         """
         A list of current sync errors as dicts (read only). This list is populated by
         the sync threads. The following keys will always be present but may contain
@@ -496,10 +495,10 @@ class Maestral:
         :raises NotLinkedError: if no Dropbox account is linked.
         """
 
-        return [error_to_dict(e) for e in self.sync.sync_errors]
+        return [orm_type_to_dict(e) for e in self.sync.sync_errors]
 
     @property
-    def fatal_errors(self) -> List[ErrorType]:
+    def fatal_errors(self) -> List[SerializedObjectType]:
         """
         Returns a list of fatal errors as dicts (read only). This does not include lost
         internet connections or file sync errors which only emit warnings and are
@@ -513,7 +512,7 @@ class Maestral:
         have ``exc_info`` attached.
         """
 
-        maestral_errors_dicts: List[ErrorType] = []
+        maestral_errors_dicts: List[SerializedObjectType] = []
 
         for r in self._log_handler_error_cache.cached_records:
             if r.exc_info:
@@ -587,7 +586,7 @@ class Maestral:
         else:
             return FileStatus.Unwatched.value
 
-    def get_activity(self, limit: Optional[int] = 100) -> List[StoneType]:
+    def get_activity(self, limit: Optional[int] = 100) -> List[SerializedObjectType]:
         """
         Returns the current upload / download activity.
 
@@ -601,11 +600,11 @@ class Maestral:
         self._check_linked()
 
         activity = list(self.manager.activity.values())[:limit]
-        serialized_activity = [sync_event_to_dict(event) for event in activity]
+        serialized_activity = [orm_type_to_dict(event) for event in activity]
 
         return serialized_activity
 
-    def get_history(self, limit: Optional[int] = 100) -> List[StoneType]:
+    def get_history(self, limit: Optional[int] = 100) -> List[SerializedObjectType]:
         """
         Returns the historic upload / download activity. Up to 1,000 sync events are
         kept in the database. Any events which occurred before the interval specified by
@@ -620,13 +619,13 @@ class Maestral:
 
         self._check_linked()
         if limit:
-            history = [sync_event_to_dict(e) for e in self.manager.history[-limit:]]
+            history = [orm_type_to_dict(e) for e in self.manager.history[-limit:]]
         else:
-            history = [sync_event_to_dict(e) for e in self.manager.history]
+            history = [orm_type_to_dict(e) for e in self.manager.history]
 
         return history
 
-    def get_account_info(self) -> StoneType:
+    def get_account_info(self) -> SerializedObjectType:
         """
         Returns the account information from Dropbox and returns it as a dictionary.
 
@@ -642,7 +641,7 @@ class Maestral:
         res = self.client.get_account_info()
         return dropbox_stone_to_dict(res)
 
-    def get_space_usage(self) -> StoneType:
+    def get_space_usage(self) -> SerializedObjectType:
         """
         Gets the space usage from Dropbox and returns it as a dictionary.
 
@@ -688,7 +687,7 @@ class Maestral:
             self._delete_old_profile_pics()
             return None
 
-    def get_metadata(self, dbx_path: str) -> Optional[StoneType]:
+    def get_metadata(self, dbx_path: str) -> Optional[SerializedObjectType]:
         """
         Returns metadata for a file or folder on Dropbox.
 
@@ -711,7 +710,7 @@ class Maestral:
         else:
             return dropbox_stone_to_dict(res)
 
-    def list_folder(self, dbx_path: str, **kwargs) -> List[StoneType]:
+    def list_folder(self, dbx_path: str, **kwargs) -> List[SerializedObjectType]:
         """
         List all items inside the folder given by ``dbx_path``. Keyword arguments are
         passed on the Dropbox API call :meth:`client.DropboxClient.list_folder`.
@@ -737,7 +736,7 @@ class Maestral:
 
     def list_folder_iterator(
         self, dbx_path: str, **kwargs
-    ) -> Iterator[List[StoneType]]:
+    ) -> Iterator[List[SerializedObjectType]]:
         """
         Returns an iterator over items inside the folder given by ``dbx_path``. Keyword
         arguments are passed on the client call
@@ -768,7 +767,9 @@ class Maestral:
                 del entries
                 gc.collect()
 
-    def list_revisions(self, dbx_path: str, limit: int = 10) -> List[StoneType]:
+    def list_revisions(
+        self, dbx_path: str, limit: int = 10
+    ) -> List[SerializedObjectType]:
         """
         List revisions of old files at the given path ``dbx_path``. This will also
         return revisions if the file has already been deleted.
@@ -888,7 +889,7 @@ class Maestral:
             )
         )
 
-    def restore(self, dbx_path: str, rev: str) -> StoneType:
+    def restore(self, dbx_path: str, rev: str) -> SerializedObjectType:
         """
         Restore an old revision of a file.
 
@@ -1253,7 +1254,7 @@ class Maestral:
         visibility: str = "public",
         password: Optional[str] = None,
         expires: Optional[float] = None,
-    ) -> StoneType:
+    ) -> SerializedObjectType:
         """
         Creates a shared link for the given ``dbx_path``. Returns a dictionary with
         information regarding the link, including the URL, access permissions, expiry
@@ -1309,7 +1310,9 @@ class Maestral:
         self._check_linked()
         self.client.revoke_shared_link(url)
 
-    def list_shared_links(self, dbx_path: Optional[str] = None) -> List[StoneType]:
+    def list_shared_links(
+        self, dbx_path: Optional[str] = None
+    ) -> List[SerializedObjectType]:
         """
         Returns a list of all shared links for the given Dropbox path. If no path is
         given, return all shared links for the account, up to a maximum of 1,000 links.

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1454,6 +1454,8 @@ class Maestral:
             self._update_from_pre_v1_4_8()
         if Version(updated_from) < Version("1.5.3"):
             self._update_from_pre_v1_5_3()
+        if Version(updated_from) < Version("1.6.0.dev0"):
+            self._update_from_pre_v1_6_0()
 
         self._state.set("app", "updated_scripts_completed", __version__)
 
@@ -1473,6 +1475,21 @@ class Maestral:
         _sql_drop_table(db, "hash_cache")
         _sql_add_column(db, "history", "symlink_target", "TEXT")
         _sql_add_column(db, "'index'", "symlink_target", "TEXT")
+
+        db.close()
+
+    def _update_from_pre_v1_6_0(self) -> None:
+
+        self._logger.info("Scheduling reindex after update from pre v1.6.0")
+
+        db_path = get_data_path("maestral", f"{self.config_name}.db")
+        db = Database(db_path, check_same_thread=False)
+
+        _sql_drop_table(db, "hash_cache")
+        _sql_drop_table(db, "'index'")
+        _sql_drop_table(db, "'history'")
+
+        self._state.reset_to_defaults("sync")
 
         db.close()
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1037,7 +1037,7 @@ class Maestral:
 
         # Perform housekeeping.
         self.sync.remove_node_from_index(dbx_path_lower)
-        self.sync.clear_sync_errors_for_path(dbx_path_lower)
+        self.sync.clear_sync_errors_for_path(dbx_path_lower, recursive=True)
 
         # Remove folder from local drive.
         local_path_uncased = f"{self.dropbox_path}{dbx_path_lower}"

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -561,7 +561,7 @@ class Maestral:
         local_path = osp.realpath(local_path)
 
         try:
-            dbx_path = self.sync.to_dbx_path(local_path)
+            dbx_path_lower = self.sync.to_dbx_path_lower(local_path)
         except ValueError:
             return FileStatus.Unwatched.value
 
@@ -579,9 +579,9 @@ class Maestral:
             return FileStatus.Uploading.value
         elif sync_event and sync_event.direction == SyncDirection.Down:
             return FileStatus.Downloading.value
-        elif any(dbx_path == err["dbx_path"] for err in self.sync_errors):
+        elif len(self.sync.sync_errors_for_path(dbx_path_lower)) > 0:
             return FileStatus.Error.value
-        elif dbx_path == "/" or self.sync.get_local_rev(normalize(dbx_path)):
+        elif dbx_path_lower == "/" or self.sync.get_local_rev(dbx_path_lower):
             return FileStatus.Synced.value
         else:
             return FileStatus.Unwatched.value
@@ -1037,7 +1037,7 @@ class Maestral:
 
         # Perform housekeeping.
         self.sync.remove_node_from_index(dbx_path_lower)
-        self.sync.clear_sync_error(dbx_path_lower)
+        self.sync.clear_sync_errors_for_path(dbx_path_lower)
 
         # Remove folder from local drive.
         local_path_uncased = f"{self.dropbox_path}{dbx_path_lower}"

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1036,22 +1036,7 @@ class Maestral:
 
         # Perform housekeeping.
         self.sync.remove_node_from_index(dbx_path_lower)
-
-        for error in self.sync.sync_errors.copy():
-
-            if not error.dbx_path:
-                continue
-
-            if is_equal_or_child(normalize(error.dbx_path), dbx_path_lower):
-                self.sync.sync_errors.discard(error)
-
-        for path in list(self.sync.download_errors):
-            if is_equal_or_child(path, dbx_path_lower):
-                self.sync.download_errors.discard(path)
-
-        for path in list(self.sync.upload_errors):
-            if is_equal_or_child(path, dbx_path_lower):
-                self.sync.upload_errors.discard(path)
+        self.sync.clear_sync_error(dbx_path_lower)
 
         # Remove folder from local drive.
         local_path_uncased = f"{self.dropbox_path}{dbx_path_lower}"

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -677,7 +677,7 @@ class SyncManager:
                 except Empty:
                     pass
                 else:
-                    # Protect against crashes.
+                    # Guard against crashes.
                     self.sync.pending_downloads.add(dbx_path_lower)
 
                     if not running.is_set():
@@ -766,8 +766,8 @@ class SyncManager:
                 if len(self.sync.download_errors) > 0:
                     self._logger.info("Retrying failed syncs...")
 
-                for dbx_path in list(self.sync.download_errors):
-                    self.sync.get_remote_item(dbx_path, client)
+                for error in list(self.sync.download_errors):
+                    self.sync.get_remote_item(error.dbx_path_lower, client)
 
                 # Resume interrupted downloads.
                 if len(self.sync.pending_downloads) > 0:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3254,7 +3254,8 @@ class SyncEngine:
             )
             return Conflict.Identical
         elif any(
-            is_equal_or_child(p, event.dbx_path_lower) for p in self.upload_errors
+            is_equal_or_child(p.dbx_path_lower, event.dbx_path_lower)
+            for p in self.upload_errors
         ):
             # Local version could not be uploaded due to a sync error. Do not over-
             # write unsynced changes but declare a conflict.

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -739,6 +739,7 @@ class SyncEngine:
                 errors_children = self._db_manager_sync_errors.query_to_objects(
                     "SELECT * FROM sync_errors WHERE dbx_path_lower LIKE ? AND direction = ?",
                     f"{dbx_path_lower}/%",
+                    direction.name,
                 )
 
             else:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -671,7 +671,7 @@ class SyncEngine:
     def upload_errors(self) -> List[SyncErrorEntry]:
         with self._database_access():
             errors = self._db_manager_sync_errors.query_to_objects(
-                "SELECT * FROM ? WHERE direction = 'Up'"
+                "SELECT * FROM sync_errors WHERE direction = 'Up'"
             )
             return cast(List[SyncErrorEntry], errors)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -666,7 +666,24 @@ class SyncEngine:
     @property
     def sync_errors(self) -> List[SyncErrorEntry]:
         with self._database_access():
-            return self._db_manager_sync_error.all()
+            errors = self._db_manager_sync_error.all()
+            return cast(List[SyncErrorEntry], errors)
+
+    @property
+    def upload_errors(self) -> List[SyncErrorEntry]:
+        with self._database_access():
+            errors = self._db_manager_sync_error.query_to_objects(
+                "SELECT * FROM ? WHERE direction = up"
+            )
+            return cast(List[SyncErrorEntry], errors)
+
+    @property
+    def download_errors(self) -> List[SyncErrorEntry]:
+        with self._database_access():
+            errors = self._db_manager_sync_error.query_to_objects(
+                "SELECT * FROM sync_errors WHERE direction = down"
+            )
+            return cast(List[SyncErrorEntry], errors)
 
     def clear_sync_history(self) -> None:
         """Clears the sync history."""

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -671,7 +671,7 @@ class SyncEngine:
     def upload_errors(self) -> List[SyncErrorEntry]:
         with self._database_access():
             errors = self._db_manager_sync_errors.query_to_objects(
-                "SELECT * FROM ? WHERE direction = up"
+                "SELECT * FROM ? WHERE direction = 'Up'"
             )
             return cast(List[SyncErrorEntry], errors)
 
@@ -679,7 +679,7 @@ class SyncEngine:
     def download_errors(self) -> List[SyncErrorEntry]:
         with self._database_access():
             errors = self._db_manager_sync_errors.query_to_objects(
-                "SELECT * FROM sync_errors WHERE direction = down"
+                "SELECT * FROM sync_errors WHERE direction = 'Down'"
             )
             return cast(List[SyncErrorEntry], errors)
 
@@ -692,10 +692,10 @@ class SyncEngine:
 
     def clear_sync_errors(self) -> None:
         """Clears all sync errors."""
-        self.sync_errors.clear()
 
         with self._database_access():
             self._db.execute("DROP TABLE sync_errors")
+            self._db_manager_sync_errors.create_table()
             self._db_manager_sync_errors.clear_cache()
 
     def reset_sync_state(self) -> None:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -3766,16 +3766,14 @@ class SyncEngine:
 
             # Add deleted events for children.
 
-            local_path_lower = normalize(local_path)
+            dbx_path_lower = self.to_dbx_path_lower(local_path)
 
             with self._database_access():
 
-                # TODO: fix me!!!
-                entries = self._db_manager_index.select(
-                    PathTreeQuery(
-                        column=IndexEntry.dbx_path_lower, path=local_path_lower
-                    )
+                query = PathTreeQuery(
+                    column=IndexEntry.dbx_path_lower, path=dbx_path_lower
                 )
+                entries = self._db_manager_index.select(query)
 
             for entry in entries:
                 entry = cast(IndexEntry, entry)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1535,7 +1535,7 @@ class SyncEngine:
                     direction=direction,
                     title=err.title,
                     message=err.message,
-                    err_type=err.__class__.__name__,
+                    type=err.__class__.__name__,
                 )
             )
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -67,7 +67,7 @@ from watchdog.events import (
 
 # local imports
 from . import notify
-from .config import MaestralConfig, MaestralState
+from .config import MaestralConfig, MaestralState, PersistentMutableSet
 from .constants import (
     IDLE,
     EXCLUDED_FILE_NAMES,
@@ -415,7 +415,6 @@ class SyncEngine:
     :param client: Dropbox API client instance.
     """
 
-    sync_errors: Set[SyncError]
     syncing: Dict[str, SyncEvent]
     _case_conversion_cache: LRUCache
 
@@ -443,15 +442,14 @@ class SyncEngine:
         # stored in these lists to be resumed if Maestral quits unexpectedly. This used
         # for downloads which are not part of the regular sync cycle and are therefore
         # not restarted automatically.
-        self.pending_downloads = PersistentStateMutableSet(
-            self.config_name, section="sync", option="pending_downloads"
+        self.pending_downloads = PersistentMutableSet(
+            self._state, section="sync", option="pending_downloads"
         )
-        self.pending_uploads = PersistentStateMutableSet(
-            self.config_name, section="sync", option="pending_uploads"
+        self.pending_uploads = PersistentMutableSet(
+            self._state, section="sync", option="pending_uploads"
         )
 
         # Data structures for internal communication.
-        self.sync_errors = set()
         self._cancel_requested = Event()
 
         # Data structures for user information.

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2252,8 +2252,6 @@ class SyncEngine:
 
         self._slow_down()
 
-        self.clear_sync_errors_from_event(event)
-
         event.status = SyncStatus.Syncing
 
         try:
@@ -2280,6 +2278,8 @@ class SyncEngine:
         except SyncError as err:
             self._handle_sync_error(err, direction=SyncDirection.Up)
             event.status = SyncStatus.Failed
+        else:
+            self.clear_sync_errors_from_event(event)
         finally:
             self.syncing.pop(event.local_path, None)
 
@@ -3479,8 +3479,6 @@ class SyncEngine:
 
         self._slow_down()
 
-        self.clear_sync_errors_from_event(event)
-
         event.status = SyncStatus.Syncing
 
         try:
@@ -3502,6 +3500,8 @@ class SyncEngine:
         except SyncError as e:
             self._handle_sync_error(e, direction=SyncDirection.Down)
             event.status = SyncStatus.Failed
+        else:
+            self.clear_sync_errors_from_event(event)
         finally:
             self.syncing.pop(event.local_path, None)
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -699,18 +699,18 @@ class SyncEngine:
     def upload_errors(self) -> List[SyncErrorEntry]:
         """Returns a list of all upload errors."""
         with self._database_access():
-            errors = self._db_manager_sync_errors.select(
-                MatchQuery(column=SyncErrorEntry.direction, value=SyncDirection.Up)
-            )
+            query = MatchQuery(column=SyncErrorEntry.direction, value=SyncDirection.Up)
+            errors = self._db_manager_sync_errors.select(query)
             return cast(List[SyncErrorEntry], errors)
 
     @property
     def download_errors(self) -> List[SyncErrorEntry]:
         """Returns a list of all download errors."""
         with self._database_access():
-            errors = self._db_manager_sync_errors.select(
-                MatchQuery(column=SyncErrorEntry.direction, value=SyncDirection.Down)
+            query = MatchQuery(
+                column=SyncErrorEntry.direction, value=SyncDirection.Down
             )
+            errors = self._db_manager_sync_errors.select(query)
             return cast(List[SyncErrorEntry], errors)
 
     def has_sync_errors(self) -> bool:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -663,6 +663,11 @@ class SyncEngine:
             )
             return cast(List[SyncEvent], sync_events)
 
+    @property
+    def sync_errors(self) -> List[SyncErrorEntry]:
+        with self._database_access():
+            return self._db_manager_sync_error.all()
+
     def clear_sync_history(self) -> None:
         """Clears the sync history."""
         with self._database_access():

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1532,6 +1532,8 @@ class SyncEngine:
                     dbx_path_lower=dbx_path_lower,
                     dbx_path_from=err.dbx_path_from,
                     dbx_path_from_lower=dbx_path_from_lower,
+                    local_path=err.local_path,
+                    local_path_from=err.local_path_from,
                     direction=direction,
                     title=err.title,
                     message=err.message,

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -580,6 +580,12 @@ class Manager:
         counts = res.fetchone()
         return counts[0]
 
+    def clear(self):
+        """Delete all rows from table."""
+        self.db.execute(f"DROP TABLE {self.table_name}")
+        self.clear_cache()
+        self.create_table()
+
     def _has_table(self) -> bool:
         """Checks if entity model already has a database table."""
         sql = "SELECT name len FROM sqlite_master WHERE type = 'table' AND name = ?"

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -357,14 +357,14 @@ class Manager:
 
         column_defs = [col.render_column() for col in columns(self.model)]
         column_defs_str = ", ".join(column_defs)
-        sql = f"CREATE TABLE {self.model.__tablename__} ({column_defs_str});"
+        sql = f"CREATE TABLE {self.table_name} ({column_defs_str});"
 
         self.db.executescript(sql)
 
         for column in columns(self.model):
             if column.index:
-                idx_name = f"idx_{self.model.__tablename__}_{column.name}"
-                sql = f"CREATE INDEX {idx_name} ON {self.model.__tablename__} ({column.name});"
+                idx_name = f"idx_{self.table_name}_{column.name}"
+                sql = f"CREATE INDEX {idx_name} ON {self.table_name} ({column.name});"
                 self.db.executescript(sql)
 
     def clear_cache(self) -> None:

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -161,7 +161,7 @@ class PathTreeQuery(Query):
         self.dir_blob = os.path.join(self.file_blob, b"")
 
     def clause(self):
-        query_part = f"({self.column.name} = ? || substr({self.column.name}, 1, ?) = ?)"
+        query_part = f"({self.column.name} = ? OR substr({self.column.name}, 1, ?) = ?)"
         args = (self.file_blob, len(self.dir_blob), self.dir_blob)
 
         return query_part, args

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -161,7 +161,7 @@ class PathTreeQuery(Query):
         self.dir_blob = os.path.join(self.file_blob, b"")
 
     def clause(self):
-        query_part = f"({self.column.name} = ? || substr({self.column}, 1, ?) = ?)"
+        query_part = f"({self.column.name} = ? || substr({self.column.name}, 1, ?) = ?)"
         args = (self.file_blob, len(self.dir_blob), self.dir_blob)
 
         return query_part, args

--- a/src/maestral/utils/orm.py
+++ b/src/maestral/utils/orm.py
@@ -153,7 +153,7 @@ class Query:
 class PathTreeQuery(Query):
     def __init__(self, column: "Column", path: str):
 
-        if column.type is not SqlPath:
+        if not isinstance(column.type, SqlPath):
             raise ValueError("Only accepts columns with type SqlPath")
 
         self.column = column

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -539,3 +539,29 @@ def getsize(path: Path) -> int:
     """Returns the size. Returns False for symlinks."""
     stat = os.stat(path, follow_symlinks=False)
     return stat.st_size
+
+
+def get_symlink_target(local_path: str) -> Optional[str]:
+    """
+    Returns the symlink target of a file.
+
+    :param local_path: Absolute path on local drive.
+    :returns: Symlink target of local file. None if the local path does not refer to
+        a symlink or does not exist.
+    """
+
+    try:
+        return os.readlink(local_path)
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    except OSError as err:
+
+        if err.errno == errno.EINVAL:
+            # File is not a symlink.
+            return None
+
+        if err.errno == errno.ENAMETOOLONG:
+            # Path cannot exist on this filesystem.
+            return None
+
+        raise err

--- a/src/maestral/utils/serializer.py
+++ b/src/maestral/utils/serializer.py
@@ -7,7 +7,7 @@ the daemon and frontends.
 import json
 import traceback
 from enum import Enum
-from typing import Dict, Union, Sequence, TYPE_CHECKING
+from typing import Dict, Union, List, TYPE_CHECKING
 
 # external imports
 from dropbox.stone_serializers import json_encode
@@ -15,28 +15,27 @@ from dropbox.stone_validators import Struct
 
 # local imports
 from . import sanitize_string
-from ..sync import SyncEvent
+from .orm import Model
 
 if TYPE_CHECKING:
     from dropbox.stone_base import Struct as StoneStruct
 
 
-StoneType = Dict[str, Union[str, float, bool, None]]
-ErrorType = Dict[str, Union[str, Sequence[str], None]]
+SerializedObjectType = Dict[str, Union[str, List[str], None]]
 
 
-def dropbox_stone_to_dict(obj: "StoneStruct") -> StoneType:
+def dropbox_stone_to_dict(obj: "StoneStruct") -> SerializedObjectType:
     """Converts the result of a Dropbox SDK call to a dictionary."""
 
     obj_string = json_encode(Struct(type(obj)), obj)
 
-    dictionary: StoneType = dict(type=type(obj).__name__)
+    dictionary: SerializedObjectType = dict(type=type(obj).__name__)
     dictionary.update(json.loads(obj_string))
 
     return dictionary
 
 
-def error_to_dict(err: Exception) -> ErrorType:
+def error_to_dict(err: Exception) -> SerializedObjectType:
     """
     Converts an exception to a dict. Keys will be strings and entries are native Python
     types.
@@ -47,7 +46,7 @@ def error_to_dict(err: Exception) -> ErrorType:
         'traceback', 'title', and 'message'.
     """
 
-    serialized: ErrorType = dict(
+    serialized: SerializedObjectType = dict(
         type=err.__class__.__name__,
         inherits=[base.__name__ for base in err.__class__.__bases__],
         traceback="".join(
@@ -68,7 +67,7 @@ def error_to_dict(err: Exception) -> ErrorType:
     return serialized
 
 
-def sync_event_to_dict(event: SyncEvent) -> StoneType:
+def orm_type_to_dict(event: Model) -> SerializedObjectType:
     """
     Converts a SyncEvent to a dict. Keys will be strings and entries are native Python
     types.

--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -17,6 +17,7 @@ from maestral.utils.path import (
     to_existing_unnormalized_path,
     is_child,
     walk,
+    get_symlink_target,
 )
 from maestral.utils.appdirs import get_home_dir
 from maestral.daemon import MaestralProxy
@@ -176,7 +177,7 @@ def assert_synced(m: Maestral):
 
         remote_hash = md.content_hash if isinstance(md, FileMetadata) else "folder"
         local_hash = m.sync.get_local_hash(local_path)
-        local_symlink_target = m.sync.get_local_symlink_target(local_path)
+        local_symlink_target = get_symlink_target(local_path)
 
         assert local_hash, f"'{md.path_display}' not found locally"
         assert local_hash == remote_hash, f'different content for "{md.path_display}"'

--- a/tests/linked/test_client.py
+++ b/tests/linked/test_client.py
@@ -59,26 +59,20 @@ def test_batch_methods(m, batch_size, force_async):
     assert isinstance(res[20], NotFoundError)
 
 
-def test_share_dir_new(m):
+@pytest.mark.parametrize("force_async", [True, False])
+def test_share_dir_new(m, force_async):
     """Test creating a shared directory."""
     md_old = m.client.get_metadata(f"{m.test_folder_dbx}/folder")
-    md_shared = m.client.share_dir(f"{m.test_folder_dbx}/folder")
-
-    assert md_old is None
-    assert isinstance(md_shared, SharedFolderMetadata)
-
-
-def test_share_dir_new_async(m):
-    """Test creating a shared directory."""
-    md_old = m.client.get_metadata(f"{m.test_folder_dbx}/folder")
-    md_shared = m.client.share_dir(f"{m.test_folder_dbx}/folder", force_async=True)
+    md_shared = m.client.share_dir(
+        f"{m.test_folder_dbx}/folder", force_async=force_async
+    )
 
     assert md_old is None
     assert isinstance(md_shared, SharedFolderMetadata)
 
 
 def test_share_dir_existing(m):
-    """Test sharing an exisitng directory."""
+    """Test sharing an existing directory."""
     md = m.client.make_dir(f"{m.test_folder_dbx}/folder")
     md_shared = m.client.share_dir(f"{m.test_folder_dbx}/folder")
 

--- a/tests/linked/test_sync.py
+++ b/tests/linked/test_sync.py
@@ -1209,8 +1209,7 @@ def test_sync_event_conversion_performance(m):
     res = m.client.list_folder(m.test_folder_dbx, recursive=True)
 
     def setup():
-        m.sync.clear_index()
-        m.sync.clear_hash_cache()
+        m.sync.reset_sync_state()
         m.sync._case_conversion_cache.clear()
 
     def generate_sync_events():


### PR DESCRIPTION
Migrate from lists in the state file to a single database table for upload and download errors. This significantly simplifies our error handling data structures.