### PR TITLE
Capture Dropbox SDK log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Improved error message for file names with incompatible characters that are rejected by
   Dropbox servers, e.g., emoji or slashes at the end of a file name.
+* Capture Dropbox SDK logs in Maestral's log output. This will log the API endpoints 
+  being called and any retries on errors or rate limiting.
 
 #### Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Improved error message for file names with incompatible characters that are rejected by
   Dropbox servers, e.g., emoji or slashes at the end of a file name.
-* Capture Dropbox SDK logs in Maestral's log output. This will log the API endpoints 
-  being called and any retries on errors or rate limiting.
+* Capture Dropbox SDK logs in Maestral's log output. This will log which API endpoints 
+  are called and any retries on errors or rate limiting.
 
 #### Fixed:
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 # system imports
 import os
 import time
-import logging
 import contextlib
 import threading
 from datetime import datetime, timezone
@@ -34,6 +33,7 @@ from dropbox.session import API_HOST
 # local imports
 from . import __version__
 from .keyring import CredentialStorage, TokenType
+from .logging import scoped_logger
 from .core import (
     AccountType,
     Team,
@@ -142,7 +142,7 @@ class DropboxClient:
         self.cred_storage = CredentialStorage(config_name)
 
         self._state = MaestralState(config_name)
-        self._logger = logging.getLogger(__name__)
+        self._logger = scoped_logger(__name__, self.config_name)
 
         self._timeout = timeout
         self._session = session or create_session()


### PR DESCRIPTION
This provides debugs logs for individual API calls, rate limiting, and retries on errors. All of those are performed by the Dropbox SDK and are transparent to Maestral but may still affect the user, e.g., several minute backoffs on rate limits.