### PR TITLE
Fix 64-bit inode handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   file was deleted if the deletion occurred while sync was not running.
 * Fixes an issue with the Linux Qt GUI where aborting the setup dialog after linking but
   before choosing a local Dropbox folder would result in an inconsistent state.
+* Fixes an issue when storing 64-bit inode numbers in our database.
 
 ## v1.5.3
 

--- a/src/maestral/database/types.py
+++ b/src/maestral/database/types.py
@@ -34,7 +34,11 @@ class SqlString(SqlType):
 
 
 class SqlInt(SqlType):
-    """Class to represent Python integers in SQLite table"""
+    """
+    Class to represent Python integers in SQLite table
+
+    SQLite supports up to 64-bit signed integers (-2**63 < int < 2**63 - 1)
+    """
 
     sql_type = "INTEGER"
     py_type = int
@@ -45,6 +49,25 @@ class SqlFloat(SqlType):
 
     sql_type = "REAL"
     py_type = float
+
+
+class SqlLargeInt(SqlType):
+    """Class to represent large integers > 64bit in SQLite table"""
+
+    sql_type = "TEXT"
+    py_type = int
+
+    def sql_to_py(self, value: str | None) -> int | None:
+        if value is None:
+            return value
+
+        return int(value)
+
+    def py_to_sql(self, value: int | None) -> str | None:
+        if value is None:
+            return value
+
+        return str(value)
 
 
 class SqlPath(SqlType):

--- a/src/maestral/database/types.py
+++ b/src/maestral/database/types.py
@@ -52,7 +52,10 @@ class SqlFloat(SqlType):
 
 
 class SqlLargeInt(SqlType):
-    """Class to represent large integers > 64bit in SQLite table"""
+    """Class to represent large integers > 64bit in SQLite table
+
+    Integers are stored as text in the database and converted on read / write.
+    """
 
     sql_type = "TEXT"
     py_type = int

--- a/src/maestral/models.py
+++ b/src/maestral/models.py
@@ -26,7 +26,7 @@ from watchdog.events import (
 
 # local imports
 from .database.orm import Model, Column
-from .database.types import SqlInt, SqlString, SqlFloat, SqlPath, SqlEnum
+from .database.types import SqlInt, SqlLargeInt, SqlFloat, SqlString, SqlPath, SqlEnum
 from .utils.path import normalize
 from .exceptions import SyncError, NotLinkedError
 
@@ -520,7 +520,7 @@ class HashCacheEntry(Model):
 
     __tablename__ = "hash_cache"
 
-    inode = Column(SqlInt(), primary_key=True, nullable=False)
+    inode = Column(SqlLargeInt(), primary_key=True, nullable=False)
     """The inode of the item."""
 
     local_path = Column(SqlPath(), nullable=False)


### PR DESCRIPTION
This PR fixes storage of inode numbers in our SQLite database for file systems with 64-bit inodes. This was previously a problem because inode numbers were stored as INTEGER in SQLite, supporting values `> -2**63` and `< 2**63 - 1`. However Linux supports inode numbers of unsigned 64-bit integers, going up to 2**64.

From https://www.mjr19.org.uk/sw/inodes64.html:

> Modern filesystems are starting to use 64 bit inodes, rather than 32 bit ones. Recent versions of [XFS](http://www.xfs.org/) do so for filesystems of more than 1TB, and other large filesystems such as [Lustre](http://lustre.org/) use them too. NFS fully supports them too, so one can find them when mounting remote filesystems.

Fixes #609.