### PR TITLE
Fix GUI entry-point selection for Python 3.9 and earlier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     desktop-notifier>=3.3.0
     dropbox>=11.28.0,<12.0
     fasteners>=0.15
-    importlib_metadata;python_version<'3.8'
+    importlib_metadata>=3.6
     keyring>=22
     keyrings.alt>=3.1.0
     packaging

--- a/src/maestral/cli/cli_core.py
+++ b/src/maestral/cli/cli_core.py
@@ -265,11 +265,7 @@ def gui(config_name: str) -> None:
 
     from packaging.version import Version
     from packaging.requirements import Requirement
-
-    try:
-        from importlib.metadata import entry_points, requires, version
-    except ImportError:
-        from importlib_metadata import entry_points, requires, version  # type: ignore
+    from importlib_metadata import entry_points, requires, version
 
     # Find all entry points for "maestral_gui" registered by other packages.
     gui_entry_points = entry_points(group="maestral_gui")
@@ -279,13 +275,14 @@ def gui(config_name: str) -> None:
             "No maestral GUI installed. Please run 'pip3 install maestral[gui]'."
         )
 
-    if len(gui_entry_points) > 1:
-        _prompt = "Multiple GUIs found, please choose:"
-        index = select(_prompt, [e.name for e in gui_entry_points])
+    entry_point_names = [e.name for e in gui_entry_points]
+
+    if len(entry_point_names) > 1:
+        index = select("Multiple GUIs found, please choose:", entry_point_names)
     else:
         index = 0
 
-    entry_point = gui_entry_points[index]
+    entry_point = gui_entry_points[entry_point_names[index]]
 
     if entry_point in {"maestral_cocoa", "maestral_qt"}:
         # For 1st party GUIs "maestral_cocoa" or "maestral_qt", check if the installed


### PR DESCRIPTION
Fixes #767.

* The `groups` parameter to `entry_points()` is only supported from Python 3.10 and upwards in `importlib.metadata` and in `importlib_metadata` from v3.6.
* Indexed access to EntryPoints is only supported in `importlib.metadata`.

API usage is now consistent with `importlib_metadata>3.6` and we always require installing `importlib_metadata` to simplify imports and mitigate regressions.