### PR TITLE
Allow relinking when the SDK has already been initialized

### DIFF
--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -324,9 +324,6 @@ class DropboxClient:
 
         with self._lock:
 
-            if self._dbx:
-                return
-
             if not (token or self._cred_storage.token):
                 raise NotLinkedError(
                     "No auth token set", "Please link a Dropbox account first."


### PR DESCRIPTION
Re-initialising the SDK would previously not work if we are already linked and have an initialised SDK. This regression was introduced in #619.

Fixes #713.