### PR TITLE
Better status updates

### DIFF
--- a/src/maestral/cli/cli_maintenance.py
+++ b/src/maestral/cli/cli_maintenance.py
@@ -16,7 +16,7 @@ from rich.text import Text
 from .cli_core import select_dbx_path_dialog
 from .dialogs import confirm, select
 from .output import ok, warn, echo, echo_via_pager, RichDateField, rich_table
-from .utils import get_term_width
+from .utils import get_term_size
 from .common import convert_api_errors, existing_config_option, inject_proxy
 from .core import DropboxPath, ConfigKey, CliException
 
@@ -49,7 +49,7 @@ Rebuilding may take several minutes, depending on the size of your Dropbox.
 @inject_proxy(fallback=True, existing_config=True)
 @convert_api_errors
 def rebuild_index(m: Maestral, yes: bool) -> None:
-    width = get_term_width()
+    size = get_term_size()
 
     msg = textwrap.fill(
         "Rebuilding the index may take several minutes, depending on the size of "
@@ -57,7 +57,7 @@ def rebuild_index(m: Maestral, yes: bool) -> None:
         "has completed. If you stop the daemon during the process, rebuilding will "
         "start again on the next launch.\nIf the daemon is not currently running, "
         "a rebuild will be scheduled for the next startup.",
-        width=width,
+        width=size.columns,
     )
 
     echo(msg + "\n")

--- a/src/maestral/cli/common.py
+++ b/src/maestral/cli/common.py
@@ -9,7 +9,7 @@ import click
 
 from .core import ConfigName
 from .output import warn
-from .utils import get_term_width
+from .utils import get_term_size
 
 if TYPE_CHECKING:
     from ..daemon import MaestralProxy
@@ -54,10 +54,10 @@ def check_for_fatal_errors(m: MaestralProxy | Maestral) -> bool:
 
     if len(maestral_err_list) > 0:
 
-        width = get_term_width()
+        size = get_term_size()
 
         err = maestral_err_list[0]
-        wrapped_msg = textwrap.fill(err.message, width=width)
+        wrapped_msg = textwrap.fill(err.message, width=size.columns)
 
         click.echo("")
         click.secho(err.title, fg="red")

--- a/src/maestral/cli/utils.py
+++ b/src/maestral/cli/utils.py
@@ -1,17 +1,18 @@
 """
 Module to print neatly formatted tables and grids to the terminal.
 """
+from __future__ import annotations
 
-import shutil
 import sys
+import os
+import shutil
 
 
-def get_term_width() -> int:
+def get_term_size() -> os.terminal_size:
     """
-    Returns the terminal width. If it cannot be determined, for example because output
-    is piped to a file, return :attr:`sys.maxsize` instead.
+    Returns the terminal size. If it cannot be determined, for example because output
+    is piped to a file, return :attr:`sys.maxsize` for width and height instead.
 
-    :returns: Terminal width.
+    :returns: (width, height).
     """
-    term_size = shutil.get_terminal_size(fallback=(sys.maxsize, sys.maxsize))
-    return term_size.columns
+    return shutil.get_terminal_size(fallback=(sys.maxsize, sys.maxsize))

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -393,7 +393,6 @@ class SyncManager:
         was_running = self.running.is_set()
 
         self.stop()
-
         self.reset_sync_state()
 
         if was_running:

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -13,17 +13,17 @@ import uuid
 import urllib.parse
 import enum
 import sqlite3
-import logging
 import gc
 from stat import S_ISDIR
 from pprint import pformat
 from threading import Event, Condition, RLock, current_thread
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from queue import Queue, Empty
 from collections import defaultdict
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-from typing import Any, Iterator, Callable, cast
+from typing import Any, Iterator, Iterable, Collection, Callable, TypeVar, cast
+from typing_extensions import ParamSpec
 
 # external imports
 import click
@@ -137,6 +137,10 @@ __all__ = [
 umask = os.umask(0o22)
 os.umask(umask)
 
+NUM_THREADS = min(64, CPU_COUNT * 4)
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 # ======================================================================================
 # Syncing functionality
@@ -1497,13 +1501,12 @@ class SyncEngine:
     ) -> list[SyncEvent]:
         """Convert local file system events to sync events. This is done in a thread
         pool to parallelize content hashing."""
-        with ThreadPoolExecutor(
-            max_workers=self._num_threads,
+        res = do_parallel(
+            self._sync_event_from_fs_event,
+            fs_events,
             thread_name_prefix="maestral-local-indexer",
-        ) as executor:
-            res = executor.map(self._sync_event_from_fs_event, fs_events)
-
-            return list(res)
+        )
+        return list(res)
 
     # ==== Upload sync =================================================================
 
@@ -1754,40 +1757,31 @@ class SyncEngine:
         if deleted:
             self._logger.info("Uploading deletions...")
 
-        with ThreadPoolExecutor(
-            max_workers=self._num_threads,
+        res = do_parallel(
+            self._create_remote_entry,
+            deleted,
+            on_progress=lambda x, y: self._logger.info(f"Deleting {x}/{y}"),
             thread_name_prefix="maestral-upload-pool",
-        ) as executor:
-            res = executor.map(self._create_remote_entry, deleted)
-
-            n_items = len(deleted)
-            for n, r in enumerate(res):
-                throttled_log(self._logger, f"Deleting {n + 1}/{n_items}...")
-                results.append(r)
+        )
+        results.extend(res)
 
         if dir_moved:
             self._logger.info("Moving folders...")
 
         for event in dir_moved:
-            self._logger.info(f"Moving {event.dbx_path_from}...")
+            self._logger.info(f"Moving {event.dbx_path_from}")
             r = self._create_remote_entry(event)
             results.append(r)
 
         # Apply other events in parallel, processing each hierarchy level successively.
-
         for level in sorted(other):
-            items = other[level]
-
-            with ThreadPoolExecutor(
-                max_workers=self._num_threads,
+            res = do_parallel(
+                self._create_remote_entry,
+                other[level],
+                on_progress=lambda x, y: self._logger.info(f"Syncing ↑ {x}/{y}"),
                 thread_name_prefix="maestral-upload-pool",
-            ) as executor:
-                res = executor.map(self._create_remote_entry, items)
-
-                n_items = len(items)
-                for n, r in enumerate(res):
-                    throttled_log(self._logger, f"Syncing ↑ {n + 1}/{n_items}")
-                    results.append(r)
+            )
+            results.extend(res)
 
         self._clean_history()
 
@@ -2955,45 +2949,35 @@ class SyncEngine:
             self._logger.info("Applying deletions...")
 
         for level in sorted(deleted):
-            items = deleted[level]
-            with ThreadPoolExecutor(
-                max_workers=self._num_threads,
+            res = do_parallel(
+                self._create_local_entry,
+                deleted[level],
+                on_progress=lambda x, y: self._logger.info(f"Deleting {x}/{y}"),
                 thread_name_prefix="maestral-download-pool",
-            ) as executor:
-                res = executor.map(self._create_local_entry, items)
-
-                n_items = len(items)
-                for n, r in enumerate(res):
-                    throttled_log(self._logger, f"Deleting {n + 1}/{n_items}...")
-                    results.append(r)
+            )
+            results.extend(res)
 
         # Create local folders, start with top-level and work your way down.
         if folders:
             self._logger.info("Creating folders...")
 
         for level in sorted(folders):
-            items = folders[level]
-            with ThreadPoolExecutor(
-                max_workers=self._num_threads,
+            res = do_parallel(
+                self._create_local_entry,
+                folders[level],
+                on_progress=lambda x, y: self._logger.info(f"Creating folder {x}/{y}"),
                 thread_name_prefix="maestral-download-pool",
-            ) as executor:
-                res = executor.map(self._create_local_entry, items)
-
-                n_items = len(items)
-                for n, r in enumerate(res):
-                    throttled_log(self._logger, f"Creating folder {n + 1}/{n_items}...")
-                    results.append(r)
+            )
+            results.extend(res)
 
         # Apply created files.
-        with ThreadPoolExecutor(
-            max_workers=self._num_threads, thread_name_prefix="maestral-download-pool"
-        ) as executor:
-            res = executor.map(self._create_local_entry, files)
-
-            n_items = len(files)
-            for n, r in enumerate(res):
-                throttled_log(self._logger, f"Syncing ↓ {n + 1}/{n_items}")
-                results.append(r)
+        res = do_parallel(
+            self._create_local_entry,
+            files,
+            on_progress=lambda x, y: self._logger.info(f"Syncing ↓ {x}/{y}"),
+            thread_name_prefix="maestral-download-pool",
+        )
+        results.extend(res)
 
         self._clean_history()
 
@@ -3711,6 +3695,26 @@ class SyncEngine:
 # ======================================================================================
 
 
+def do_parallel(
+    fn: Callable[P, T],
+    *args_iter: Collection[P.args],
+    thread_name_prefix: str = "",
+    max_workers: int = NUM_THREADS,
+    on_progress: Callable[[int, int], Any] | None = None,
+) -> Iterable[T]:
+    with ThreadPoolExecutor(
+        max_workers=max_workers, thread_name_prefix=thread_name_prefix
+    ) as tpe:
+        fs = [tpe.submit(fn, *args) for args in zip(*args_iter)]
+
+        n_done = 0
+        for f in as_completed(fs):
+            n_done += 1
+            if on_progress:
+                on_progress(n_done, len(args_iter[0]))
+            yield f.result()
+
+
 def get_dest_path(event: FileSystemEvent) -> str:
     """
     Returns the dest_path of a file system event if present (moved events only)
@@ -3769,27 +3773,6 @@ class pf_repr:
 
 
 _last_emit = time.time()
-
-
-def throttled_log(
-    log: logging.Logger, msg: str, level: int = logging.INFO, limit: int = 2
-) -> None:
-    """
-    Emits the given log message only if the previous message was emitted more than
-    ``limit`` seconds ago. This can be used to prevent spamming a log with frequent
-    updates.
-
-    :param log: Logger used to emit the message.
-    :param msg: Log message.
-    :param level: Log level.
-    :param limit: Minimum time between log messages.
-    """
-
-    global _last_emit
-
-    if time.time() - _last_emit > limit:
-        log.log(level=level, msg=msg)
-        _last_emit = time.time()
 
 
 def validate_encoding(local_path: str) -> None:


### PR DESCRIPTION
* Log status while syncing immediately when there is an update. This is done by using `cuncurrent.futures.as_completed` on the futures.
* Update the activity view of `maestral activity` every 0.2 seconds.
* Limit the output of `maestral activity` to the terminal size.