### PR TITLE
Allow configuring max number of parallel transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow limiting the upload and download bandwidth used for syncing, either by setting
   the config file values, by using the CLI `maestral bandwidth-limit up|down`, or
   through the Settings pane in the GUI.
+* Add config file items for the maximum number of parallel uploads and downloads.
 * Speed up querying the sync status of folders.
 * Added support for Python 3.12.
 

--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -33,6 +33,8 @@ DEFAULTS_CONFIG: _DefaultsType = {
         "update_notification_interval": 60 * 60 * 24 * 7,  # default: weekly
         "bandwidth_limit_up": 0.0,  # upload limit in bytes / sec (0 = unlimited)
         "bandwidth_limit_down": 0.0,  # download limit in bytes / sec (0 = unlimited)
+        "max_parallel_uploads": 6,  # max number of parallel downloads
+        "max_parallel_downloads": 6,  # max number of parallel downloads
     },
     "sync": {
         "path": "",  # dropbox folder location


### PR DESCRIPTION
Add new config file values `max_parallel_uploads` and `max_parallel_downloads` to control the maximum number of parallel file transfers. The default values is 6.

Config changes will only take effect after restarting Maestral.

Fixes #831.