### PR TITLE
Allow linking with auth tokens

### DIFF
--- a/src/maestral/cli/cli_core.py
+++ b/src/maestral/cli/cli_core.py
@@ -334,11 +334,26 @@ def auth() -> None:
     default=False,
     help="Relink to the existing account. Keeps the sync state.",
 )
+@click.option(
+    "--refresh-token",
+    hidden=True,
+    help="Refresh token to bypass OAuth exchange.",
+)
+@click.option(
+    "--access-token",
+    hidden=True,
+    help="Access token to bypass OAuth exchange.",
+)
 @inject_proxy(fallback=True, existing_config=False)
 @convert_api_errors
-def auth_link(m: Maestral, relink: bool) -> None:
+def auth_link(
+    m: Maestral, relink: bool, refresh_token: str | None, access_token: str | None
+) -> None:
     if m.pending_link or relink:
-        link_dialog(m)
+        if refresh_token or access_token:
+            m.link(refresh_token=refresh_token, access_token=access_token)
+        else:
+            link_dialog(m)
     else:
         echo(
             "Maestral is already linked. Use '-r' to relink to the same "

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -247,10 +247,10 @@ class DropboxClient:
     def get_auth_url(self) -> str:
         """
         Returns a URL to authorize access to a Dropbox account. To link a Dropbox
-        account, retrieve an auth token from the URL and link Maestral by calling
-        :meth:`link` with the provided token.
+        account, retrieve an authorization code from the URL and link Maestral by
+        calling :meth:`link` with the provided code.
 
-        :returns: URL to retrieve an OAuth token.
+        :returns: URL to retrieve an authorization code.
         """
         self._auth_flow = DropboxOAuth2FlowNoRedirect(
             consumer_key=DROPBOX_APP_KEY,
@@ -259,34 +259,57 @@ class DropboxClient:
         )
         return self._auth_flow.start()
 
-    def link(self, token: str) -> int:
+    def link(
+        self,
+        code: str | None = None,
+        refresh_token: str | None = None,
+        access_token: str | None = None,
+    ) -> int:
         """
-        Links Maestral with a Dropbox account using the given access token. The token
-        will be stored for future usage in the provided credential store.
+        Links Maestral with a Dropbox account using the given authorization code. The
+        code will be exchanged for an access token and a refresh token with Dropbox
+        servers. The refresh token will be stored for future usage in the provided
+        credential store.
 
-        :param token: OAuth token for Dropbox access.
+        :param code: Authorization code.
+        :param refresh_token: Optionally, instead of an authorization code, directly
+            provide a refresh token.
+        :param access_token: Optionally, instead of an authorization code or a refresh
+            token, directly provide an access token. Note that access tokens are
+            short-lived.
         :returns: 0 on success, 1 for an invalid token and 2 for connection errors.
         """
-        if not self._auth_flow:
-            raise RuntimeError("Please start auth flow with 'get_auth_url' first")
+        if code:
+            if not self._auth_flow:
+                raise RuntimeError("Please start auth flow with 'get_auth_url' first")
+
+            try:
+                res = self._auth_flow.finish(code)
+            except requests.exceptions.HTTPError:
+                return 1
+            except CONNECTION_ERRORS:
+                return 2
+
+            token = res.refresh_token
+            token_type = TokenType.Offline
+        elif refresh_token:
+            token = refresh_token
+            token_type = TokenType.Offline
+        elif access_token:
+            token = access_token
+            token_type = TokenType.Legacy
+        else:
+            raise RuntimeError("No auth code, refresh token ior access token provided.")
+
+        self._init_sdk(token, token_type)
 
         try:
-            res = self._auth_flow.finish(token)
-        except requests.exceptions.HTTPError:
-            return 1
+            account_info = self.get_account_info()
+            self.update_path_root(account_info.root_info)
         except CONNECTION_ERRORS:
             return 2
 
-        self._init_sdk(res.refresh_token, TokenType.Offline)
-
-        try:
-            self.update_path_root()
-        except CONNECTION_ERRORS:
-            return 2
-
-        self._cred_storage.save_creds(
-            res.account_id, res.refresh_token, TokenType.Offline
-        )
+        self._cred_storage.save_creds(account_info.account_id, token, token_type)
         self._auth_flow = None
 
         return 0

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -462,7 +462,7 @@ class DropboxClient:
         """
         return self.clone(session=create_session())
 
-    def update_path_root(self, root_info: RootInfo | None = None) -> None:
+    def update_path_root(self, root_info: RootInfo) -> None:
         """
         Updates the root path for the Dropbox client. All files paths given as arguments
         to API calls such as :meth:`list_folder` or :meth:`get_metadata` will be
@@ -483,14 +483,9 @@ class DropboxClient:
             calls. Be prepared to handle :exc:`maestral.exceptions.PathRootError`
             and act accordingly for all methods.
 
-        :param root_info: Optional :class:`core.RootInfo` describing the path
-            root. If not given, the latest root info will be fetched from Dropbox
-            servers.
+        :param root_info: :class:`core.RootInfo` describing the path root. Use
+            :meth:`get_account_info` to retrieve.
         """
-        if not root_info:
-            account_info = self.get_account_info()
-            root_info = account_info.root_info
-
         root_nsid = root_info.root_namespace_id
 
         path_root = common.PathRoot.root(root_nsid)

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -242,7 +242,9 @@ class Maestral:
             * Plain text storage
 
         For testing, it is also possible to directly provide a long-lived refresh token
-        or a short-lived access token.
+        or a short-lived access token. Note that the tokens must be issued for Maestral,
+        with the required scopes, and will be validated with Dropbox servers as part of
+        this call.
 
         :param code: Authorization code.
         :param refresh_token: Optionally, instead of an authorization code, directly

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -216,29 +216,45 @@ class Maestral:
     def get_auth_url(self) -> str:
         """
         Returns a URL to authorize access to a Dropbox account. To link a Dropbox
-        account, retrieve an auth token from the URL and link Maestral by calling
-        :meth:`link` with the provided token.
+        account, retrieve an authorization code from the URL and link Maestral by
+        calling :meth:`link` with the provided code.
 
-        :returns: URL to retrieve an OAuth token.
+        :returns: URL to retrieve an authorization code.
         """
         return self.client.get_auth_url()
 
-    def link(self, token: str) -> int:
+    def link(
+        self,
+        code: str | None = None,
+        refresh_token: str | None = None,
+        access_token: str | None = None,
+    ) -> int:
         """
-        Links Maestral with a Dropbox account using the given access token. The token
-        will be stored for future usage as documented in the :mod:`oauth` module.
-        Supported keyring backends are, in order of preference:
+        Links Maestral with a Dropbox account using the given authorization code. The
+        code will be exchanged for an access token and a refresh token with Dropbox
+        servers. The refresh token will be stored for future usage as documented in the
+        :mod:`oauth` module. Supported keyring backends are, in order of preference:
 
-            * MacOS Keychain
+            * macOS Keychain
             * Any keyring implementing the SecretService Dbus specification
             * KWallet
             * Gnome Keyring
             * Plain text storage
 
-        :param token: OAuth token for Dropbox access.
+        For testing, it is also possible to directly provide a long-lived refresh token
+        or a short-lived access token.
+
+        :param code: Authorization code.
+        :param refresh_token: Optionally, instead of an authorization code, directly
+            provide a refresh token.
+        :param access_token: Optionally, instead of an authorization code or a refresh
+            token, directly provide an access token. Note that access tokens are
+            short-lived.
         :returns: 0 on success, 1 for an invalid token and 2 for connection errors.
         """
-        return self.client.link(token)
+        return self.client.link(
+            code=code, refresh_token=refresh_token, access_token=access_token
+        )
 
     def unlink(self) -> None:
         """

--- a/tests/linked/integration/conftest.py
+++ b/tests/linked/integration/conftest.py
@@ -9,7 +9,6 @@ from maestral.main import Maestral
 from maestral.config import remove_configuration
 from maestral.utils.path import generate_cc_name, delete
 from maestral.utils.appdirs import get_home_dir
-from maestral.keyring import TokenType
 from maestral.exceptions import NotFoundError
 
 from ..lock import DropboxTestLock
@@ -57,13 +56,10 @@ def m(pytestconfig):
     m = Maestral(config_name)
     m.log_level = logging.DEBUG
 
-    # link with given token and store auth info in keyring for other processes
+    # link with the given token
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
-    token = access_token or refresh_token
-    token_type = TokenType.Legacy if access_token else TokenType.Offline
-    m.cred_storage.save_creds("1234", token, token_type)
-    m.client.update_path_root()
+    m.link(refresh_token=refresh_token, access_token=access_token)
 
     # set local Dropbox directory
     home = get_home_dir()
@@ -115,7 +111,7 @@ def m(pytestconfig):
     # release lock
     lock.release()
 
-    # remove creds from system keyring
+    # remove creds from system keyring but don't unlink so that tokens remain valid
     m.cred_storage.delete_creds()
 
 

--- a/tests/offline/test_client.py
+++ b/tests/offline/test_client.py
@@ -33,9 +33,10 @@ def test_link():
     client = DropboxClient("test-config", cred_storage)
 
     client._auth_flow = Mock(spec_set=DropboxOAuth2FlowNoRedirect)
+    client.get_account_info = Mock()
     client.update_path_root = Mock()
 
-    res = client.link("token")
+    res = client.link("code")
 
     assert res == 0
     client.update_path_root.assert_called_once()
@@ -47,7 +48,7 @@ def test_link_error():
     client = DropboxClient("test-config", cred_storage)
 
     with pytest.raises(RuntimeError):
-        client.link("token")
+        client.link("code")
 
 
 def test_link_failed_1():
@@ -74,6 +75,7 @@ def test_link_failed_2():
     assert res == 2
 
     client._auth_flow = Mock(spec_set=DropboxOAuth2FlowNoRedirect)
+    client.get_account_info = Mock()
     client.update_path_root = Mock(side_effect=ConnectionError("failed"))
 
     res = client.link("token")


### PR DESCRIPTION
The regular linking flow requires going through the full OAuth flow with Maestral: 

1. Get a Dropbox URL with `Maestral.get_auth_url()`.
2. Navigating to the URL to retrieve an auth code,
3. Call `Maestral.link()` with the retrieved code to exchange it for a long-lived refresh token.

This is inconvenient for automated testing where either a long-lived refresh token or a short-lived access token are already provided, typically through environment variables.

This PR allows directly providing a refresh or access token for linking. Note that the token must be issued for Maestral, with the required scopes, and will validated during the `Maestral.link()` call.