### PR TITLE
Remove support for long-lived access tokens in keyring module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -U .[test]
 
-      - name: Get short-lived Dropbox token
+      - name: Get short-lived Oauth2 access token
         # We generate a short-lived auth token which is passed to the test runner as
-        # an environment variable. At no point does the test code, potentially from a
-        # malicious PR, get access to a long-lived token.
+        # an environment variable. At no point does the test code, potentially from an
+        # untrusted 3rd party, get access to a long-lived token.
         run: |
           auth_result=$(curl https://api.dropbox.com/oauth2/token \
               -d grant_type=refresh_token \
@@ -109,6 +109,11 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -v --cov=maestral --cov-report=xml tests/linked/unit
+
+      - name: Revoke access token
+        run: |
+          curl -X POST https://api.dropboxapi.com/2/auth/token/revoke \
+              --header "Authorization: Bearer $DROPBOX_ACCESS_TOKEN"
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   with the developer name instead of the app name in macOS Ventura's System Settings.
 * Fixes an issue which would prevent periodic reindexing.
 
+#### Removed:
+
+* Removed support for access token authentication. Users who linked Maestral to their
+  Dropbox account before September 2020 will be asked to reauthenticate so that Maestral
+  can retrieve a refresh token instead.
+
 ## v1.6.5
 
 #### Fixed:

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -387,7 +387,7 @@ class DropboxClient:
 
         :raises KeyringAccessError: if keyring access fails.
         """
-        return self._cred_storage.token is not None
+        return self._cred_storage.token is not None or self._dbx is not None
 
     def get_auth_url(self) -> str:
         """

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -23,8 +23,9 @@ CONFIG_DIR_NAME = "maestral"
 
 DEFAULTS_CONFIG: _DefaultsType = {
     "auth": {
-        "account_id": "",  # dropbox account id, must match the saved account key
+        "account_id": "",  # dropbox account id
         "keyring": "automatic",  # keychain backend to use for credential storage
+        "token_access_type": "offline",
     },
     "app": {
         "notification_level": 15,  # desktop notification level, default: FILECHANGE
@@ -56,9 +57,6 @@ DEFAULTS_STATE: _DefaultsType = {
         "path_root_nsid": "",  # the namespace id of the root path
         "home_path": "",  # the path of the user folder if not the root path
     },
-    "auth": {
-        "token_access_type": "",  # will be updated on completed OAuth
-    },
     "app": {  # app state
         "updated_scripts_completed": __version__,
         "update_notification_last": 0.0,
@@ -89,7 +87,7 @@ for section_name, section_values in DEFAULTS_CONFIG.items():
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0 to 4.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = Version("18.0")
+CONF_VERSION = Version("19.0")
 
 
 # =============================================================================

--- a/tests/linked/integration/conftest.py
+++ b/tests/linked/integration/conftest.py
@@ -9,7 +9,7 @@ from maestral.main import Maestral
 from maestral.config import remove_configuration
 from maestral.utils.path import generate_cc_name, delete
 from maestral.utils.appdirs import get_home_dir
-from maestral.exceptions import NotFoundError
+from maestral.exceptions import NotFoundError, DropboxAuthError
 
 from ..lock import DropboxTestLock
 
@@ -59,7 +59,14 @@ def m(pytestconfig):
     # link with the given token
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
-    m.link(refresh_token=refresh_token, access_token=access_token)
+    res = m.link(refresh_token=refresh_token, access_token=access_token)
+
+    if res == 1:
+        raise DropboxAuthError("Invalid token")
+    elif res == 2:
+        raise ConnectionError("Could not connect to Dropbox")
+    elif res > 0:
+        raise RuntimeError(f"[error {res}] linking failed")
 
     # set local Dropbox directory
     home = get_home_dir()

--- a/tests/linked/unit/conftest.py
+++ b/tests/linked/unit/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from maestral.client import DropboxClient
 from maestral.config import remove_configuration
 from maestral.keyring import CredentialStorage
-from maestral.exceptions import NotFoundError
+from maestral.exceptions import NotFoundError, DropboxAuthError
 
 from ..lock import DropboxTestLock
 
@@ -28,7 +28,14 @@ def client():
     # link with the given token
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
-    c.link(refresh_token=refresh_token, access_token=access_token)
+    res = c.link(refresh_token=refresh_token, access_token=access_token)
+
+    if res == 1:
+        raise DropboxAuthError("Invalid token")
+    elif res == 2:
+        raise ConnectionError("Could not connect to Dropbox")
+    elif res > 0:
+        raise RuntimeError(f"[error {res}] linking failed")
 
     # acquire test lock
     lock = DropboxTestLock(c)

--- a/tests/offline/test_manager.py
+++ b/tests/offline/test_manager.py
@@ -7,12 +7,11 @@ from maestral.core import FullAccount, TeamRootInfo, UserRootInfo, AccountType
 from maestral.exceptions import NoDropboxDirError
 from maestral.utils.appdirs import get_home_dir
 from maestral.utils.path import generate_cc_name, delete
-from maestral.keyring import TokenType
 
 
 def fake_linked(m: Maestral, account_info: FullAccount) -> None:
     m.client.get_account_info = mock.Mock(return_value=account_info)  # type: ignore
-    m.cred_storage.save_creds("account_id", "1234", TokenType.Offline)
+    m.cred_storage.save_creds("account_id", "1234")
 
 
 def verify_folder_structure(root: str, structure: dict) -> None:


### PR DESCRIPTION
Remove support for deprecated long-lived access tokens from the keyring module. Dropbox has now fully switched to long-lived refresh tokens which can be used to fetch short-lived access tokens.

We keep the linking infrastructure in place for access tokens because those are useful for testing. However, we no longer expect them to be long-lived and therefore don't store them in the keyring anymore.
