### PR TITLE
Fix SQL queries for older SQLite releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Fixed:
 
 * Fixes an error when querying space usage from Dropbox servers for team accounts.
+* Fixes reading from the database on SQLite versions pre 3.23.0 (2018-04-02), for
+  example on macOS High Sierra.
 
 ## v1.6.0
 

--- a/src/maestral/database/query.py
+++ b/src/maestral/database/query.py
@@ -73,7 +73,9 @@ class AllQuery(Query):
     """
 
     def clause(self):
-        return "TRUE", ()
+        # Note: Use "1" instead of "TRUE" here for compatibility with SQLite versions
+        # pre SQLite 3.23.0 (2018-04-02).
+        return "1", ()
 
 
 class CollectionQuery(Query):


### PR DESCRIPTION
SQLite before 3.23.0 (2018-04-02) don't accept `TRUE` as a truth value, however we were using this to query all rows in a table, as defined in `maestral.database.query.AllQuery`. `TRUE` has now been replaced with `1` which is also accepted in older SQLite versions.

See https://www.sqlite.org/lang_expr.html#booleanexpr. Fixes #644.