### PR TITLE
Normalise local paths before comparing to the server

### DIFF
--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -2564,7 +2564,7 @@ class SyncEngine:
 
         home_path = self._state.get("account", "home_path")
 
-        if event.dbx_path == home_path:
+        if event.dbx_path_lower == normalize(home_path):
             raise SyncError(
                 title="Could not delete item",
                 message="Cannot delete the user's home folder",
@@ -2665,7 +2665,7 @@ class SyncEngine:
         if event.is_deleted:
             raise ValueError("Cannot process deleted event.")
 
-        if md_new.name == osp.basename(event.local_path):
+        if md_new.path_lower == event.dbx_path_lower:
             # No conflicting copy was created.
             return False
 


### PR DESCRIPTION
This PR changes how we compare local paths to paths on the server.

1. Use normalised paths as input to the Dropbox API when specifying an existing / expected file on the server.
2. Always normalise local paths before comparing them to the server.

Normalisation means conversion to lower case and unicode normalisation to NFC (i.e., composed versions of special characters: `a + °` -> `å`).

This is necessary because Dropbox will always convert paths to their normalised version on the server. This is transparent to users for case changes -- the Dropbox API will generally find the file when passing an upper case version as well -- but not for unicode normalisation. Dropbox APIs will raise "not found" errors when querying for a path with the wrong unicode normalisation.

Performing unicode normalisation before comparison allows us keep the local form of unicode characters while still seeing the file as properly synced. 

This fixes #671 because modern macOS file system APIs make it difficult (impossible?) to change the unicode normalisation of a local file (`os.rename()` will seemingly pass but without actually renaming the file). Instead, we need to live with what the OS gives us and accept it as "synced".

Note that this PR has some overlap with #409 which introduced "unicode conflict" errors on platforms that do allow file names which only differ in unicode normalisation in the same folder.  