### PR TITLE
Improved conflict handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Abort uploads if the file is modified between the upload of individual chunks. This
   saves some bandwidth and prevents us from ever committing an inconsistent file to
   Dropbox's version history.
+* Show desktop notifications when a conflicting copy is created both during upload and
+  download sync. Unlike regular notifications, those notifications are shown for each
+  conflicting copy instead of giving a summary count.
+* Append the username and date to the file name of a conflicting copy, for example
+  `myfile (Sam's conflicting copy 2022-08-30).pdf`.
 
 ## v1.7.1
 

--- a/src/maestral/models.py
+++ b/src/maestral/models.py
@@ -61,6 +61,7 @@ class SyncStatus(enum.Enum):
     Failed = "failed"
     Skipped = "skipped"
     Aborted = "aborted"
+    Conflict = "conflict"
 
 
 class ItemType(enum.Enum):

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -1788,6 +1788,9 @@ class SyncEngine:
             changes, cursor = self.list_local_changes()
             self.apply_local_changes(changes)
 
+            conflicts = [e for e in changes if e.status is SyncStatus.Conflict]
+            self.notify_user(conflicts)
+
             self.local_cursor = cursor
 
             # Free memory early to prevent fragmentation.

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -28,6 +28,7 @@ from typing import (
     Iterator,
     Iterable,
     Collection,
+    Sequence,
     Callable,
     Type,
     TypeVar,
@@ -671,7 +672,7 @@ class SyncEngine:
             self._conf.set("sync", "excluded_items", clean_list)
 
     @staticmethod
-    def clean_excluded_items_list(folder_list: list[str]) -> list[str]:
+    def clean_excluded_items_list(folder_list: Collection[str]) -> list[str]:
         """
         Removes all duplicates and children of excluded items from the excluded items
         list. Normalises all paths to lower case.
@@ -1610,7 +1611,7 @@ class SyncEngine:
         return SyncEvent.from_file_system_event(fs_event, self)
 
     def _sync_events_from_fs_events(
-        self, fs_events: list[FileSystemEvent]
+        self, fs_events: Collection[FileSystemEvent]
     ) -> list[SyncEvent]:
         """Convert local file system events to sync events. This is done in a thread
         pool to parallelize content hashing."""
@@ -1827,7 +1828,9 @@ class SyncEngine:
 
         return sync_events, local_cursor
 
-    def apply_local_changes(self, sync_events: list[SyncEvent]) -> list[SyncEvent]:
+    def apply_local_changes(
+        self, sync_events: Collection[SyncEvent]
+    ) -> list[SyncEvent]:
         """
         Applies locally detected changes to the remote Dropbox. Changes which should be
         ignored (mignore or always ignored files) are skipped.
@@ -1903,7 +1906,7 @@ class SyncEngine:
         return results
 
     def _clean_local_events(
-        self, events: list[FileSystemEvent]
+        self, events: Collection[FileSystemEvent]
     ) -> list[FileSystemEvent]:
         """
         Takes local file events and cleans them up as follows:
@@ -2882,7 +2885,9 @@ class SyncEngine:
 
             yield sync_events, changes.cursor
 
-    def apply_remote_changes(self, sync_events: list[SyncEvent]) -> list[SyncEvent]:
+    def apply_remote_changes(
+        self, sync_events: Collection[SyncEvent]
+    ) -> list[SyncEvent]:
         """
         Applies remote changes to local folder. Call this on the result of
         :meth:`list_remote_changes`. The saved cursor is updated after a set of changes
@@ -2978,7 +2983,7 @@ class SyncEngine:
 
         return results
 
-    def notify_user(self, sync_events: list[SyncEvent]) -> None:
+    def notify_user(self, sync_events: Sequence[SyncEvent]) -> None:
         """
         Shows a desktop notification for the given file changes.
 

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -265,10 +265,11 @@ def normalized_path_exists(path: str, root: str = osp.sep) -> bool:
     return False
 
 
-def generate_cc_name(path: str, suffix: str = "conflicting copy") -> str:
+def generate_cc_name(path: str, suffix: str) -> str:
     """
     Generates a path for a conflicting copy of ``path``. The file name is created by
-    inserting the given ``suffix`` between the filename and the extension. For instance:
+    inserting the given ``suffix`` between the filename and the extension. For example,
+    for ``suffix = "conflicting copy"``:
 
         "my_file.txt" -> "my_file (conflicting copy).txt"
 
@@ -278,7 +279,7 @@ def generate_cc_name(path: str, suffix: str = "conflicting copy") -> str:
         "my_file.txt" -> "my_file (conflicting copy 1).txt"
 
     :param path: Original path name.
-    :param suffix: Suffix to use. Defaults to "conflicting copy".
+    :param suffix: Suffix to use.
     :returns: New path.
     """
     dirname, basename = osp.split(path)

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -458,8 +458,10 @@ def test_file_conflict_modified(m: Maestral) -> None:
 
     wait_for_idle(m)
 
+    cc_name = m.sync._local_cc_filename("file.txt", m.client.account_info.account_id)
+
     new_tree: DirTreeType = {
-        "file (conflicting copy).txt": "content modified conflict",
+        cc_name: "content modified conflict",
         "file.txt": "content 2",
     }
 
@@ -480,8 +482,10 @@ def test_file_conflict_created(m: Maestral) -> None:
     m.start_sync()
     wait_for_idle(m)
 
+    cc_name = m.sync._local_cc_filename("file.txt", m.client.account_info.account_id)
+
     new_tree: DirTreeType = {
-        "file (conflicting copy).txt": "content",
+        cc_name: "content",
         "file.txt": "content 2",
     }
 
@@ -530,6 +534,7 @@ def test_remote_file_replaced_by_folder_and_unsynced_local_changes(m: Maestral) 
     display_name = m.get_account_info().display_name
 
     new_tree: DirTreeType = {
+        # Conflicted copy is created remotely by Dropbox, use their naming scheme.
         f"file ({display_name}'s conflicted copy).txt": "content modified",
         "file.txt": {},
     }
@@ -595,9 +600,11 @@ def test_remote_folder_replaced_by_file_and_unsynced_local_changes(m: Maestral) 
 
     # Check for expected result:
 
+    cc_name = m.sync._local_cc_filename("folder", m.client.account_info.account_id)
+
     new_tree: DirTreeType = {
         "folder": "content",
-        "folder (conflicting copy)": {
+        cc_name: {
             "subfolder": {},
         },
     }
@@ -918,9 +925,11 @@ def test_local_and_remote_creation_with_different_content(m: Maestral) -> None:
     m.start_sync()
     wait_for_idle(m)
 
+    cc_name = m.sync._local_cc_filename("file.txt", m.client.account_info.account_id)
+
     new_tree: DirTreeType = {
         "file.txt": "content 2",
-        "file (conflicting copy).txt": "content",
+        cc_name: "content",
     }
 
     assert_no_errors(m)


### PR DESCRIPTION
* Show desktop notifications when a conflicting copy is created both during upload and download sync. Unlike regular notifications, those notifications are shown for each conflicting copy instead of giving a summary count.
* Append the user name and date to a conflicting copy file name, for example `myfile (Sam's  conflicting copy 2022-08-30).pdf`.

Fixes #861.