### PR TITLE
Separate `maestral ls` output by new lines when not attached to terminal

### DIFF
--- a/src/maestral/cli/cli_info.py
+++ b/src/maestral/cli/cli_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import time
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -261,8 +262,11 @@ def ls(m: Maestral, long: bool, dropbox_path: str, include_deleted: bool) -> Non
         table.echo()
         echo(" " * 15)
 
-    else:
+    if not sys.stdout.isatty():
+        names = [entry.name for entries in entries_iter for entry in entries]
+        echo("\n".join(names))
 
+    else:
         grid = Grid()
 
         for entries in entries_iter:


### PR DESCRIPTION
Fixes #691.