### PR TITLE
Allow setting bandwidth limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Changed:
 
+* Allow limiting the upload and download bandwidth used for syncing, either by setting
+  the config file values or by using the CLI `maestral bandwidth-limit up|down`.
 * Speed up querying the sync status of folders.
 * Added support for Python 3.12.
 

--- a/src/maestral/cli/cli_main.py
+++ b/src/maestral/cli/cli_main.py
@@ -7,7 +7,7 @@ import click
 from .core import OrderedGroup
 from .cli_core import start, stop, gui, pause, resume, auth, sharelink
 from .cli_info import status, filestatus, activity, history, ls, config_files
-from .cli_settings import autostart, excluded, notify
+from .cli_settings import autostart, excluded, notify, bandwidth_limit
 from .cli_maintenance import (
     move_dir,
     rebuild_index,
@@ -48,6 +48,7 @@ main.add_command(config_files, section="Information")
 main.add_command(autostart, section="Settings")
 main.add_command(excluded, section="Settings")
 main.add_command(notify, section="Settings")
+main.add_command(bandwidth_limit, section="Settings")
 
 main.add_command(move_dir, section="Maintenance")
 main.add_command(rebuild_index, section="Maintenance")

--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -142,3 +142,43 @@ def notify_snooze(m: Maestral, minutes: int) -> None:
         ok(f"Notifications snoozed for {minutes} min. Set snooze to 0 to reset.")
     else:
         ok("Notifications enabled.")
+
+
+@click.group(help="View and manage bandwidth limits.")
+def bandwidth_limit() -> None:
+    pass
+
+
+@bandwidth_limit.command(name="up", help="Bandwidth limit for uploads (0 = unlimited).")
+@click.argument(
+    "mb_per_second",
+    required=False,
+    type=click.FLOAT,
+)
+@inject_proxy(fallback=True, existing_config=True)
+def bandwidth_limit_up(m: Maestral, mb_per_second: float | None) -> None:
+    if mb_per_second is not None:
+        m.bandwidth_limit_up = mb_per_second * 10**6
+        speed_str = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
+        ok(f"Upload bandwidth limit set to {speed_str}.")
+    else:
+        mb_per_second = m.bandwidth_limit_up / 10 ** 6
+        speed_fmt = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
+        echo(f"{mb_per_second} MB/sec" if speed_fmt > 0 else "unlimited")
+
+
+@bandwidth_limit.command(name="down", help="Bandwidth limit for downloads (0 = unlimited).")
+@click.argument(
+    "mb_per_second",
+    required=False,
+    type=click.FLOAT,
+)
+@inject_proxy(fallback=True, existing_config=True)
+def bandwidth_limit_down(m: Maestral, mb_per_second: float | None) -> None:
+    if mb_per_second is not None:
+        m.bandwidth_limit_down = mb_per_second * 10**6
+        speed_fmt = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
+        ok(f"Download bandwidth limit set to {speed_fmt}.")
+    else:
+        mb_per_second = m.bandwidth_limit_down / 10**6
+        echo(f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited")

--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -144,12 +144,14 @@ def notify_snooze(m: Maestral, minutes: int) -> None:
         ok("Notifications enabled.")
 
 
-@click.group(help="View and manage bandwidth limits.")
+@click.group(help="View and manage bandwidth limits. Changes take effect immediately.")
 def bandwidth_limit() -> None:
     pass
 
 
-@bandwidth_limit.command(name="up", help="Bandwidth limit for uploads (0 = unlimited).")
+@bandwidth_limit.command(
+    name="up", help="Get / set bandwidth limit for uploads in MB/sec (0 = unlimited)."
+)
 @click.argument(
     "mb_per_second",
     required=False,
@@ -162,12 +164,15 @@ def bandwidth_limit_up(m: Maestral, mb_per_second: float | None) -> None:
         speed_str = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
         ok(f"Upload bandwidth limit set to {speed_str}.")
     else:
-        mb_per_second = m.bandwidth_limit_up / 10 ** 6
+        mb_per_second = m.bandwidth_limit_up / 10**6
         speed_fmt = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
         echo(f"{mb_per_second} MB/sec" if speed_fmt > 0 else "unlimited")
 
 
-@bandwidth_limit.command(name="down", help="Bandwidth limit for downloads (0 = unlimited).")
+@bandwidth_limit.command(
+    name="down",
+    help="Get / set bandwidth limit for downloads in MB/sec (0 = unlimited).",
+)
 @click.argument(
     "mb_per_second",
     required=False,

--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -165,8 +165,7 @@ def bandwidth_limit_up(m: Maestral, mb_per_second: float | None) -> None:
         ok(f"Upload bandwidth limit set to {speed_str}.")
     else:
         mb_per_second = m.bandwidth_limit_up / 10**6
-        speed_fmt = f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited"
-        echo(f"{mb_per_second} MB/sec" if speed_fmt > 0 else "unlimited")
+        echo(f"{mb_per_second} MB/sec" if mb_per_second > 0 else "unlimited")
 
 
 @bandwidth_limit.command(

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -289,17 +289,15 @@ class DropboxClient:
                     time.sleep(wait_time)
 
     def _throttled_upload_iter(self, data: bytes) -> Iterator[bytes] | bytes:
-        if self.bandwidth_limit_down == 0:
-            return data
-        else:
-            pos = 0
-            while pos < len(data):
-                tick = time.monotonic()
-                yield data[pos : pos + self.upload_chunk_size]
-                tock = time.monotonic()
+        pos = 0
+        while pos < len(data):
+            tick = time.monotonic()
+            yield data[pos : pos + self.upload_chunk_size]
+            tock = time.monotonic()
 
-                pos += self.upload_chunk_size
+            pos += self.upload_chunk_size
 
+            if self.bandwidth_limit_up > 0:
                 speed_per_upload = self.bandwidth_limit_up / self._num_uploads
                 target_tock = tick + self.upload_chunk_size / speed_per_upload
 

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -30,6 +30,8 @@ DEFAULTS_CONFIG: _DefaultsType = {
         "notification_level": 15,  # desktop notification level, default: FILECHANGE
         "log_level": 20,  # log level for journal and file, default: INFO
         "update_notification_interval": 60 * 60 * 24 * 7,  # default: weekly
+        "bandwidth_limit_up": 0.0,  # upload limit in bytes / sec (0 = unlimited)
+        "bandwidth_limit_down": 0.0,  # download limit in bytes / sec (0 = unlimited)
     },
     "sync": {
         "path": "",  # dropbox folder location

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -180,7 +180,12 @@ class Maestral:
             self._dn = MaestralDesktopNotifier(self._config_name, self._loop)
 
         # Set up sync infrastructure.
-        self.client = DropboxClient(self.config_name, self.cred_storage)
+        self.client = DropboxClient(
+            self.config_name,
+            self.cred_storage,
+            bandwidth_limit_up=self.bandwidth_limit_up,
+            bandwidth_limit_down=self.bandwidth_limit_down,
+        )
         self.sync = SyncEngine(self.client, self._dn)
         self.manager = SyncManager(self.sync, self._dn)
 
@@ -458,6 +463,28 @@ class Maestral:
         if not self._dn:
             raise RuntimeError("Desktop notifications require an event loop")
         self._dn.notify_level = level
+
+    @property
+    def bandwidth_limit_down(self) -> float:
+        """Maximum download bandwidth to use in bytes per second."""
+        return self._conf.get("app", "bandwidth_limit_down")
+
+    @bandwidth_limit_down.setter
+    def bandwidth_limit_down(self, value: float) -> None:
+        """Setter: log_level."""
+        self.client.bandwidth_limit_down = value
+        self._conf.set("app", "bandwidth_limit_down", value)
+
+    @property
+    def bandwidth_limit_up(self) -> float:
+        """Maximum download bandwidth to use in bytes per second."""
+        return self._conf.get("app", "bandwidth_limit_up")
+
+    @bandwidth_limit_up.setter
+    def bandwidth_limit_up(self, value: float) -> None:
+        """Setter: log_level."""
+        self.client.bandwidth_limit_down = value
+        self._conf.set("app", "bandwidth_limit_up", value)
 
     # ==== State information  ==========================================================
 

--- a/tests/linked/unit/test_client.py
+++ b/tests/linked/unit/test_client.py
@@ -56,9 +56,9 @@ def test_upload(client: DropboxClient) -> None:
 
     file = resources + "/file.txt"
     file_size = os.path.getsize(file)
-    chunk_size = file_size * 2
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size * 2
 
-    md = client.upload(file, "/file.txt", chunk_size=chunk_size)
+    md = client.upload(file, "/file.txt")
     assert md.content_hash == content_hash(file)[0]
 
 
@@ -67,9 +67,9 @@ def test_upload_session(client: DropboxClient) -> None:
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
-    md = client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+    md = client.upload(large_file, "/large-file.pdf")
 
     assert md.content_hash == content_hash(large_file)[0]
 
@@ -94,13 +94,13 @@ def test_upload_session_start_hash_mismatch(client: DropboxClient, monkeypatch) 
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(0, 4)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
     with pytest.raises(DataCorruptionError):
-        client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+        client.upload(large_file, "/large-file.pdf")
 
     assert not client.get_metadata("/large-file.pdf")
 
@@ -110,12 +110,12 @@ def test_upload_session_start_retry(client: DropboxClient, monkeypatch) -> None:
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(0, 3)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
-    md = client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+    md = client.upload(large_file, "/large-file.pdf")
 
     assert md.content_hash == content_hash(large_file)[0]
 
@@ -128,13 +128,13 @@ def test_upload_session_append_hash_mismatch(
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(1, 5)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
     with pytest.raises(DataCorruptionError):
-        client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+        client.upload(large_file, "/large-file.pdf")
 
     assert not client.get_metadata("/large-file.pdf")
 
@@ -147,12 +147,12 @@ def test_upload_session_append_hash_mismatch_retry(
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(1, 4)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
-    md = client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+    md = client.upload(large_file, "/large-file.pdf")
     assert md.content_hash == content_hash(large_file)[0]
 
 
@@ -164,13 +164,13 @@ def test_upload_session_finish_hash_mismatch(
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(9, 13)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
     with pytest.raises(DataCorruptionError):
-        client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+        client.upload(large_file, "/large-file.pdf")
 
     assert not client.get_metadata("/large-file.pdf")
 
@@ -182,12 +182,12 @@ def test_upload_session_finish_hash_mismatch_retry(
 
     large_file = resources + "/large-file.pdf"
     file_size = os.path.getsize(large_file)
-    chunk_size = file_size // 10
+    client.UPLOAD_REQUEST_CHUNK_SIZE = file_size // 10
 
     hasher = failing_content_hasher(9, 12)
     monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
 
-    md = client.upload(large_file, "/large-file.pdf", chunk_size=chunk_size)
+    md = client.upload(large_file, "/large-file.pdf")
 
     assert md.content_hash == content_hash(large_file)[0]
 


### PR DESCRIPTION
The initial version is CLI / config file only. Bandwidth limits apply separately for uploads and downloads across all parallel transfers. Bandwidth is limited by delaying transmission of chunks at a 2 kB size, i.e., bandwidth limits < 2 kB / sec will result in spiky network usage instead of smooth limiting.

Fixes #438.