### PR TITLE
Abort upload on local file changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-## v1.7.2
+## v1.7.2.dev
 
 #### Changed:
 
 * Improved support for systems where some file system calls don't accept a
  `follow_symlinks = False` option, notably `chmod` and `utime`.
+* Abort uploads if the file is modified between the upload of individual chunks. This
+  saves some bandwidth and prevents us from ever committing an inconsistent file to
+  Dropbox's version history.
 
 ## v1.7.1
 

--- a/src/maestral/client.py
+++ b/src/maestral/client.py
@@ -873,6 +873,7 @@ class DropboxClient:
                             dbx_write_mode,
                             autorename,
                             sync_event,
+                            stat,
                         )
                     else:
                         # Upload in chunks.
@@ -910,9 +911,12 @@ class DropboxClient:
         mode: files.WriteMode,
         autorename: bool,
         sync_event: SyncEvent | None,
+        old_stat: os.stat_result,
     ) -> files.FileMetadata:
         data = f.read()
         stat = os.stat(f.fileno())
+        if check_for_changes(os.stat(f.fileno()), old_stat):
+            raise DataChangedError("File was modified during read")
 
         with convert_api_errors(dbx_path=dbx_path):
             md = self.dbx.files_upload(

--- a/src/maestral/exceptions.py
+++ b/src/maestral/exceptions.py
@@ -63,6 +63,10 @@ class DataCorruptionError(SyncError):
     """Raised when data is corrupted in transit during upload or download."""
 
 
+class DataChangedError(SyncError):
+    """Raised when file changes during upload."""
+
+
 class InsufficientPermissionsError(SyncError):
     """Raised when accessing a file or folder fails due to insufficient permissions,
     both locally and on Dropbox servers."""

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -88,6 +88,7 @@ from .exceptions import (
     FolderConflictError,
     IsAFolderError,
     NotAFolderError,
+    DataChangedError,
     InvalidDbidError,
     DatabaseError,
 )
@@ -2418,6 +2419,12 @@ class SyncEngine:
                 'Could not upload "%s": the file does not exist', event.local_path
             )
             return None
+        except DataChangedError:
+            self._logger.debug(
+                'Could not upload "%s": the file was modified during upload',
+                event.local_path,
+            )
+            return None
 
         if not self._handle_upload_conflict(md_new, event):
             self._logger.debug('Created "%s" on Dropbox', event.dbx_path)
@@ -2534,6 +2541,12 @@ class SyncEngine:
             # refers to a file instead of a folder.
             self._logger.debug(
                 'Could not upload "%s": the item does not exist', event.dbx_path
+            )
+            return None
+        except DataChangedError:
+            self._logger.debug(
+                'Could not upload "%s": the file was modified during upload',
+                event.local_path,
             )
             return None
 


### PR DESCRIPTION
If a local file is changed while being uploaded, we currently continue with the upload and proceeded to resync the file after it has completed. This has a number of disadvantages:

1. For large files, it may use unnecessary bandwidth.
2. It may result in inconsistent versions of a file being uploaded, for example if changes are made to both the byte ranges already uploaded and those pending. Even though we will eventually upload a consistent version of the file, once the user stopped editing for the duration of a single upload, this still means that a inconsistent version may be saved in Dropbox's version history.

This PR checks the file consistently for between the upload of individual chunks, by calling stat on the open file descriptor, and aborts the upload if changes are detected.

Fixes #848.