### PR TITLE
Shared link update

### DIFF
--- a/src/maestral/cli/cli_core.py
+++ b/src/maestral/cli/cli_core.py
@@ -437,12 +437,7 @@ def sharelink_create(
     else:
         expiry_dt = None
 
-    if password:
-        visibility = "password"
-    else:
-        visibility = "public"
-
-    link_info = m.create_shared_link(dropbox_path, visibility, password, expiry_dt)
+    link_info = m.create_shared_link(dropbox_path, password=password, expires=expiry_dt)
 
     echo(link_info["url"])
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1265,7 +1265,7 @@ class DropboxClient:
         self,
         dbx_path: str,
         visibility: sharing.LinkAudience = sharing.LinkAudience.public,
-        access_level: sharing.LinkAccessLevel = sharing.LinkAccessLevel.viewer,
+        access_level: sharing.RequestedLinkAccessLevel = sharing.RequestedLinkAccessLevel.viewer,
         allow_download: bool | None = None,
         password: str | None = None,
         expires: datetime | None = None,

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1264,39 +1264,36 @@ class DropboxClient:
     def create_shared_link(
         self,
         dbx_path: str,
-        visibility: sharing.RequestedVisibility = sharing.RequestedVisibility.public,
+        visibility: sharing.LinkAudience = sharing.LinkAudience.public,
+        access_level: sharing.LinkAccessLevel = sharing.LinkAccessLevel.viewer,
+        allow_download: bool | None = None,
         password: str | None = None,
         expires: datetime | None = None,
-        **kwargs,
     ) -> sharing.SharedLinkMetadata:
         """
         Creates a shared link for the given path. Some options are only available for
-        Professional and Business accounts. Note that the requested visibility as access
-        level for the link may not be granted, depending on the Dropbox folder or team
-        settings. Check the returned link metadata to verify the visibility and access
-        level.
+        Professional and Business accounts. Note that the requested visibility and
+        access level for the link may not be granted, depending on the Dropbox folder or
+        team settings. Check the returned link metadata to verify the visibility and
+        access level.
 
         :param dbx_path: Dropbox path to file or folder to share.
         :param visibility: The visibility of the shared link. Can be public, team-only,
-            or password protected. In case of the latter, the password argument must be
-            given. Only available for Professional and Business accounts.
-        :param password: Password to protect shared link. Is required if visibility
-            is set to password protected and will be ignored otherwise
+            or no-one. In case of the latter, the link merely points the user to the
+            content and does not grant additional rights to the user. Users of this link
+            can only access the content with their pre-existing access rights.
+        :param visibility: The visibility of the shared link. Can be public, team-only,
+            or no-one. In case of the latter, the link merely points the user to the
+            content and does not grant additional rights to the user. Users of this link
+            can only access the content with their pre-existing access rights.
+        :param access_level: The level of access granted with the link. Can be viewer,
+            editor, or max for maximum possible access level.
+        :param allow_download: Whether to allow download capabilities for the link.
+        :param password: If given, enables password protection for the link.
         :param expires: Expiry time for shared link. Only available for Professional and
             Business accounts.
-        :param kwargs: Additional keyword arguments to create the
-            :class:`dropbox.sharing.SharedLinkSettings` instance.
         :returns: Metadata for shared link.
         """
-
-        if visibility.is_password() and not password:
-            raise MaestralApiError(
-                "Invalid shared link setting",
-                "Password is required to share a password-protected link",
-            )
-
-        if not visibility.is_password():
-            password = None
 
         # Convert timestamp to utc time if not naive.
         if expires is not None:
@@ -1305,10 +1302,12 @@ class DropboxClient:
                 expires.astimezone(timezone.utc)
 
         settings = sharing.SharedLinkSettings(
-            requested_visibility=visibility,
+            require_password=password is not None,
             link_password=password,
             expires=expires,
-            **kwargs,
+            audience=visibility,
+            access=access_level,
+            allow_download=allow_download,
         )
 
         with convert_api_errors(dbx_path=dbx_path):

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -25,7 +25,7 @@ from watchdog.events import DirDeletedEvent, FileDeletedEvent
 from packaging.version import Version
 from datetime import datetime, timezone
 from dropbox.files import FileMetadata
-from dropbox.sharing import RequestedVisibility
+from dropbox.sharing import LinkAudience
 
 # local imports
 from . import __version__
@@ -1300,11 +1300,10 @@ class Maestral:
 
         :param dbx_path: Path to item on Dropbox.
         :param visibility: Requested visibility of the shared link. Must be "public",
-            "team_only" or "password". The actual visibility may be different, depending
+            "team" or "no_one". The actual visibility may be different, depending
             on the team and folder settings. Inspect the "link_permissions" entry of the
             returned dictionary.
-        :param password: An optional password required to access the link. Will be
-            ignored if the visibility is not "password".
+        :param password: An optional password required to access the link.
         :param expires: An optional expiry time for the link as POSIX timestamp.
         :returns: Shared link information as dict. See
             :class:`dropbox.sharing.SharedLinkMetadata` for keys and values.
@@ -1317,15 +1316,15 @@ class Maestral:
 
         self._check_linked()
 
-        if visibility not in ("public", "team_only", "password"):
-            raise ValueError("Visibility must be 'public', 'team_only', or 'password'")
+        if visibility not in ("public", "team", "no_one"):
+            raise ValueError("Visibility must be 'public', 'team', or 'no_one'")
 
         if visibility == "password" and not password:
             raise ValueError("Please specify a password")
 
         link_info = self.client.create_shared_link(
             dbx_path=dbx_path,
-            visibility=RequestedVisibility(visibility),
+            visibility=LinkAudience(visibility),
             password=password,
             expires=datetime.utcfromtimestamp(expires) if expires else None,
         )

--- a/tests/linked/integration/test_main.py
+++ b/tests/linked/integration/test_main.py
@@ -2,17 +2,11 @@ import sys
 import os
 import os.path as osp
 import shutil
-import requests
 import subprocess
 
 import pytest
 
-from maestral.exceptions import (
-    NotFoundError,
-    UnsupportedFileTypeForDiff,
-    SharedLinkError,
-    SyncError,
-)
+from maestral.exceptions import NotFoundError, UnsupportedFileTypeForDiff, SyncError
 from maestral.constants import FileStatus, IDLE
 from maestral.utils.path import delete
 from maestral.utils.integration import get_inotify_limits
@@ -346,66 +340,6 @@ def test_restore_failed(m):
 
     with pytest.raises(NotFoundError):
         m.restore("/restored-file", "015982ea314dac40000000154e40990")
-
-
-def test_sharedlink_lifecycle(m):
-
-    # create a folder to share
-    dbx_path = "/shared_folder"
-    m.client.make_dir(dbx_path)
-
-    # test creating a shared link
-    link_data = m.create_shared_link(dbx_path)
-
-    resp = requests.get(link_data["url"])
-    assert resp.status_code == 200
-
-    links = m.list_shared_links(dbx_path)
-    assert link_data in links
-
-    # test revoking a shared link
-    m.revoke_shared_link(link_data["url"])
-    links = m.list_shared_links(dbx_path)
-    assert link_data not in links
-
-
-def test_sharedlink_errors(m):
-
-    dbx_path = "/shared_folder"
-    m.client.make_dir(dbx_path)
-
-    # test creating a shared link with password, no password provided
-    with pytest.raises(ValueError):
-        m.create_shared_link(dbx_path, visibility="password")
-
-    # test creating a shared link with password fails on basic account
-    account_info = m.get_account_info()
-
-    if account_info["account_type"][".tag"] == "basic":
-        with pytest.raises(SharedLinkError):
-            m.create_shared_link(dbx_path, visibility="password", password="secret")
-
-    # test creating a shared link with the same settings as an existing link
-    m.create_shared_link(dbx_path)
-
-    with pytest.raises(SharedLinkError):
-        m.create_shared_link(dbx_path)
-
-    # test creating a shared link with an invalid path
-    with pytest.raises(NotFoundError):
-        m.create_shared_link("/this_is_not_a_file.txt")
-
-    # test listing shared links for an invalid path
-    with pytest.raises(NotFoundError):
-        m.list_shared_links("/this_is_not_a_file.txt")
-
-    # test revoking a non existent link
-    with pytest.raises(NotFoundError):
-        m.revoke_shared_link("https://www.dropbox.com/sh/48r2qxq748jfk5x/AAAS-niuW")
-
-    # test revoking a malformed link
-    with pytest.raises(SharedLinkError):
-        m.revoke_shared_link("https://www.testlink.de")
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="inotify specific test")


### PR DESCRIPTION
Update `DropboxClient.create_shared_link()` to replace deprecated usage of the `requested_visibility` argument with usage of the `audience` argument instead.