### PR TITLE
Pass down dependencies

### DIFF
--- a/src/maestral/fsevents/__init__.py
+++ b/src/maestral/fsevents/__init__.py
@@ -8,15 +8,15 @@ events.
 """
 
 from watchdog.utils import platform
-from watchdog.utils import UnsupportedLibc
 
 
 if platform.is_linux():
-    try:
-        from watchdog.observers.inotify import InotifyObserver as Observer
-    except UnsupportedLibc:
-        from .polling import OrderedPollingObserver as Observer
+    from watchdog.observers.inotify import InotifyObserver as Observer
+elif platform.is_darwin():
+    from watchdog.observers.fsevents import FSEventsObserver as Observer
+elif platform.is_bsd():
+    from watchdog.observers.kqueue import KqueueObserver as Observer
 else:
-    from watchdog.observers import Observer
+    from .polling import OrderedPollingObserver as Observer
 
 __all__ = ["Observer"]

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -28,6 +28,7 @@ from datetime import datetime, timezone
 # local imports
 from . import __version__
 from .client import DropboxClient
+from .keyring import CredentialStorage
 from .core import (
     SharedLinkMetadata,
     FullAccount,
@@ -38,7 +39,7 @@ from .core import (
     LinkAccessLevel,
     UpdateCheckResult,
 )
-from .sync import SyncDirection
+from .sync import SyncDirection, SyncEngine
 from .manager import SyncManager
 from .models import SyncEvent, SyncErrorEntry
 from .exceptions import (
@@ -130,13 +131,13 @@ class Maestral:
     def __init__(
         self, config_name: str = "maestral", log_to_stderr: bool = False
     ) -> None:
-
         self._config_name = validate_config_name(config_name)
-        self._conf = MaestralConfig(self._config_name)
-        self._state = MaestralState(self._config_name)
+        self._conf = MaestralConfig(self.config_name)
+        self._state = MaestralState(self.config_name)
+        self.cred_storage = CredentialStorage(self.config_name)
 
         # Set up logging.
-        self._logger = scoped_logger(__name__, config_name)
+        self._logger = scoped_logger(__name__, self.config_name)
         self._log_to_stderr = log_to_stderr
         self._setup_logging()
 
@@ -144,9 +145,9 @@ class Maestral:
         self._check_and_run_post_update_scripts()
 
         # Set up sync infrastructure.
-        self.client = DropboxClient(config_name=self.config_name)
-        self.manager = SyncManager(self.client)
-        self.sync = self.manager.sync
+        self.client = DropboxClient(self.config_name, self.cred_storage)
+        self.sync = SyncEngine(self.client)
+        self.manager = SyncManager(self.sync)
 
         # Schedule background tasks.
         self._loop = asyncio.get_event_loop_policy().get_event_loop()
@@ -217,7 +218,7 @@ class Maestral:
             self._logger.debug("Could not remove token from keyring", exc_info=True)
 
         try:
-            self.client.cred_storage.delete_creds()
+            self.cred_storage.delete_creds()
         except KeyringAccessError:
             self._logger.debug("Could not remove token from keyring", exc_info=True)
 
@@ -231,8 +232,8 @@ class Maestral:
 
     def _setup_logging(self) -> None:
         """
-        Sets up logging to log files, status and error properties, desktop notifications,
-        the systemd journal if available, and to stderr if requested.
+        Sets up logging to log files, status and error properties, desktop
+        notifications, the systemd journal if available, and to stderr if requested.
         """
         self._root_logger = scoped_logger("maestral", self.config_name)
         (
@@ -1537,7 +1538,7 @@ class Maestral:
 
         while True:
 
-            if self.client.cred_storage.loaded:
+            if self.cred_storage.loaded:
 
                 # Only run if we have loaded the access token, we don't
                 # want to trigger any keyring access from here.

--- a/tests/linked/integration/conftest.py
+++ b/tests/linked/integration/conftest.py
@@ -62,7 +62,7 @@ def m(pytestconfig):
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
     token = access_token or refresh_token
     token_type = TokenType.Legacy if access_token else TokenType.Offline
-    m.client.cred_storage.save_creds("1234", token, token_type)
+    m.cred_storage.save_creds("1234", token, token_type)
     m.client.update_path_root()
 
     # set local Dropbox directory
@@ -116,7 +116,7 @@ def m(pytestconfig):
     lock.release()
 
     # remove creds from system keyring
-    m.client.cred_storage.delete_creds()
+    m.cred_storage.delete_creds()
 
 
 # helper functions

--- a/tests/linked/unit/conftest.py
+++ b/tests/linked/unit/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from maestral.client import DropboxClient
 from maestral.config import remove_configuration
-from maestral.keyring import TokenType
+from maestral.keyring import TokenType, CredentialStorage
 from maestral.exceptions import NotFoundError
 
 from ..lock import DropboxTestLock
@@ -22,14 +22,15 @@ def client():
     """
     config_name = "test-config"
 
-    c = DropboxClient(config_name)
+    cred_storage = CredentialStorage(config_name)
+    c = DropboxClient(config_name, cred_storage)
 
     # link with given token and store auth info in keyring for other processes
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
     token = access_token or refresh_token
     token_type = TokenType.Legacy if access_token else TokenType.Offline
-    c.cred_storage.save_creds("1234", token, token_type)
+    cred_storage.save_creds("1234", token, token_type)
     c.update_path_root()
 
     # acquire test lock
@@ -66,4 +67,4 @@ def client():
     lock.release()
 
     # remove creds from system keyring
-    c.cred_storage.delete_creds()
+    cred_storage.delete_creds()

--- a/tests/offline/conftest.py
+++ b/tests/offline/conftest.py
@@ -10,6 +10,7 @@ from maestral.fsevents import Observer
 from maestral.client import DropboxClient
 from maestral.config import list_configs, remove_configuration
 from maestral.daemon import stop_maestral_daemon_process, Stop
+from maestral.keyring import CredentialStorage
 from maestral.utils.appdirs import get_home_dir
 from maestral.utils.path import delete
 
@@ -28,7 +29,7 @@ def sync():
     local_dir = osp.join(get_home_dir(), "dummy_dir")
     os.mkdir(local_dir)
 
-    sync = SyncEngine(DropboxClient("test-config"))
+    sync = SyncEngine(DropboxClient("test-config", CredentialStorage("test-config")))
     sync.fs_events.enable()
     sync.dropbox_path = local_dir
 
@@ -47,7 +48,7 @@ def sync():
 
 @pytest.fixture
 def client():
-    yield DropboxClient("test-config")
+    yield DropboxClient("test-config", CredentialStorage("test-config"))
     remove_configuration("test-config")
 
 

--- a/tests/offline/test_clean_local_events.py
+++ b/tests/offline/test_clean_local_events.py
@@ -11,12 +11,13 @@ from watchdog.events import (
 
 from maestral.sync import SyncEngine
 from maestral.client import DropboxClient
+from maestral.keyring import CredentialStorage
 from maestral.config import remove_configuration
 
 
 @pytest.fixture
 def sync():
-    sync = SyncEngine(DropboxClient("test-config"))
+    sync = SyncEngine(DropboxClient("test-config", CredentialStorage("test-config")))
     sync.dropbox_path = "/"
 
     yield sync

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -23,33 +23,36 @@ from maestral.exceptions import NotLinkedError
 
 
 def test_get_auth_url():
-    client = DropboxClient("test-config")
+    cred_storage = CredentialStorage("test-config")
+    client = DropboxClient("test-config", cred_storage)
     assert client.get_auth_url().startswith("https://")
 
 
 def test_link():
-    client = DropboxClient("test-config")
+    cred_storage = Mock(spec_set=CredentialStorage)
+    client = DropboxClient("test-config", cred_storage)
 
     client._auth_flow = Mock(spec_set=DropboxOAuth2FlowNoRedirect)
-    client.cred_storage = Mock(spec_set=CredentialStorage)
     client.update_path_root = Mock()
 
     res = client.link("token")
 
     assert res == 0
     client.update_path_root.assert_called_once()
-    client.cred_storage.save_creds.assert_called_once()
+    cred_storage.save_creds.assert_called_once()
 
 
 def test_link_error():
-    client = DropboxClient("test-config")
+    cred_storage = CredentialStorage("test-config")
+    client = DropboxClient("test-config", cred_storage)
 
     with pytest.raises(RuntimeError):
         client.link("token")
 
 
 def test_link_failed_1():
-    client = DropboxClient("test-config")
+    cred_storage = CredentialStorage("test-config")
+    client = DropboxClient("test-config", cred_storage)
 
     client._auth_flow = Mock(spec_set=DropboxOAuth2FlowNoRedirect)
     client._auth_flow.finish = Mock(side_effect=requests.exceptions.HTTPError("failed"))
@@ -60,7 +63,8 @@ def test_link_failed_1():
 
 
 def test_link_failed_2():
-    client = DropboxClient("test-config")
+    cred_storage = Mock(spec_set=CredentialStorage)
+    client = DropboxClient("test-config", cred_storage)
 
     client._auth_flow = Mock(spec_set=DropboxOAuth2FlowNoRedirect)
     client._auth_flow.finish = Mock(side_effect=ConnectionError("failed"))
@@ -78,7 +82,8 @@ def test_link_failed_2():
 
 
 def test_unlink_error():
-    client = DropboxClient("test-config")
+    cred_storage = CredentialStorage("test-config")
+    client = DropboxClient("test-config", cred_storage)
 
     with pytest.raises(NotLinkedError):
         client.unlink()

--- a/tests/offline/test_manager.py
+++ b/tests/offline/test_manager.py
@@ -11,8 +11,8 @@ from maestral.keyring import TokenType
 
 
 def fake_linked(m: Maestral, account_info: FullAccount) -> None:
-    m.sync.client.get_account_info = mock.Mock(return_value=account_info)  # type: ignore
-    m.sync.client.cred_storage.save_creds("account_id", "1234", TokenType.Offline)
+    m.client.get_account_info = mock.Mock(return_value=account_info)  # type: ignore
+    m.cred_storage.save_creds("account_id", "1234", TokenType.Offline)
 
 
 def verify_folder_structure(root: str, structure: dict) -> None:


### PR DESCRIPTION
Pass down dependencies to the requiring classes. This enables easier "injection" of test dependencies if required.