### PR TITLE
Improve shared link metadata conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   Sparkle framework if available instead of the one bundled with Maestral. This could
   lead to unexpected issues if the system-wide installation would have an incompatible
   version.
+* Fixes an issue where the access level of shared links may be incorrectly reported.
 
 ## v1.6.1
 

--- a/src/maestral/cli/cli_core.py
+++ b/src/maestral/cli/cli_core.py
@@ -455,11 +455,16 @@ def sharelink_list(m: Maestral, dropbox_path: str | None) -> None:
         else:
             dt_field = TextField("-")
 
+        if link.link_permissions.require_password:
+            access = "password"
+        else:
+            access = link.link_permissions.effective_audience.value
+
         link_table.append(
             [
                 link.url,
                 link.name,
-                link.link_permissions.effective_audience.value,
+                access,
                 dt_field,
             ]
         )

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1590,6 +1590,7 @@ def convert_list_folder_result(res: files.ListFolderResult) -> ListFolderResult:
 
 def convert_shared_link_metadata(res: sharing.SharedLinkMetadata) -> SharedLinkMetadata:
     effective_audience = LinkAudience.Other
+    require_password = res.link_permissions.require_password is True
 
     if res.link_permissions.effective_audience:
         if res.link_permissions.effective_audience.is_public():
@@ -1597,6 +1598,19 @@ def convert_shared_link_metadata(res: sharing.SharedLinkMetadata) -> SharedLinkM
         elif res.link_permissions.effective_audience.is_team():
             effective_audience = LinkAudience.Team
         elif res.link_permissions.effective_audience.is_no_one():
+            effective_audience = LinkAudience.NoOne
+
+    elif res.link_permissions.resolved_visibility:
+        if res.link_permissions.resolved_visibility.is_public():
+            effective_audience = LinkAudience.Public
+        elif res.link_permissions.resolved_visibility.is_team_only():
+            effective_audience = LinkAudience.Team
+        elif res.link_permissions.resolved_visibility.is_team_and_password():
+            effective_audience = LinkAudience.Team
+            require_password = True
+        elif res.link_permissions.resolved_visibility.is_password():
+            require_password = True
+        elif res.link_permissions.resolved_visibility.is_no_one():
             effective_audience = LinkAudience.NoOne
 
     link_access_level = LinkAccessLevel.Other
@@ -1612,7 +1626,7 @@ def convert_shared_link_metadata(res: sharing.SharedLinkMetadata) -> SharedLinkM
         res.link_permissions.allow_download,
         effective_audience,
         link_access_level,
-        res.link_permissions.require_password,
+        require_password,
     )
     return SharedLinkMetadata(
         res.url, res.name, res.path_lower, res.expires, link_permissions

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1618,7 +1618,7 @@ def convert_shared_link_metadata(res: sharing.SharedLinkMetadata) -> SharedLinkM
     if res.link_permissions.link_access_level:
         if res.link_permissions.link_access_level.is_viewer():
             link_access_level = LinkAccessLevel.Viewer
-        elif res.link_permissions.effective_audience.is_editor():
+        elif res.link_permissions.link_access_level.is_editor():
             link_access_level = LinkAccessLevel.Editor
 
     link_permissions = LinkPermissions(


### PR DESCRIPTION
Handle cases when the Dropbox API returns `LinkPermissions.resolved_visibility` in place of `LinkPermissions.effective_audience`.