### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/maestral/constants.py
+++ b/src/maestral/constants.py
@@ -69,6 +69,7 @@ class FileStatus(Enum):
 # platform detection
 IS_MACOS = platform.system() == "Darwin"
 IS_LINUX = platform.system() == "Linux"
+IS_FREEBSD = platform.system() == "FreeBSD"
 
 # keys
 DROPBOX_APP_KEY = "2jmbq42w7vof78h"

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -40,7 +40,7 @@ from fasteners import InterProcessLock
 # local imports
 from .utils import exc_info_tuple
 from .utils.appdirs import get_runtime_path
-from .constants import IS_MACOS, ENV
+from .constants import IS_MACOS, IS_FREEBSD, ENV
 from . import core, models, exceptions
 
 
@@ -249,7 +249,7 @@ class Lock:
             except OSError:
                 return None
 
-            if IS_MACOS:
+            if IS_MACOS or IS_FREEBSD:
                 fmt = "qqihh"
                 pid_index = 2
                 flock = struct.pack(fmt, 0, 0, 0, fcntl.F_WRLCK, 0)

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -258,7 +258,11 @@ class Lock:
                 pid_index = 4
                 flock = struct.pack(fmt, fcntl.F_WRLCK, 0, 0, 0, 0, 0)
 
-            lockdata = fcntl.fcntl(fh.fileno(), fcntl.F_GETLK, flock)
+            try:
+                lockdata = fcntl.fcntl(fh.fileno(), fcntl.F_GETLK, flock)
+            except:
+                return None
+
             lockdata_list = struct.unpack(fmt, lockdata)
             pid = lockdata_list[pid_index]
 

--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -260,7 +260,7 @@ class Lock:
 
             try:
                 lockdata = fcntl.fcntl(fh.fileno(), fcntl.F_GETLK, flock)
-            except:
+            except OSError:
                 return None
 
             lockdata_list = struct.unpack(fmt, lockdata)

--- a/src/maestral/fsevents/__init__.py
+++ b/src/maestral/fsevents/__init__.py
@@ -17,10 +17,12 @@ if platform.is_linux():
     except UnsupportedLibc:
         from .polling import OrderedPollingObserver as Observer
 elif platform.is_bsd():
-    try:
-        from watchdog.observers.kqueue import KqueueObserver as Observer
-    except UnsupportedLibc:
-        from .polling import OrderedPollingObserver as Observer
+    from watchdog.observers import Observer
+# This is disabled pending an exhaustive test.
+#    try:
+#        from watchdog.observers.kqueue import KqueueObserver as Observer
+#    except UnsupportedLibc:
+#        from .polling import OrderedPollingObserver as Observer
 
 else:
     from watchdog.observers import Observer

--- a/src/maestral/fsevents/__init__.py
+++ b/src/maestral/fsevents/__init__.py
@@ -16,6 +16,12 @@ if platform.is_linux():
         from watchdog.observers.inotify import InotifyObserver as Observer
     except UnsupportedLibc:
         from .polling import OrderedPollingObserver as Observer
+elif platform.is_bsd():
+    try:
+        from watchdog.observers.kqueue import KqueueObserver as Observer
+    except UnsupportedLibc:
+        from .polling import OrderedPollingObserver as Observer
+
 else:
     from watchdog.observers import Observer
 

--- a/src/maestral/utils/appdirs.py
+++ b/src/maestral/utils/appdirs.py
@@ -62,7 +62,7 @@ def get_conf_path(
     Returns the default config path for the platform. This will be:
 
         - macOS: "~/Library/Application Support/<subfolder>/<filename>."
-        - Linux: "XDG_CONFIG_HOME/<subfolder>/<filename>"
+        - Linux: "XDG_CONFIG_HOME/<subfolder>/<filename>" (also FreeBSD)
         - other: "~/.config/<subfolder>/<filename>"
 
     :param subfolder: The subfolder for the app.
@@ -71,7 +71,7 @@ def get_conf_path(
     """
     if platform.system() == "Darwin":
         conf_path = osp.join(get_home_dir(), "Library", "Application Support")
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         fallback = osp.join(get_home_dir(), ".config")
         conf_path = os.environ.get("XDG_CONFIG_HOME", fallback)
     else:
@@ -87,7 +87,7 @@ def get_data_path(
     Returns the default path to save application data for the platform. This will be:
 
         - macOS: "~/Library/Application Support/SUBFOLDER/FILENAME"
-        - Linux: "$XDG_DATA_DIR/SUBFOLDER/FILENAME"
+        - Linux: "$XDG_DATA_DIR/SUBFOLDER/FILENAME" (also FreeBSD)
         - fallback: "$HOME/.local/share/SUBFOLDER/FILENAME"
 
     Note: We do not use "~/Library/Saved Application State" on macOS since this folder
@@ -99,7 +99,7 @@ def get_data_path(
     """
     if platform.system() == "Darwin":
         state_path = osp.join(get_home_dir(), "Library", "Application Support")
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         fallback = osp.join(get_home_dir(), ".local", "share")
         state_path = os.environ.get("XDG_DATA_HOME", fallback)
     else:
@@ -115,7 +115,7 @@ def get_cache_path(
     Returns the default cache path for the platform. This will be:
 
         - macOS: "~/Library/Caches/SUBFOLDER/FILENAME"
-        - Linux: "$XDG_CACHE_HOME/SUBFOLDER/FILENAME"
+        - Linux: "$XDG_CACHE_HOME/SUBFOLDER/FILENAME" (also FreeBSD)
         - fallback: "$HOME/.cache/SUBFOLDER/FILENAME"
 
     :param subfolder: The subfolder for the app.
@@ -124,7 +124,7 @@ def get_cache_path(
     """
     if platform.system() == "Darwin":
         cache_path = osp.join(home_dir, "Library", "Caches")
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         fallback = osp.join(home_dir, ".cache")
         cache_path = os.environ.get("XDG_CACHE_HOME", fallback)
     else:
@@ -140,7 +140,7 @@ def get_log_path(
     Returns the default log path for the platform. This will be:
 
         - macOS: "~/Library/Logs/SUBFOLDER/FILENAME"
-        - Linux: "$XDG_CACHE_HOME/SUBFOLDER/FILENAME"
+        - Linux: "$XDG_CACHE_HOME/SUBFOLDER/FILENAME" (also FreeBSD)
         - fallback: "$HOME/.cache/SUBFOLDER/FILENAME"
 
     :param subfolder: The subfolder for the app.
@@ -150,7 +150,7 @@ def get_log_path(
 
     if platform.system() == "Darwin":
         log_path = osp.join(home_dir, "Library", "Logs")
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         log_path = get_cache_path(create=False)
     else:
         raise RuntimeError("Platform not supported")
@@ -163,7 +163,7 @@ def get_autostart_path(filename: Optional[str] = None, create: bool = True) -> s
     Returns the default path for login items for the platform. This will be:
 
         - macOS: "~/Library/LaunchAgents/FILENAME"
-        - Linux: "$XDG_CONFIG_HOME/autostart/FILENAME"
+        - Linux: "$XDG_CONFIG_HOME/autostart/FILENAME" (also FreeBSD)
         - fallback: "$HOME/.config/autostart/FILENAME"
 
     :param filename: The filename to append for the app.
@@ -171,7 +171,7 @@ def get_autostart_path(filename: Optional[str] = None, create: bool = True) -> s
     """
     if platform.system() == "Darwin":
         autostart_path = osp.join(home_dir, "Library", "LaunchAgents")
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         autostart_path = get_conf_path("autostart", create=create)
     else:
         raise RuntimeError("Platform not supported")
@@ -189,7 +189,7 @@ def get_runtime_path(
     Returns the default runtime path for the platform. This will be:
 
         - macOS: "~/Library/Application Support/SUBFOLDER/FILENAME"
-        - Linux: "$XDG_RUNTIME_DIR/SUBFOLDER/FILENAME"
+        - Linux: "$XDG_RUNTIME_DIR/SUBFOLDER/FILENAME" (also FreeBSD)
         - fallback: "$HOME/.cache/SUBFOLDER/FILENAME"
 
     :param subfolder: The subfolder for the app.
@@ -199,7 +199,7 @@ def get_runtime_path(
 
     if platform.system() == "Darwin":
         runtime_path = get_conf_path(create=False)
-    elif platform.system() == "Linux":
+    elif platform.system() == "Linux" or platform.system() == "FreeBSD":
         fallback = get_cache_path(create=False)
         runtime_path = os.environ.get("XDG_RUNTIME_DIR", fallback)
     else:


### PR DESCRIPTION
With these changes, maestral appears to work on FreeBSD.

FreeBSD and macOS use the same file locking semantics (which makes sense, as macOS uses a modified FreeBSD kernel).

FreeBSD uses the same desktop environments as Linux, so adding FreeBSD to the relevant operating system checks works fine.

FreeBSD has a working kqueue() implementation, so it should be used for the Observer bits.