### PR TITLE
Pass event loop explicitly instead of creating it on-demand

### DIFF
--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -16,8 +16,8 @@ import tempfile
 import mimetypes
 import difflib
 import logging
-from concurrent.futures import ThreadPoolExecutor
-from typing import Iterator, Awaitable, Any, Sequence
+from asyncio import AbstractEventLoop, Future
+from typing import Iterator, Any, Sequence
 
 # external imports
 import requests
@@ -47,6 +47,7 @@ from .core import (
 from .sync import SyncDirection, SyncEngine
 from .manager import SyncManager
 from .models import SyncEvent, SyncErrorEntry
+from .notify import MaestralDesktopNotifier
 from .exceptions import (
     MaestralApiError,
     NotLinkedError,
@@ -75,7 +76,6 @@ from .utils.path import (
     delete,
 )
 from .utils.appdirs import get_cache_path, get_data_path
-from .utils.integration import get_ac_state, ACState
 from .database.core import Database
 from .constants import IDLE, PAUSED, CONNECTING, GITHUB_RELEASES_API, FileStatus
 
@@ -137,6 +137,12 @@ class Maestral:
     :param log_to_stderr: If ``True``, Maestral will print log messages to stderr.
         When started as a systemd services, this can result in duplicate log messages
         in the systemd journal. Defaults to ``False``.
+    :param event_loop: Event loop to use for any features that require an asyncio event
+        loop. If not given, those features will be disabled. This currently only affects
+        desktop notifications.
+    :param shutdown_future: Feature to set a result when shutdown is complete. Used to
+        inform the caller if an API client calls :method:`shutdown_daemon`. The event
+        loop associated with the Future must be the same as ``event_loop``.
     """
 
     _external_log_handlers: Sequence[logging.Handler]
@@ -144,8 +150,13 @@ class Maestral:
     _log_handler_error_cache: CachedHandler
 
     def __init__(
-        self, config_name: str = "maestral", log_to_stderr: bool = False
+        self,
+        config_name: str = "maestral",
+        log_to_stderr: bool = False,
+        event_loop: AbstractEventLoop | None = None,
+        shutdown_future: Future[bool] | None = None,
     ) -> None:
+        self._loop = event_loop
         self._config_name = validate_config_name(config_name)
         self._conf = MaestralConfig(self.config_name)
         self._state = MaestralState(self.config_name)
@@ -163,25 +174,22 @@ class Maestral:
         # Run update scripts after init of loggers and config / state.
         self._check_and_run_post_update_scripts()
 
+        # Set up desktop notifier using event loop.
+        self._dn: MaestralDesktopNotifier | None = None
+        if self._loop:
+            self._dn = MaestralDesktopNotifier(self._config_name, self._loop)
+
         # Set up sync infrastructure.
         self.client = DropboxClient(self.config_name, self.cred_storage)
-        self.sync = SyncEngine(self.client)
-        self.manager = SyncManager(self.sync)
-
-        # Schedule background tasks.
-        self._loop = asyncio.get_event_loop_policy().get_event_loop()
-        self._tasks: set[asyncio.Task[Any]] = set()
-        self._pool = ThreadPoolExecutor(
-            thread_name_prefix="maestral-thread-pool",
-            max_workers=2,
-        )
-
-        self._schedule_task(self._periodic_refresh_profile())
-        self._schedule_task(self._periodic_reindexing())
+        self.sync = SyncEngine(self.client, self._dn)
+        self.manager = SyncManager(self.sync, self._dn)
 
         # Create a future which will return once `shutdown_daemon` is called.
         # This can be used by an event loop to wait until maestral has been stopped.
-        self.shutdown_complete = self._loop.create_future()
+        if shutdown_future and not shutdown_future.get_loop() is self._loop:
+            raise RuntimeError("'shutdown_future' must use the passed event loop.")
+
+        self.shutdown_future = shutdown_future
 
     def _setup_logging_external(self) -> None:
         """
@@ -426,22 +434,30 @@ class Maestral:
     def notification_snooze(self) -> float:
         """Snooze time for desktop notifications in minutes. Defaults to 0 if
         notifications are not snoozed."""
-        return self.sync.desktop_notifier.snoozed
+        if not self._dn:
+            raise RuntimeError("Desktop notifications require an event loop")
+        return self._dn.snoozed
 
     @notification_snooze.setter
     def notification_snooze(self, minutes: float) -> None:
         """Setter: notification_snooze."""
-        self.sync.desktop_notifier.snoozed = minutes
+        if not self._dn:
+            raise RuntimeError("Desktop notifications require an event loop")
+        self._dn.snoozed = minutes
 
     @property
     def notification_level(self) -> int:
         """Level for desktop notifications. See :mod:`notify` for level definitions."""
-        return self.sync.desktop_notifier.notify_level
+        if not self._dn:
+            raise RuntimeError("Desktop notifications require an event loop")
+        return self._dn.notify_level
 
     @notification_level.setter
     def notification_level(self, level: int) -> None:
         """Setter: notification_level."""
-        self.sync.desktop_notifier.notify_level = level
+        if not self._dn:
+            raise RuntimeError("Desktop notifications require an event loop")
+        self._dn.notify_level = level
 
     # ==== State information  ==========================================================
 
@@ -1411,19 +1427,12 @@ class Maestral:
 
     def shutdown_daemon(self) -> None:
         """
-        Stop syncing and clean up our asyncio tasks. Notifies the :mod:`daemon` module
-        to shut down the event loop and exit the running process if Maestral was started
-        as a daemon.
+        Stop syncing and notify anyone monitoring ``shutdown_future`` that we are done.
         """
         self.stop_sync()
 
-        for task in self._tasks:
-            task.cancel()
-
-        self._pool.shutdown()
-
-        if self._loop.is_running():
-            self._loop.call_soon_threadsafe(self.shutdown_complete.set_result, True)
+        if self.shutdown_future and self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self.shutdown_future.set_result, True)
 
     # ==== Verifiers ===================================================================
 
@@ -1514,47 +1523,6 @@ class Maestral:
         db.close()
 
     # ==== Periodic async jobs =========================================================
-
-    def _schedule_task(self, coro: Awaitable[Any]) -> None:
-        """Schedules a task in our asyncio loop."""
-        task = asyncio.ensure_future(coro, loop=self._loop)
-        self._tasks.add(task)
-
-    async def _periodic_refresh_profile(self) -> None:
-        """Periodically refresh some infos."""
-        await asyncio.sleep(60 * 5)
-
-        while True:
-            if self.cred_storage.loaded:
-                # Only run if we have loaded the access token, we don't
-                # want to trigger any keyring access from here.
-                try:
-                    await self._loop.run_in_executor(self._pool, self.get_profile_pic)
-                    await self._loop.run_in_executor(self._pool, self.get_account_info)
-                except (ConnectionError, MaestralApiError, NotLinkedError):
-                    await sleep_rand(60 * 10)
-                else:
-                    await sleep_rand(60 * 45)
-
-    async def _periodic_reindexing(self) -> None:
-        """
-        Trigger periodic reindexing, determined by the 'reindex_interval' setting. Don't
-        reindex if we are running on battery power.
-        """
-        while True:
-
-            if self.manager.running.is_set():
-                elapsed = time.time() - self.sync.last_reindex
-                ac_state = get_ac_state()
-
-                reindexing_due = elapsed > self.manager.reindex_interval
-                is_idle = self.manager.idle_time > 20 * 60
-                has_ac_power = ac_state in (ACState.Connected, ACState.Undetermined)
-
-                if reindexing_due and is_idle and has_ac_power:
-                    self.manager.rebuild_index()
-
-            await sleep_rand(60 * 5)
 
     def __repr__(self) -> str:
         email = self._state.get("account", "email")

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -190,7 +190,6 @@ class SyncManager:
         Returns the idle time in seconds since the last file change or since startup if
         there haven't been any changes in our current session.
         """
-
         now = time.time()
         time_since_startup = now - self._startup_time
         time_since_last_sync = now - self.sync.last_change

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -44,9 +44,11 @@ from .exceptions import (
 )
 from .sync import SyncEngine
 from .logging import scoped_logger
+from .notify import MaestralDesktopNotifier
 from .utils import removeprefix
 from .utils.integration import check_connection, get_inotify_limits
 from .utils.path import move, delete, is_equal_or_child, is_child, normalize
+from .utils.integration import get_ac_state, ACState
 
 
 __all__ = ["SyncManager"]
@@ -115,13 +117,18 @@ class SyncManager:
     """Class to manage sync threads
 
     :param sync: The SyncEngine.
+    :param desktop_notifier: Used to send desktop notifications for management-level
+        events such as joining or leaving a team or fatal errors.
     """
 
     download_queue: PersistentQueue[str]
     """Queue of remote paths which have been newly included in syncing."""
 
-    def __init__(self, sync: SyncEngine):
+    def __init__(
+        self, sync: SyncEngine, desktop_notifier: MaestralDesktopNotifier | None = None
+    ) -> None:
         self.sync = sync
+        self.desktop_notifier = desktop_notifier
         self._conf = MaestralConfig(self.sync.config_name)
         self._state = MaestralState(self.sync.config_name)
         self._logger = scoped_logger(__name__, self.sync.config_name)
@@ -261,9 +268,10 @@ class SyncManager:
                     self.local_observer_thread = self._create_observer()
                 except MaestralApiError as exc:
                     self._logger.error(exc.title, exc_info=True)
-                    self.sync.desktop_notifier.notify(
-                        exc.title, exc.message, level=notify.ERROR
-                    )
+                    if self.desktop_notifier:
+                        self.desktop_notifier.notify(
+                            exc.title, exc.message, level=notify.ERROR
+                        )
                     return
 
         self.running.set()
@@ -391,6 +399,20 @@ class SyncManager:
         if was_running:
             self.start()
 
+    def _should_rebuild_index(self) -> bool:
+        """
+        Check if reindexing is due and can be performed now. This is determined by the
+        'reindex_interval' setting. Don't reindex if we are running on battery power.
+        """
+        elapsed = time.time() - self.sync.last_reindex
+        ac_state = get_ac_state()
+
+        reindexing_due = elapsed > self.reindex_interval
+        is_idle = self.idle_time > 20 * 60
+        has_ac_power = ac_state in (ACState.Connected, ACState.Undetermined)
+
+        return reindexing_due and is_idle and has_ac_power
+
     # ---- path root management --------------------------------------------------------
 
     def check_and_update_path_root(self) -> bool:
@@ -475,10 +497,11 @@ class SyncManager:
             if new_root_type == "team" and current_root_type == "user":
                 # User joined a team.
                 self._logger.info("User joined %s. Resyncing user files.", team_name)
-                self.sync.desktop_notifier.notify(
-                    f"Joined {team_name}",
-                    "Migrating user files and downloading team folders",
-                )
+                if self.desktop_notifier:
+                    self.desktop_notifier.notify(
+                        f"Joined {team_name}",
+                        "Migrating user files and downloading team folders",
+                    )
 
                 # Migrate user folder to "self.sync.dropbox_path/home_path". We do this
                 # by creating a temporary folder and renaming it after moving all
@@ -507,10 +530,11 @@ class SyncManager:
             elif new_root_type == "user" and current_root_type == "team":
                 # User left a team.
                 self._logger.info("User left team. Updating folder layout.")
-                self.sync.desktop_notifier.notify(
-                    "Left Dropbox Team",
-                    "Migrating user files and removing team folders",
-                )
+                if self.desktop_notifier:
+                    self.desktop_notifier.notify(
+                        "Left Dropbox Team",
+                        "Migrating user files and removing team folders",
+                    )
 
                 # Remove all team folders.
                 for entry in local_dropbox_dirlist:
@@ -555,9 +579,10 @@ class SyncManager:
             elif new_root_type == "team" and current_root_type == "team":
                 # User switched between different teams.
                 self._logger.info("User switched teams. Updating team folders.")
-                self.sync.desktop_notifier.notify(
-                    f"Switched teams to {team_name}", "Updating team folders"
-                )
+                if self.desktop_notifier:
+                    self.desktop_notifier.notify(
+                        f"Switched teams to {team_name}", "Updating team folders"
+                    )
 
                 # Remove all team folders, leave user folder alone.
                 for entry in local_dropbox_dirlist:
@@ -631,6 +656,10 @@ class SyncManager:
                     # changes in case of a changed root path.
                     if self.check_and_update_path_root():
                         return
+
+                    # Check for and perform reindexing.
+                    if self._should_rebuild_index():
+                        self.rebuild_index()
 
                     if not running.is_set():
                         return
@@ -803,7 +832,8 @@ class SyncManager:
             title = getattr(err, "title", "Unexpected error")
             message = getattr(err, "message", "Please restart to continue syncing")
             self._logger.error(title, exc_info=True)
-            self.sync.desktop_notifier.notify(title, message, level=notify.ERROR)
+            if self.desktop_notifier:
+                self.desktop_notifier.notify(title, message, level=notify.ERROR)
             self.stop()
 
     def __del__(self) -> None:

--- a/src/maestral/notify.py
+++ b/src/maestral/notify.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import time
 import asyncio
+from asyncio import AbstractEventLoop
 from typing import Callable, Any, cast
 
 # external imports
@@ -98,16 +99,13 @@ class MaestralDesktopNotifier:
 
     :param config_name: Config name. This is used to access notification settings for
         the daemon.
+    :param event_loop: Event loop to use to send notifications and receive callbacks.
     """
 
-    def __init__(self, config_name: str) -> None:
+    def __init__(self, config_name: str, event_loop: AbstractEventLoop) -> None:
         self._conf = MaestralConfig(config_name)
         self._snooze = 0.0
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
+        self._loop = event_loop
 
     @property
     def notify_level(self) -> int:
@@ -150,22 +148,25 @@ class MaestralDesktopNotifier:
         :param actions: A dictionary with button names and callbacks for the
             notification.
         """
-        snoozed = self.snoozed and level <= FILECHANGE
+        if level < self.notify_level:
+            return
 
-        if level >= self.notify_level and not snoozed:
-            urgency = Urgency.Critical if level >= ERROR else Urgency.Normal
+        if self.snoozed and level <= FILECHANGE:
+            return
 
-            if actions:
-                buttons = [Button(name, handler) for name, handler in actions.items()]
-            else:
-                buttons = []
+        urgency = Urgency.Critical if level >= ERROR else Urgency.Normal
 
-            coro = _desktop_notifier.send(
-                title=title,
-                message=message,
-                urgency=urgency,
-                on_clicked=on_click,
-                buttons=buttons,
-            )
+        if actions:
+            buttons = [Button(name, handler) for name, handler in actions.items()]
+        else:
+            buttons = []
 
-            asyncio.run_coroutine_threadsafe(coro, self._loop)
+        coro = _desktop_notifier.send(
+            title=title,
+            message=message,
+            urgency=urgency,
+            on_clicked=on_click,
+            buttons=buttons,
+        )
+
+        asyncio.run_coroutine_threadsafe(coro, self._loop)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -631,10 +631,12 @@ class SyncEngine:
         """The time stamp of the last file change or 0.0 if there are no file changes in
         our history."""
         with self._database_access():
-            res = self._db.execute("SELECT MAX(last_sync) FROM 'index'").fetchone()
-            if res:
-                return res["MAX(sync_time)"] or 0.0
-            else:
+            row = self._db.execute("SELECT MAX(last_sync) FROM 'index'").fetchone()
+            if not row:
+                return 0.0
+            try:
+                return row[0] or 0.0
+            except IndexError:
                 return 0.0
 
     @property


### PR DESCRIPTION
This makes it more explicit which event-loop is being used instead of relying on other components setting the event loop policy.

This CL also removes a two async tasks:

1. Periodic fetching of the profile picture. API clients must now do this themselves when they need it.
2. Period reindexing. This is now triggered by the download worker.