### PR TITLE
Persist download queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 #### Changed:
 
-* Improved error message for file names with incompatible characters that are rejected by
-  Dropbox servers, e.g., emoji or slashes at the end of a file name.
+* Improved error message for file names with incompatible characters that are rejected 
+  by Dropbox servers, e.g., emoji or slashes at the end of a file name.
 
 #### Fixed:
 
@@ -14,6 +14,8 @@
   lead to unexpected issues if the system-wide installation would have an incompatible
   version.
 * Fixes an issue where the access level of shared links may be incorrectly reported.
+* Resume interrupted downloads after a shutdown when including new items with selective
+  sync.
 
 ## v1.6.1
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -367,7 +367,7 @@ class Maestral:
                     for path in added_included_items:
                         if not self.sync.is_excluded_by_user(path):
                             self._logger.info("Included %s", path)
-                            self.manager.added_item_queue.put(path)
+                            self.manager.download_queue.put(path)
 
                     self._logger.info(IDLE)
 
@@ -1148,10 +1148,10 @@ class Maestral:
                     self._logger.info(
                         "Included '%s' and parent directories", dbx_path_lower
                     )
-                    self.manager.added_item_queue.put(excluded_parent)
+                    self.manager.download_queue.put(excluded_parent)
                 else:
                     self._logger.info("Included '%s'", dbx_path_lower)
-                    self.manager.added_item_queue.put(dbx_path_lower)
+                    self.manager.download_queue.put(dbx_path_lower)
             finally:
                 self.sync.sync_lock.release()
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -49,7 +49,7 @@ from watchdog.events import (
 
 # local imports
 from . import notify
-from .config import MaestralConfig, MaestralState, PersistentMutableSet
+from .config import MaestralConfig, MaestralState
 from .core import (
     Metadata,
     FileMetadata,
@@ -428,18 +428,6 @@ class SyncEngine:
         self.reload_cached_config()
 
         self.desktop_notifier = notify.MaestralDesktopNotifier(self.config_name)
-
-        # Pending_uploads and pending_downloads contain interrupted uploads and
-        # downloads, respectively. to retry later. Running uploads / downloads can be
-        # stored in these lists to be resumed if Maestral quits unexpectedly. This used
-        # for downloads which are not part of the regular sync cycle and are therefore
-        # not restarted automatically.
-        self.pending_downloads = PersistentMutableSet(
-            self._state, section="sync", option="pending_downloads"
-        )
-        self.pending_uploads = PersistentMutableSet(
-            self._state, section="sync", option="pending_uploads"
-        )
 
         # Data structures for internal communication.
         self._cancel_requested = Event()

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -1202,7 +1202,7 @@ def test_invalid_pending_download(m: Maestral) -> None:
 
     # add a non-existent path to the pending downloads list
     bogus_path = "/bogus path"
-    m.sync.pending_downloads.add(bogus_path)
+    m.manager.download_queue.put(bogus_path)
 
     # trigger a resync
     m.stop_sync()
@@ -1211,7 +1211,7 @@ def test_invalid_pending_download(m: Maestral) -> None:
 
     # assert that there are no sync errors / fatal errors and that the invalid path
     # was cleared
-    assert bogus_path not in m.sync.pending_downloads
+    assert bogus_path not in m.manager.download_queue
 
     assert_synced(m)
     assert_no_errors(m)


### PR DESCRIPTION
Persist the queue to download newly added folder in selective sync. This ensures that downloads resume properly after restarting Maestral.