### PR TITLE
Handle unicode renames on apfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 #### Fixed:
 
 * Fixed a segfault on startup for a small number of macOS users.
+* Fixed an issue where files which contain decomposed unicode characters could be
+  deleted after renaming them locally on some versions of macOS.
 
 ## v1.6.2
 

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -358,6 +358,12 @@ class FSEventHandler(FileSystemEventHandler):
         if not event.is_directory and event.event_type not in self.file_event_types:
             return
 
+        # Ignore moves onto itself, they may be erroneuosly emitted on older versions of
+        # macOS when changing the unicode normalisation of a path with os.rename().
+        # See https://github.com/samschott/maestral/issues/671.
+        if event.event_type == EVENT_TYPE_MOVED and event.src_path == event.dest_path:
+            return
+
         # Check if event should be ignored.
         if self._is_ignored(event):
             return


### PR DESCRIPTION
When renaming a local item to reflect an automatic rename on upload in `SyncEngine._handle_upload_conflict()`, we discard the corresponding local file system events which gets reported.

For some versions of macOS / APFS, this does not work properly when the local item is renamed to change the unicode normalisation only. Instead of reporting the rename as it actually occurred, the new and old path are sometimes reported as being the same (and macOS APIs do in fact allow accessing the item through both paths). This would however result in spurious and incorrect file system events being reported which could lead to sync issues and loss of data.

This PR fixes this behaviour by always ignoring rename events with equal source and destination path: They are either correct, in which case there is nothing to do in the first place, or they are incorrect, in which case they should be ignored.

Fixes #671.