### PR TITLE
Class-level decorators are no longer static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixed:
 
+* Fixes an error which would prevent running Maestral on Python 3.7.
 * Fixes a regression where the CLI command `maestral activity` would fail when run from
   a macOS app bundle.
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -159,8 +159,7 @@ class DropboxClient:
         self._is_team_space = self._state.get("account", "path_root_type") == "team"
         self._lock = threading.Lock()
 
-    @staticmethod
-    def _retry_on_error(
+    def _retry_on_error(  # type: ignore
         error_cls: type[Exception],
         max_retries: int,
         backoff: int = 0,

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -147,7 +147,6 @@ class SyncManager:
 
         self.local_observer_thread: Observer | None = None
 
-    @staticmethod
     def _with_lock(fn: FT) -> FT:  # type: ignore
         @wraps(fn)
         def wrapper(self, *args, **kwargs):


### PR DESCRIPTION
Fixes a crash on Python 3.7.