### PR TITLE
Fix time stamps displayed in the CLI

### DIFF
--- a/src/maestral/cli/cli_info.py
+++ b/src/maestral/cli/cli_info.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import time
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import click
@@ -164,9 +165,10 @@ def history(m: Maestral) -> None:
     )
 
     for event in events:
-        table.append(
-            [event.dbx_path, event.change_type.value, event.change_time_or_sync_time]
-        )
+        dt_local_naive = datetime.fromtimestamp(event.change_time_or_sync_time)
+        dt_field = DateField(dt_local_naive)
+
+        table.append([event.dbx_path, event.change_type.value, dt_field])
 
     echo("")
     table.echo()

--- a/src/maestral/cli/output.py
+++ b/src/maestral/cli/output.py
@@ -173,7 +173,7 @@ class DateField(Field):
     """
 
     def __init__(self, dt: datetime, **style) -> None:
-        self.dt = dt
+        self.dt = dt.astimezone()
         self.style = style
 
     @property

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -1571,8 +1571,8 @@ def convert_metadata(res):
             res.path_lower,
             res.path_display,
             res.id,
-            res.client_modified,
-            res.server_modified,
+            res.client_modified.replace(tzinfo=timezone.utc),
+            res.server_modified.replace(tzinfo=timezone.utc),
             res.rev,
             res.size,
             symlink_target,
@@ -1637,8 +1637,13 @@ def convert_shared_link_metadata(res: sharing.SharedLinkMetadata) -> SharedLinkM
         link_access_level,
         require_password,
     )
+
     return SharedLinkMetadata(
-        res.url, res.name, res.path_lower, res.expires, link_permissions
+        res.url,
+        res.name,
+        res.path_lower,
+        res.expires.replace(tzinfo=timezone.utc) if res.expires else None,
+        link_permissions,
     )
 
 

--- a/src/maestral/models.py
+++ b/src/maestral/models.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import time
 import enum
-from datetime import timezone
 from typing import TYPE_CHECKING
 
 # external imports
@@ -318,7 +317,7 @@ class SyncEvent(Model):
             symlink_target = md.symlink_target
             dbx_id = md.id
             size = md.size
-            change_time = md.client_modified.replace(tzinfo=timezone.utc).timestamp()
+            change_time = md.client_modified.timestamp()
             if sync_engine.get_local_rev(md.path_lower):
                 change_type = ChangeType.Modified
             else:

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -1,4 +1,5 @@
-import datetime
+from datetime import datetime
+from datetime import timezone
 
 import pytest
 import requests
@@ -255,8 +256,8 @@ def test_convert_metadata_file():
         path_lower="/folder/hello",
         path_display="/folder/Hello",
         id="id-0123456789",
-        client_modified=datetime.datetime.fromtimestamp(10),
-        server_modified=datetime.datetime.fromtimestamp(20),
+        client_modified=datetime.utcfromtimestamp(10),
+        server_modified=datetime.utcfromtimestamp(20),
         rev="abcdf12687980",
         size=658,
         symlink_info=files.SymlinkInfo(target="/symlink-target"),
@@ -276,8 +277,8 @@ def test_convert_metadata_file():
     assert md.path_display == "/folder/Hello"
     assert md.path_lower == "/folder/hello"
     assert md.id == "id-0123456789"
-    assert md.client_modified == datetime.datetime.fromtimestamp(10)
-    assert md.server_modified == datetime.datetime.fromtimestamp(20)
+    assert md.client_modified == datetime.fromtimestamp(10, tz=timezone.utc)
+    assert md.server_modified == datetime.fromtimestamp(20, tz=timezone.utc)
     assert md.rev == "abcdf12687980"
     assert md.size == 658
     assert md.symlink_target == "/symlink-target"
@@ -349,7 +350,7 @@ def test_convert_sharedlink_metdata():
         url="/url",
         name="Hello",
         path_lower="/folder/hello",
-        expires=datetime.datetime.fromtimestamp(10),
+        expires=datetime.utcfromtimestamp(10),
         link_permissions=sharing.LinkPermissions(
             can_revoke=False,
             effective_audience=sharing.LinkAudience.public,
@@ -365,7 +366,7 @@ def test_convert_sharedlink_metdata():
     assert md.url == "/url"
     assert md.name == "Hello"
     assert md.path_lower == "/folder/hello"
-    assert md.expires == datetime.datetime.fromtimestamp(10)
+    assert md.expires == datetime.fromtimestamp(10, tz=timezone.utc)
     assert md.link_permissions.require_password is True
     assert md.link_permissions.can_revoke is False
     assert md.link_permissions.allow_download is True
@@ -390,7 +391,7 @@ def test_convert_sharedlink_metdata():
         url="/url",
         name="Hello",
         path_lower="/folder/hello",
-        expires=datetime.datetime.fromtimestamp(10),
+        expires=datetime.utcfromtimestamp(10),
         link_permissions=sharing.LinkPermissions(
             can_revoke=False,
             resolved_visibility=sharing.ResolvedVisibility.public,
@@ -405,7 +406,7 @@ def test_convert_sharedlink_metdata():
     assert md.url == "/url"
     assert md.name == "Hello"
     assert md.path_lower == "/folder/hello"
-    assert md.expires == datetime.datetime.fromtimestamp(10)
+    assert md.expires == datetime.fromtimestamp(10, tz=timezone.utc)
     assert md.link_permissions.require_password is False
     assert md.link_permissions.can_revoke is False
     assert md.link_permissions.allow_download is True


### PR DESCRIPTION
* Convert timestamps to datetime in the output for the `history` command.
* Convert from UTC to the local timezone for all displayed time stamps.

Fixes #665.