### PR TITLE
Work around failing access token refresh calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 #### Fixed:
 
+* Work around transitory server-side errors when refreshing access tokens by retrying
+  the refresh up to three times.
 * Fixed a segfault on startup for a small number of macOS users.
 
 ## v1.6.2

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -236,7 +236,7 @@ class DropboxClient:
 
         return 0
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def unlink(self) -> None:
         """
         Unlinks the Dropbox account. The password will be deleted from the provided
@@ -462,7 +462,7 @@ class DropboxClient:
     def get_account_info(self, dbid: str) -> Account:
         ...
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def get_account_info(self, dbid=None):
         """
         Gets current account information.
@@ -504,7 +504,7 @@ class DropboxClient:
 
         return self._cached_account_info
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def get_space_usage(self) -> SpaceUsage:
         """
         :returns: The space usage of the currently linked account.
@@ -537,7 +537,7 @@ class DropboxClient:
 
         return convert_space_usage(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def get_metadata(
         self, dbx_path: str, include_deleted: bool = False
     ) -> Metadata | None:
@@ -560,7 +560,7 @@ class DropboxClient:
         except (NotFoundError, PathError):
             return None
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def list_revisions(
         self, dbx_path: str, mode: str = "path", limit: int = 10
     ) -> list[FileMetadata]:
@@ -580,7 +580,7 @@ class DropboxClient:
 
         return [convert_metadata(entry) for entry in res.entries]
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def restore(self, dbx_path: str, rev: str) -> FileMetadata:
         """
         Restore an old revision of a file.
@@ -596,7 +596,7 @@ class DropboxClient:
 
         return convert_metadata(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def download(
         self,
@@ -781,7 +781,7 @@ class DropboxClient:
 
         return convert_metadata(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_helper(
         self,
@@ -811,7 +811,7 @@ class DropboxClient:
 
         return md
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_start_helper(
         self,
@@ -839,7 +839,7 @@ class DropboxClient:
 
         return session_start.session_id
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_append_helper(
         self,
@@ -881,7 +881,7 @@ class DropboxClient:
         if sync_event:
             sync_event.completed = f.tell()
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_finish_helper(
         self,
@@ -941,7 +941,7 @@ class DropboxClient:
 
         return md
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def remove(
         self, dbx_path: str, parent_rev: str | None = None
     ) -> FileMetadata | FolderMetadata:
@@ -959,7 +959,7 @@ class DropboxClient:
 
         return convert_metadata(res.metadata)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def remove_batch(
         self, entries: Sequence[tuple[str, str | None]], batch_size: int = 900
     ) -> list[FileMetadata | FolderMetadata | MaestralApiError]:
@@ -1037,7 +1037,7 @@ class DropboxClient:
 
         return result_list
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def move(
         self, dbx_path: str, new_path: str, autorename: bool = False
     ) -> FileMetadata | FolderMetadata:
@@ -1062,7 +1062,7 @@ class DropboxClient:
 
         return convert_metadata(res.metadata)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def make_dir(self, dbx_path: str, autorename: bool = False) -> FolderMetadata:
         """
         Creates a folder on Dropbox.
@@ -1079,7 +1079,7 @@ class DropboxClient:
         md = cast(files.FolderMetadata, res.metadata)
         return convert_metadata(md)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def make_dir_batch(
         self,
         dbx_paths: list[str],
@@ -1152,7 +1152,7 @@ class DropboxClient:
 
         return result_list
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def share_dir(self, dbx_path: str, **kwargs) -> FolderMetadata | None:
         """
         Converts a Dropbox folder to a shared folder. Creates the folder if it does not
@@ -1216,7 +1216,7 @@ class DropboxClient:
         else:
             return None
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def get_latest_cursor(
         self, dbx_path: str, include_non_downloadable_files: bool = False, **kwargs
     ) -> str:
@@ -1243,7 +1243,7 @@ class DropboxClient:
 
         return res.cursor
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def list_folder(
         self,
         dbx_path: str,
@@ -1281,7 +1281,7 @@ class DropboxClient:
 
         return self.flatten_results(list(iterator))
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def list_folder_iterator(
         self,
         dbx_path: str,
@@ -1332,12 +1332,12 @@ class DropboxClient:
                 res = self._list_folder_continue_helper(res.cursor)
                 yield convert_list_folder_result(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     @retry_on_error(requests.exceptions.ReadTimeout, MAX_LIST_FOLDER_RETRIES, backoff=3)
     def _list_folder_continue_helper(self, cursor: str) -> files.ListFolderResult:
         return self.dbx.files_list_folder_continue(cursor)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def wait_for_remote_changes(self, last_cursor: str, timeout: int = 40) -> bool:
         """
         Waits for remote changes since ``last_cursor``. Call this method after
@@ -1382,7 +1382,7 @@ class DropboxClient:
         iterator = self.list_remote_changes_iterator(last_cursor)
         return self.flatten_results(list(iterator))
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def list_remote_changes_iterator(
         self, last_cursor: str
     ) -> Iterator[ListFolderResult]:
@@ -1408,7 +1408,7 @@ class DropboxClient:
                 res = self.dbx.files_list_folder_continue(res.cursor)
                 yield convert_list_folder_result(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def create_shared_link(
         self,
         dbx_path: str,
@@ -1459,7 +1459,7 @@ class DropboxClient:
 
         return convert_shared_link_metadata(res)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def revoke_shared_link(self, url: str) -> None:
         """
         Revokes a shared link.
@@ -1469,7 +1469,7 @@ class DropboxClient:
         with convert_api_errors():
             self.dbx.sharing_revoke_shared_link(url)
 
-    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
+    @retry_on_error(BadInputError, max_retries=5, backoff=2, msg_regex="v1_retired")
     def list_shared_links(
         self, dbx_path: str | None = None
     ) -> list[SharedLinkMetadata]:

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -63,6 +63,7 @@ from .exceptions import (
     NotFoundError,
     NotLinkedError,
     DataCorruptionError,
+    BadInputError,
 )
 from .errorhandling import (
     convert_api_errors,
@@ -235,6 +236,7 @@ class DropboxClient:
 
         return 0
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def unlink(self) -> None:
         """
         Unlinks the Dropbox account. The password will be deleted from the provided
@@ -460,6 +462,7 @@ class DropboxClient:
     def get_account_info(self, dbid: str) -> Account:
         ...
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def get_account_info(self, dbid=None):
         """
         Gets current account information.
@@ -501,6 +504,7 @@ class DropboxClient:
 
         return self._cached_account_info
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def get_space_usage(self) -> SpaceUsage:
         """
         :returns: The space usage of the currently linked account.
@@ -533,6 +537,7 @@ class DropboxClient:
 
         return convert_space_usage(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def get_metadata(
         self, dbx_path: str, include_deleted: bool = False
     ) -> Metadata | None:
@@ -555,6 +560,7 @@ class DropboxClient:
         except (NotFoundError, PathError):
             return None
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def list_revisions(
         self, dbx_path: str, mode: str = "path", limit: int = 10
     ) -> list[FileMetadata]:
@@ -574,6 +580,7 @@ class DropboxClient:
 
         return [convert_metadata(entry) for entry in res.entries]
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def restore(self, dbx_path: str, rev: str) -> FileMetadata:
         """
         Restore an old revision of a file.
@@ -589,6 +596,7 @@ class DropboxClient:
 
         return convert_metadata(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def download(
         self,
@@ -773,6 +781,7 @@ class DropboxClient:
 
         return convert_metadata(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_helper(
         self,
@@ -802,6 +811,7 @@ class DropboxClient:
 
         return md
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_start_helper(
         self,
@@ -829,6 +839,7 @@ class DropboxClient:
 
         return session_start.session_id
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_append_helper(
         self,
@@ -870,6 +881,7 @@ class DropboxClient:
         if sync_event:
             sync_event.completed = f.tell()
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(DataCorruptionError, MAX_TRANSFER_RETRIES)
     def _upload_session_finish_helper(
         self,
@@ -929,6 +941,7 @@ class DropboxClient:
 
         return md
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def remove(
         self, dbx_path: str, parent_rev: str | None = None
     ) -> FileMetadata | FolderMetadata:
@@ -946,6 +959,7 @@ class DropboxClient:
 
         return convert_metadata(res.metadata)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def remove_batch(
         self, entries: Sequence[tuple[str, str | None]], batch_size: int = 900
     ) -> list[FileMetadata | FolderMetadata | MaestralApiError]:
@@ -1023,6 +1037,7 @@ class DropboxClient:
 
         return result_list
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def move(
         self, dbx_path: str, new_path: str, autorename: bool = False
     ) -> FileMetadata | FolderMetadata:
@@ -1047,6 +1062,7 @@ class DropboxClient:
 
         return convert_metadata(res.metadata)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def make_dir(self, dbx_path: str, autorename: bool = False) -> FolderMetadata:
         """
         Creates a folder on Dropbox.
@@ -1063,6 +1079,7 @@ class DropboxClient:
         md = cast(files.FolderMetadata, res.metadata)
         return convert_metadata(md)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def make_dir_batch(
         self,
         dbx_paths: list[str],
@@ -1135,6 +1152,7 @@ class DropboxClient:
 
         return result_list
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def share_dir(self, dbx_path: str, **kwargs) -> FolderMetadata | None:
         """
         Converts a Dropbox folder to a shared folder. Creates the folder if it does not
@@ -1198,6 +1216,7 @@ class DropboxClient:
         else:
             return None
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def get_latest_cursor(
         self, dbx_path: str, include_non_downloadable_files: bool = False, **kwargs
     ) -> str:
@@ -1224,6 +1243,7 @@ class DropboxClient:
 
         return res.cursor
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def list_folder(
         self,
         dbx_path: str,
@@ -1261,6 +1281,7 @@ class DropboxClient:
 
         return self.flatten_results(list(iterator))
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def list_folder_iterator(
         self,
         dbx_path: str,
@@ -1311,10 +1332,12 @@ class DropboxClient:
                 res = self._list_folder_continue_helper(res.cursor)
                 yield convert_list_folder_result(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     @retry_on_error(requests.exceptions.ReadTimeout, MAX_LIST_FOLDER_RETRIES, backoff=3)
     def _list_folder_continue_helper(self, cursor: str) -> files.ListFolderResult:
         return self.dbx.files_list_folder_continue(cursor)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def wait_for_remote_changes(self, last_cursor: str, timeout: int = 40) -> bool:
         """
         Waits for remote changes since ``last_cursor``. Call this method after
@@ -1359,6 +1382,7 @@ class DropboxClient:
         iterator = self.list_remote_changes_iterator(last_cursor)
         return self.flatten_results(list(iterator))
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def list_remote_changes_iterator(
         self, last_cursor: str
     ) -> Iterator[ListFolderResult]:
@@ -1384,6 +1408,7 @@ class DropboxClient:
                 res = self.dbx.files_list_folder_continue(res.cursor)
                 yield convert_list_folder_result(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def create_shared_link(
         self,
         dbx_path: str,
@@ -1434,6 +1459,7 @@ class DropboxClient:
 
         return convert_shared_link_metadata(res)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def revoke_shared_link(self, url: str) -> None:
         """
         Revokes a shared link.
@@ -1443,6 +1469,7 @@ class DropboxClient:
         with convert_api_errors():
             self.dbx.sharing_revoke_shared_link(url)
 
+    @retry_on_error(BadInputError, max_retries=3, backoff=2, msg_regex="v1_retired")
     def list_shared_links(
         self, dbx_path: str | None = None
     ) -> list[SharedLinkMetadata]:

--- a/src/maestral/exceptions.py
+++ b/src/maestral/exceptions.py
@@ -40,6 +40,7 @@ class MaestralApiError(Exception):
         local_path: str | None = None,
         local_path_from: str | None = None,
     ) -> None:
+        super().__init__(f"{title}. {message}")
         self.title = title
         self.message = message
         self.dbx_path = dbx_path
@@ -48,7 +49,7 @@ class MaestralApiError(Exception):
         self.local_path_from = local_path_from
 
     def __str__(self) -> str:
-        return ". ".join([self.title, self.message])
+        return f"{self.title}. {self.message}"
 
 
 # ==== regular sync errors =============================================================


### PR DESCRIPTION
Fixes #683 by mitigating the server-side errors with a client-side retry when refreshing the access token fails.