### PR TITLE
Verify file integrity after transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * The CLI command `maestral filestatus PATH` will now return `error` if there is a sync
   error for any child of the given path. This brings it in line with the `syncing` status.
 * Re-enabled updating from versions older than 1.5.0.
+* Improved file integrity checks after upload or download.
 
 # Fixed:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires = build
 install_requires =
     click>=8.0.2
     desktop-notifier>=3.3.0
-    dropbox>=11.26.0,<12.0
+    dropbox>=11.28.0,<12.0
     fasteners>=0.15
     importlib_metadata;python_version<'3.8'
     keyring>=22

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 # system imports
 import os
-import os.path as osp
 import time
 import logging
 import contextlib
@@ -543,12 +542,6 @@ class DropboxClient:
         """
 
         with convert_api_errors(dbx_path=dbx_path):
-
-            dst_path_directory = osp.dirname(local_path)
-            try:
-                os.makedirs(dst_path_directory)
-            except FileExistsError:
-                pass
 
             md, http_resp = self.dbx.files_download(dbx_path, **kwargs)
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -12,7 +12,7 @@ import logging
 import contextlib
 import threading
 from datetime import datetime, timezone
-from typing import Callable, Any, Iterator, TypeVar, Union, TYPE_CHECKING
+from typing import Callable, Any, Iterator, TypeVar, Union, BinaryIO, TYPE_CHECKING
 
 # external imports
 import requests
@@ -34,12 +34,13 @@ from .exceptions import (
 from .errorhandling import (
     convert_api_errors,
     dropbox_to_maestral_error,
+    retry_on_error,
     CONNECTION_ERRORS,
 )
 from .config import MaestralState
 from .constants import DROPBOX_APP_KEY
 from .utils import natural_size, chunks, clamp
-from .utils.path import opener_no_symlink
+from .utils.path import opener_no_symlink, delete
 from .utils.hashing import DropboxContentHasher, StreamHasher
 
 if TYPE_CHECKING:
@@ -54,6 +55,7 @@ FT = TypeVar("FT", bound=Callable[..., Any])
 
 _major_minor_version = ".".join(__version__.split(".")[:2])
 USER_AGENT = f"Maestral/v{_major_minor_version}"
+MAX_ATTEMPTS = 3
 
 
 def get_hash(data: bytes) -> str:
@@ -523,12 +525,12 @@ class DropboxClient:
         with convert_api_errors(dbx_path=dbx_path):
             return self.dbx.files_restore(dbx_path, rev)
 
+    @retry_on_error(DataCorruptionError, MAX_ATTEMPTS)
     def download(
         self,
         dbx_path: str,
         local_path: str,
         sync_event: SyncEvent | None = None,
-        **kwargs,
     ) -> files.FileMetadata:
         """
         Downloads a file from Dropbox to given local path.
@@ -537,17 +539,16 @@ class DropboxClient:
         :param local_path: Path to local download destination.
         :param sync_event: If given, the sync event will be updated with the number of
             downloaded bytes.
-        :param kwargs: Keyword arguments for the Dropbox API files_download endpoint.
         :returns: Metadata of downloaded item.
+        :raises DataCorruptionError: if data is corrupted during download.
         """
 
         with convert_api_errors(dbx_path=dbx_path):
 
-            md, http_resp = self.dbx.files_download(dbx_path, **kwargs)
+            md = self.dbx.files_get_metadata(dbx_path)
 
-            if md.symlink_info is not None:
+            if isinstance(md, files.FileMetadata) and md.symlink_info:
                 # Don't download but reproduce symlink locally.
-                http_resp.close()
                 try:
                     os.unlink(local_path)
                 except FileNotFoundError:
@@ -555,7 +556,10 @@ class DropboxClient:
                 os.symlink(md.symlink_info.target, local_path)
 
             else:
-                chunksize = 2 ** 13
+                chunk_size = 2 ** 13
+
+                md, http_resp = self.dbx.files_download(dbx_path)
+
                 hasher = DropboxContentHasher()
 
                 with open(local_path, "wb", opener=opener_no_symlink) as f:
@@ -563,17 +567,18 @@ class DropboxClient:
                     wrapped_f = StreamHasher(f, hasher)
 
                     with contextlib.closing(http_resp):
-                        for c in http_resp.iter_content(chunksize):
+                        for c in http_resp.iter_content(chunk_size):
                             wrapped_f.write(c)
                             if sync_event:
                                 sync_event.completed = wrapped_f.tell()
 
-                local_hash = hasher.hexdigest()
+                    local_hash = hasher.hexdigest()
 
-                if md.content_hash != local_hash:
-                    raise DataCorruptionError(
-                        "Data corrupted", "Please retry download."
-                    )
+                    if md.content_hash != local_hash:
+                        delete(local_path)
+                        raise DataCorruptionError(
+                            "Data corrupted", "Please retry download."
+                        )
 
             # Dropbox SDK provides naive datetime in UTC.
             client_mod = md.client_modified.replace(tzinfo=timezone.utc)
@@ -591,20 +596,27 @@ class DropboxClient:
         local_path: str,
         dbx_path: str,
         chunk_size: int = 5 * 10 ** 6,
+        mode: files.WriteMode = files.WriteMode.add,
+        autorename: bool = False,
         sync_event: SyncEvent | None = None,
-        **kwargs,
     ) -> files.FileMetadata:
         """
         Uploads local file to Dropbox.
 
         :param local_path: Path of local file to upload.
         :param dbx_path: Path to save file on Dropbox.
-        :param kwargs: Keyword arguments for Dropbox SDK files_upload.
         :param chunk_size: Maximum size for individual uploads. If larger than 150 MB,
             it will be set to 150 MB.
+        :param mode: Your intent when writing a file to some path. This is used to
+            determine what constitutes a conflict and what the autorename strategy is.
+            See :class:`dropbox.files.WriteMode` for exact behavior.
         :param sync_event: If given, the sync event will be updated with the number of
             downloaded bytes.
+        :param autorename: If there's a conflict, as determined by ``mode``, have the
+            Dropbox server try to autorename the file to avoid conflict. The default for
+            this field is False.
         :returns: Metadata of uploaded file.
+        :raises DataCorruptionError: if data is corrupted during upload.
         """
 
         chunk_size = clamp(chunk_size, 10 ** 5, 150 * 10 ** 6)
@@ -618,91 +630,198 @@ class DropboxClient:
 
             if stat.st_size <= chunk_size:
 
-                with open(local_path, "rb", opener=opener_no_symlink) as f:
+                # Upload all at once.
 
-                    data = f.read()
+                return self._upload_helper(
+                    local_path, dbx_path, mtime_dt, mode, autorename, sync_event
+                )
 
-                    md = self.dbx.files_upload(
-                        data,
-                        dbx_path,
-                        client_modified=mtime_dt,
-                        content_hash=get_hash(data),
-                        **kwargs,
-                    )
-                    if sync_event:
-                        sync_event.completed = f.tell()
-                return md
             else:
+
+                # Upload in chunks.
                 # Note: We currently do not support resuming interrupted uploads.
                 # Dropbox keeps upload sessions open for 48h so this could be done in
                 # the future.
+
                 with open(local_path, "rb", opener=opener_no_symlink) as f:
-                    data = f.read(chunk_size)
 
-                    session_start = self.dbx.files_upload_session_start(
-                        data, content_hash=get_hash(data)
-                    )
-                    uploaded = f.tell()
-
-                    cursor = files.UploadSessionCursor(
-                        session_id=session_start.session_id, offset=uploaded
-                    )
-                    commit = files.CommitInfo(
-                        path=dbx_path, client_modified=mtime_dt, **kwargs
+                    session_id = self._upload_session_start_helper(
+                        f, chunk_size, dbx_path, sync_event
                     )
 
-                    if sync_event:
-                        sync_event.completed = uploaded
+                    while stat.st_size - f.tell() > chunk_size:
+                        self._upload_session_append_helper(
+                            f, session_id, chunk_size, dbx_path, sync_event
+                        )
 
-                    while True:
-                        try:
+                    return self._upload_session_finish_helper(
+                        f,
+                        session_id,
+                        chunk_size,
+                        # Commit info.
+                        dbx_path,
+                        mtime_dt,
+                        mode,
+                        autorename,
+                        # Commit info end.
+                        sync_event,
+                    )
 
-                            if stat.st_size - f.tell() <= chunk_size:
-                                # Finish upload session and return metadata.
-                                data = f.read(chunk_size)
+    @retry_on_error(DataCorruptionError, MAX_ATTEMPTS)
+    def _upload_helper(
+        self,
+        local_path: str,
+        dbx_path: str,
+        client_modified: datetime,
+        mode: files.WriteMode,
+        autorename: bool,
+        sync_event: SyncEvent | None,
+    ) -> files.FileMetadata:
 
-                                md = self.dbx.files_upload_session_finish(
-                                    data, cursor, commit, content_hash=get_hash(data)
-                                )
-                                if sync_event:
-                                    sync_event.completed = sync_event.size
-                                return md
-                            else:
-                                # Append to upload session.
-                                data = f.read(chunk_size)
-                                hasher = DropboxContentHasher()
-                                hasher.update(data)
-                                content_hash = hasher.hexdigest()
+        with open(local_path, "rb", opener=opener_no_symlink) as f:
+            data = f.read()
 
-                                self.dbx.files_upload_session_append_v2(
-                                    data, cursor, content_hash=content_hash
-                                )
+            with convert_api_errors(dbx_path=dbx_path, local_path=local_path):
+                md = self.dbx.files_upload(
+                    data,
+                    dbx_path,
+                    client_modified=client_modified,
+                    content_hash=get_hash(data),
+                    mode=mode,
+                    autorename=autorename,
+                )
 
-                                uploaded = f.tell()
-                                cursor.offset = uploaded
+            if sync_event:
+                sync_event.completed = f.tell()
 
-                                if sync_event:
-                                    sync_event.completed = uploaded
+        return md
 
-                        except exceptions.DropboxException as exc:
-                            error = getattr(exc, "error", None)
-                            if (
-                                isinstance(error, files.UploadSessionFinishError)
-                                and error.is_lookup_failed()
-                            ):
-                                lookup_error = error.get_lookup_failed()
-                            elif isinstance(error, files.UploadSessionLookupError):
-                                lookup_error = error
-                            else:
-                                raise exc
+    @retry_on_error(DataCorruptionError, MAX_ATTEMPTS)
+    def _upload_session_start_helper(
+        self,
+        f: BinaryIO,
+        chunk_size: int,
+        dbx_path: str,
+        sync_event: SyncEvent | None,
+    ) -> str:
 
-                            if lookup_error.is_incorrect_offset():
-                                # Reset position in file.
-                                offset_error = lookup_error.get_incorrect_offset()
-                                f.seek(offset_error.correct_offset)
-                                cursor.offset = f.tell()
-                            else:
-                                raise exc
+        initial_offset = f.tell()
+        data = f.read(chunk_size)
+
+        try:
+            with convert_api_errors(dbx_path=dbx_path):
+                session_start = self.dbx.files_upload_session_start(
+                    data, content_hash=get_hash(data)
+                )
+        except Exception:
+            # Return to previous position in file.
+            f.seek(initial_offset)
+            raise
+
+        if sync_event:
+            sync_event.completed = f.tell()
+
+        return session_start.session_id
+
+    @retry_on_error(DataCorruptionError, MAX_ATTEMPTS)
+    def _upload_session_append_helper(
+        self,
+        f: BinaryIO,
+        session_id: str,
+        chunk_size: int,
+        dbx_path: str,
+        sync_event: SyncEvent | None,
+    ) -> None:
+
+        initial_offset = f.tell()
+        data = f.read(chunk_size)
+
+        cursor = files.UploadSessionCursor(
+            session_id=session_id,
+            offset=initial_offset,
+        )
+
+        try:
+            with convert_api_errors(dbx_path=dbx_path):
+                self.dbx.files_upload_session_append_v2(
+                    data, cursor, content_hash=get_hash(data)
+                )
+        except exceptions.DropboxException as exc:
+            error = getattr(exc, "error", None)
+            if (
+                isinstance(error, files.UploadSessionAppendError)
+                and error.is_incorrect_offset()
+            ):
+                offset_error = error.get_incorrect_offset()
+                last_successful_offset = offset_error.correct_offset
+                f.seek(last_successful_offset)
+            raise exc
+
+        except Exception:
+            f.seek(initial_offset)
+            raise
+
+        if sync_event:
+            sync_event.completed = f.tell()
+
+    @retry_on_error(DataCorruptionError, MAX_ATTEMPTS)
+    def _upload_session_finish_helper(
+        self,
+        f: BinaryIO,
+        session_id: str,
+        chunk_size: int,
+        dbx_path: str,
+        client_modified: datetime,
+        mode: files.WriteMode,
+        autorename: bool,
+        sync_event: SyncEvent | None,
+    ) -> files.FileMetadata:
+
+        initial_offset = f.tell()
+        data = f.read(chunk_size)
+
+        if len(data) > chunk_size:
+            raise RuntimeError("Too much data left to finish the session")
+
+        # Finish upload session and return metadata.
+
+        cursor = files.UploadSessionCursor(
+            session_id=session_id,
+            offset=initial_offset,
+        )
+        commit = files.CommitInfo(
+            path=dbx_path,
+            client_modified=client_modified,
+            autorename=autorename,
+            mode=mode,
+        )
+
+        try:
+            with convert_api_errors(dbx_path=dbx_path):
+                md = self.dbx.files_upload_session_finish(
+                    data, cursor, commit, content_hash=get_hash(data)
+                )
+        except exceptions.DropboxException as exc:
+            error = getattr(exc, "error", None)
+            if (
+                isinstance(error, files.UploadSessionFinishError)
+                and error.is_lookup_failed()
+                and error.get_lookup_failed().is_incorrect_offset()
+            ):
+                offset_error = error.get_lookup_failed().get_incorrect_offset()
+                last_successful_offset = offset_error.correct_offset
+                f.seek(last_successful_offset)
+            raise exc
+
+        except Exception:
+            # Return to previous position in file.
+            f.seek(initial_offset)
+            raise
+
+        if sync_event:
+            sync_event.completed = sync_event.size
+
+        return md
 
     def remove(self, dbx_path: str, **kwargs) -> files.Metadata:
         """

--- a/src/maestral/errorhandling.py
+++ b/src/maestral/errorhandling.py
@@ -323,6 +323,9 @@ def dropbox_to_maestral_error(
             elif error.is_properties_error():
                 # Occurs only for programming error in maestral.
                 text = "Invalid property group provided."
+            elif error.is_payload_too_large():
+                text = "Can only upload in chunks of at most 150 MB."
+                err_cls = FileSizeError
 
         elif isinstance(error, files.UploadSessionStartError):
             title = "Could not upload file"
@@ -335,6 +338,9 @@ def dropbox_to_maestral_error(
                     "Uploading data not allowed when starting concurrent upload "
                     "session."
                 )
+            elif error.is_payload_too_large():
+                text = "Can only upload in chunks of at most 150 MB."
+                err_cls = SyncError
 
         elif isinstance(error, files.UploadSessionFinishError):
             title = "Could not upload file"
@@ -352,6 +358,9 @@ def dropbox_to_maestral_error(
                     "There are too many write operations happening in your "
                     "Dropbox. Please retry again later."
                 )
+                err_cls = SyncError
+            elif error.is_payload_too_large():
+                text = "Can only upload in chunks of at most 150 MB."
                 err_cls = SyncError
 
         elif isinstance(error, files.UploadSessionLookupError):
@@ -731,6 +740,8 @@ def get_session_lookup_error_msg(
     elif session_lookup_error.is_too_large():
         text = "You can only upload files up to 350 GB."
         err_cls = FileSizeError
+    elif session_lookup_error.is_payload_too_large():
+        text = "Can only upload in chunks of at most 150 MB."
 
     return text, err_cls
 

--- a/src/maestral/errorhandling.py
+++ b/src/maestral/errorhandling.py
@@ -686,7 +686,6 @@ def get_lookup_error_msg(
     lookup_error: files.LookupError,
 ) -> tuple[str, type[SyncError]]:
 
-    text = ""
     err_cls = SyncError
 
     if lookup_error.is_malformed_path():
@@ -714,6 +713,8 @@ def get_lookup_error_msg(
     elif lookup_error.is_locked():
         text = "The given path is locked."
         err_cls = InsufficientPermissionsError
+    else:
+        text = "An unexpected error occurred. Please try again later."
 
     return text, err_cls
 
@@ -722,19 +723,14 @@ def get_session_lookup_error_msg(
     session_lookup_error: files.UploadSessionLookupError,
 ) -> tuple[str, type[SyncError]]:
 
-    text = ""
     err_cls = SyncError
 
     if session_lookup_error.is_closed():
-        # Occurs when trying to append data to a closed session.
-        # This is caused by internal Maestral errors.
-        pass
+        text = "Cannot append data to a closed upload session."
     elif session_lookup_error.is_incorrect_offset():
         text = "A network error occurred during the upload session."
     elif session_lookup_error.is_not_closed():
-        # Occurs when trying to finish an open session.
-        # This is caused by internal Maestral errors.
-        pass
+        text = "Upload session is still open, cannot finish."
     elif session_lookup_error.is_not_found():
         text = (
             "The upload session ID was not found or has expired. "
@@ -745,6 +741,8 @@ def get_session_lookup_error_msg(
         err_cls = FileSizeError
     elif session_lookup_error.is_payload_too_large():
         text = "Can only upload in chunks of at most 150 MB."
+    else:
+        text = "An unexpected error occurred. Please try again later."
 
     return text, err_cls
 
@@ -753,7 +751,6 @@ def get_bad_path_error_msg(
     path_error: sharing.SharePathError,
 ) -> tuple[str, type[SyncError]]:
 
-    text = ""
     err_cls = SyncError
 
     if path_error.is_is_file():
@@ -793,6 +790,8 @@ def get_bad_path_error_msg(
         text = "Cannot share a folder inside a locked Vault."
     elif path_error.is_is_family():
         text = "Cannot share the Family folder."
+    else:
+        text = "An unexpected error occurred. Please try again later."
 
     return text, err_cls
 

--- a/src/maestral/errorhandling.py
+++ b/src/maestral/errorhandling.py
@@ -743,6 +743,7 @@ def get_session_lookup_error_msg(
         text = "Cannot append data to a closed upload session."
     elif session_lookup_error.is_incorrect_offset():
         text = "A network error occurred during the upload session."
+        err_cls = DataCorruptionError
     elif session_lookup_error.is_not_closed():
         text = "Upload session is still open, cannot finish."
     elif session_lookup_error.is_not_found():

--- a/src/maestral/errorhandling.py
+++ b/src/maestral/errorhandling.py
@@ -760,7 +760,7 @@ def get_session_lookup_error_msg(
         isinstance(session_lookup_error, files.UploadSessionAppendError)
         and session_lookup_error.is_content_hash_mismatch()
     ):
-        text = "Data corruption during upload. Please try again."
+        text = "A network error occurred during the upload session."
         err_cls = DataCorruptionError
     else:
         text = "An unexpected error occurred. Please try again later."

--- a/src/maestral/errorhandling.py
+++ b/src/maestral/errorhandling.py
@@ -359,6 +359,9 @@ def dropbox_to_maestral_error(
                     "Dropbox. Please retry again later."
                 )
                 err_cls = SyncError
+            elif error.is_too_many_shared_folder_targets():
+                text = "The batch request commits files into too many different shared folders. Please limit your batch request to files contained in a single shared folder."
+                err_cls = SyncError
             elif error.is_payload_too_large():
                 text = "Can only upload in chunks of at most 150 MB."
                 err_cls = SyncError

--- a/src/maestral/exceptions.py
+++ b/src/maestral/exceptions.py
@@ -58,6 +58,10 @@ class SyncError(MaestralApiError):
     """Base class for recoverable sync issues."""
 
 
+class DataCorruptionError(SyncError):
+    """Raised when data is corrupted in transit during upload or download."""
+
+
 class InsufficientPermissionsError(SyncError):
     """Raised when accessing a file or folder fails due to insufficient permissions,
     both locally and on Dropbox servers."""

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -810,7 +810,7 @@ class Maestral:
             """
 
             with tempfile.NamedTemporaryFile(mode="w+") as f:
-                md = self.client.download(dbx_path, f.name, rev=rev)
+                md = self.client.download(f"rev:{rev}", f.name)
 
                 # Read from the file.
                 try:

--- a/src/maestral/utils/hashing.py
+++ b/src/maestral/utils/hashing.py
@@ -88,3 +88,59 @@ class DropboxContentHasher:
         c._block_hasher = self._block_hasher.copy()
         c._block_pos = self._block_pos
         return c
+
+
+class StreamHasher:
+    """
+    A wrapper around a file-like object (either for reading or writing)
+    that hashes everything that passes through it.  Can be used with
+    DropboxContentHasher or any 'hashlib' hasher.
+    Example:
+        hasher = DropboxContentHasher()
+        with open('some-file', 'rb') as f:
+            wrapped_f = StreamHasher(f, hasher)
+            response = some_api_client.upload(wrapped_f)
+        locally_computed = hasher.hexdigest()
+        assert response.content_hash == locally_computed
+    """
+
+    def __init__(self, f, hasher):
+        self._f = f
+        self._hasher = hasher
+
+    def close(self):
+        return self._f.close()
+
+    def flush(self):
+        return self._f.flush()
+
+    def fileno(self):
+        return self._f.fileno()
+
+    def tell(self):
+        return self._f.tell()
+
+    def read(self, *args):
+        b = self._f.read(*args)
+        self._hasher.update(b)
+        return b
+
+    def write(self, b):
+        self._hasher.update(b)
+        return self._f.write(b)
+
+    def next(self):
+        b = self._f.next()
+        self._hasher.update(b)
+        return b
+
+    def readline(self, *args):
+        b = self._f.readline(*args)
+        self._hasher.update(b)
+        return b
+
+    def readlines(self, *args):
+        bs = self._f.readlines(*args)
+        for b in bs:
+            self._hasher.update(b)
+        return b

--- a/src/maestral/utils/hashing.py
+++ b/src/maestral/utils/hashing.py
@@ -1,7 +1,13 @@
 """Module for content hashing file contents."""
 
+from __future__ import annotations
+
 # system imports
 import hashlib
+
+from typing import BinaryIO, Union
+
+WritableBuffer = Union[bytes, bytearray]
 
 
 class DropboxContentHasher:
@@ -39,13 +45,13 @@ class DropboxContentHasher:
 
         self.digest_size = self._overall_hasher.digest_size
 
-    def update(self, new_data: bytes) -> None:
+    def update(self, new_data: WritableBuffer) -> None:
         if self._overall_hasher is None:
             raise RuntimeError(
                 "can't use this object anymore; you already called digest()"
             )
 
-        if not isinstance(new_data, bytes):
+        if not isinstance(new_data, (bytes, bytearray)):
             raise ValueError(f"Expecting a byte string, got {new_data!r}")
 
         new_data_pos = 0
@@ -82,7 +88,7 @@ class DropboxContentHasher:
     def hexdigest(self) -> str:
         return self._finish().hexdigest()
 
-    def copy(self) -> "DropboxContentHasher":
+    def copy(self) -> DropboxContentHasher:
         c = DropboxContentHasher.__new__(DropboxContentHasher)
         c._overall_hasher = self._overall_hasher.copy()
         c._block_hasher = self._block_hasher.copy()
@@ -95,52 +101,52 @@ class StreamHasher:
     A wrapper around a file-like object (either for reading or writing)
     that hashes everything that passes through it.  Can be used with
     DropboxContentHasher or any 'hashlib' hasher.
-    Example:
-        hasher = DropboxContentHasher()
-        with open('some-file', 'rb') as f:
-            wrapped_f = StreamHasher(f, hasher)
-            response = some_api_client.upload(wrapped_f)
-        locally_computed = hasher.hexdigest()
-        assert response.content_hash == locally_computed
+
+    :Example:
+
+        >>> hasher = DropboxContentHasher()
+        >>> with open('some-file', 'rb') as f:
+        ...     wrapped_f = StreamHasher(f, hasher)
+        ...     response = some_api_client.upload(wrapped_f)
+        >>> locally_computed = hasher.hexdigest()
+        >>> assert response.content_hash == locally_computed
+
+    :param f: File-like object.
+    :param hasher: Hasher to use. Must implement an ``update`` method.
     """
 
-    def __init__(self, f, hasher):
+    def __init__(self, f: BinaryIO, hasher) -> None:
         self._f = f
         self._hasher = hasher
 
-    def close(self):
+    def close(self) -> None:
         return self._f.close()
 
-    def flush(self):
+    def flush(self) -> None:
         return self._f.flush()
 
-    def fileno(self):
+    def fileno(self) -> int:
         return self._f.fileno()
 
-    def tell(self):
+    def tell(self) -> int:
         return self._f.tell()
 
-    def read(self, *args):
-        b = self._f.read(*args)
+    def read(self, size: int = -1) -> bytes:
+        b = self._f.read(size)
         self._hasher.update(b)
         return b
 
-    def write(self, b):
+    def write(self, b: WritableBuffer) -> int:
         self._hasher.update(b)
         return self._f.write(b)
 
-    def next(self):
-        b = self._f.next()
+    def readline(self, size: int = -1) -> bytes:
+        b = self._f.readline(size)
         self._hasher.update(b)
         return b
 
-    def readline(self, *args):
-        b = self._f.readline(*args)
-        self._hasher.update(b)
-        return b
-
-    def readlines(self, *args):
-        bs = self._f.readlines(*args)
+    def readlines(self, hint: int = -1) -> list[bytes]:
+        bs = self._f.readlines(hint)
         for b in bs:
             self._hasher.update(b)
-        return b
+        return bs

--- a/tests/linked/test_client.py
+++ b/tests/linked/test_client.py
@@ -45,8 +45,19 @@ def failing_content_hasher(
     return FailingHasher
 
 
+def test_upload(m):
+    """Test upload in a single chunk"""
+
+    file = resources + "/file.txt"
+    file_size = os.path.getsize(file)
+    chunk_size = file_size * 2
+
+    md = m.client.upload(file, "/file.txt", chunk_size=chunk_size)
+    assert md.content_hash == m.sync.get_local_hash(file)
+
+
 def test_upload_session(m):
-    # not tested during integration tests
+    """Test an upload session in multiple chunks"""
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)

--- a/tests/linked/test_client.py
+++ b/tests/linked/test_client.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import os
 
 import pytest
 from dropbox.files import FolderMetadata
 from dropbox.sharing import SharedFolderMetadata
 
-from maestral.exceptions import NotFoundError, PathError
+import maestral.client
+from maestral.exceptions import NotFoundError, PathError, DataCorruptionError
 from maestral.utils.path import normalize
+from maestral.utils.hashing import DropboxContentHasher
 
 from .conftest import resources
 
@@ -19,13 +23,168 @@ if not ("DROPBOX_ACCESS_TOKEN" in os.environ or "DROPBOX_REFRESH_TOKEN" in os.en
 # because niche cases require additional testing.
 
 
-def test_upload_large_file(m):
+def failing_content_hasher(
+    start_fail: int = 0, end_fail: int = 4
+) -> type[DropboxContentHasher]:
+    class FailingHasher(DropboxContentHasher):
+
+        START_FAIL = start_fail
+        END_FAIL = end_fail
+        DONE = -1
+
+        _fake_hash = "c4eec85eb66b69b8f59ff76a97d5d97aac1b5eca8c6675b4e988a5deea786e53"
+
+        def hexdigest(self) -> str:
+            FailingHasher.DONE += 1
+
+            if FailingHasher.START_FAIL <= FailingHasher.DONE < FailingHasher.END_FAIL:
+                return FailingHasher._fake_hash
+            else:
+                return super().hexdigest()
+
+    return FailingHasher
+
+
+def test_upload_session(m):
     # not tested during integration tests
 
     large_file = resources + "/large-file.pdf"
-    md = m.client.upload(large_file, "/large-file.pdf", chunk_size=5 * 10 ** 5)
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    md = m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
 
     assert md.content_hash == m.sync.get_local_hash(large_file)
+
+
+def test_upload_hash_mismatch(m, monkeypatch):
+    """Test that DataCorruptionError is raised after four failed attempts."""
+
+    file = resources + "/file2.txt"
+
+    Hasher = failing_content_hasher()
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    with pytest.raises(DataCorruptionError):
+        m.client.upload(file, "/file2.txt")
+
+    assert not m.client.get_metadata("/file2.txt")
+
+
+def test_upload_session_start_hash_mismatch(m, monkeypatch):
+    """Test that DataCorruptionError is raised after four failed attempts when starting
+    to upload session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(0, 4)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    with pytest.raises(DataCorruptionError):
+        m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    assert not m.client.get_metadata("/large-file.pdf")
+
+
+def test_upload_session_start_retry(m, monkeypatch):
+    """Test that upload succeeds after three failed attempts when starting session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(0, 3)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    remote_hash = m.client.get_metadata("/large-file.pdf").content_hash
+
+    assert remote_hash == m.sync.get_local_hash(large_file)
+
+
+def test_upload_session_append_hash_mismatch(m, monkeypatch):
+    """Test that DataCorruptionError is raised after four failed attempts when appending
+    to upload session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(1, 5)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    with pytest.raises(DataCorruptionError):
+        m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    assert not m.client.get_metadata("/large-file.pdf")
+
+
+def test_upload_session_append_hash_mismatch_retry(m, monkeypatch):
+    """Test that upload succeeds after three failed attempts when appending to
+    session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(1, 4)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    remote_hash = m.client.get_metadata("/large-file.pdf").content_hash
+
+    assert remote_hash == m.sync.get_local_hash(large_file)
+
+
+def test_upload_session_finish_hash_mismatch(m, monkeypatch):
+    """Test that DataCorruptionError is raised after four failed attempts when finishing
+    upload session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(9, 13)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    with pytest.raises(DataCorruptionError):
+        m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    assert not m.client.get_metadata("/large-file.pdf")
+
+
+def test_upload_session_finish_hash_mismatch_retry(m, monkeypatch):
+    """Test that upload succeeds after three failed attempts when finishing session."""
+
+    large_file = resources + "/large-file.pdf"
+    file_size = os.path.getsize(large_file)
+    chunk_size = file_size // 10
+
+    Hasher = failing_content_hasher(9, 12)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    m.client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+
+    remote_hash = m.client.get_metadata("/large-file.pdf").content_hash
+
+    assert remote_hash == m.sync.get_local_hash(large_file)
+
+
+def test_download_hash_mismatch(m, monkeypatch, tmp_path):
+    # not tested during integration tests
+
+    file = resources + "/file2.txt"
+    m.client.upload(file, "/file2.txt")
+
+    Hasher = failing_content_hasher(0, 4)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", Hasher)
+
+    with pytest.raises(DataCorruptionError):
+        m.client.download("/file2.txt", str(tmp_path / "file2.txt"))
 
 
 @pytest.mark.parametrize("batch_size", [10, 30])

--- a/tests/offline/test_errorhandling.py
+++ b/tests/offline/test_errorhandling.py
@@ -37,6 +37,7 @@ from maestral.exceptions import (
     FileReadError,
     FileConflictError,
     FolderConflictError,
+    DataCorruptionError,
 )
 from maestral.exceptions import PathRootError as MPRE
 from maestral.errorhandling import (
@@ -112,11 +113,12 @@ def test_get_write_error_msg(error, maestral_exc):
         (UploadSessionLookupError.closed, SyncError),
         (
             UploadSessionLookupError.incorrect_offset(UploadSessionOffsetError(20)),
-            SyncError,
+            DataCorruptionError,
         ),
         (UploadSessionLookupError.not_closed, SyncError),
         (UploadSessionLookupError.not_found, SyncError),
         (UploadSessionLookupError.too_large, FileSizeError),
+        (UploadSessionAppendError.content_hash_mismatch, DataCorruptionError),
     ],
 )
 def test_get_session_lookup_error_msg(error, maestral_exc):
@@ -153,6 +155,7 @@ def test_get_session_lookup_error_msg(error, maestral_exc):
             SyncError,
         ),
         (UploadError.properties_error, MaestralApiError),
+        (UploadError.content_hash_mismatch, DataCorruptionError),
         (UploadError.other, MaestralApiError),
         (
             UploadSessionStartError.concurrent_session_close_not_allowed,
@@ -167,6 +170,7 @@ def test_get_session_lookup_error_msg(error, maestral_exc):
         (UploadSessionFinishError.path(WriteError.team_folder), SyncError),
         (UploadSessionFinishError.properties_error, MaestralApiError),
         (UploadSessionFinishError.too_many_write_operations, SyncError),
+        (UploadSessionFinishError.content_hash_mismatch, DataCorruptionError),
         (UploadSessionFinishError.other, MaestralApiError),
         (UploadSessionLookupError.too_large, FileSizeError),
         (UploadSessionLookupError.other, MaestralApiError),


### PR DESCRIPTION
* In addition to checking offsets, also check content hashes after upload / download to prevent data corruption.
* Retry up to 3 times on data corruption. In case of chunked uploads, individual chunks will be retried up to 3 times, preserving progress from successfully uploaded data.