### PR TITLE
Always use `os.rename` for moves

### DIFF
--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -346,6 +346,8 @@ def move(
     the destination path no longer exist, this function does nothing. Any other
     exceptions are either raised or returned if ``raise_error`` is False.
 
+    Uses ``os.rename`` internally.
+
     :param src_path: Path of item to move.
     :param dest_path: Destination path. Any existing file at this path will be replaced
         by the move. Any existing **empty** folder will be replaced if the source is
@@ -366,7 +368,7 @@ def move(
             pass
 
     try:
-        shutil.move(src_path, dest_path)
+        os.rename(src_path, dest_path)
     except FileNotFoundError:
         # do nothing if source or dest path no longer exist
         pass

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -803,35 +803,39 @@ def test_unicode_decomposed(m: Maestral) -> None:
     """
     file_name = b"fo\xcc\x81lder".decode()  # decomposed ó (NFD)
     local_path = f"{m.dropbox_path}/{file_name}"
+    local_path_normalized = normalize_unicode(local_path)
 
-    os.mkdir(local_path)
+    with open(local_path, "a") as f:
+        f.write("content")
+
     wait_for_idle(m)
 
     if platform.system() == "Darwin":
         # Local file stays as is, macOS treats unicode normalisations transparently.
         assert osp.exists(local_path)
-        assert osp.samefile(local_path, normalize_unicode(local_path))
+        assert osp.samefile(local_path, local_path_normalized)
     else:
         # Rename to NFC version on Dropbox servers is mirrored locally.
         assert not osp.exists(local_path)
-        assert osp.exists(normalize_unicode(local_path))
+        assert osp.exists(local_path_normalized)
 
     assert_no_errors(m)
     assert_synced(m)
 
     # Test rename.
     target_path = local_path + "_target"
-    os.rename(normalize_unicode(local_path), target_path)
+    target_path_normalized = normalize_unicode(target_path)
+    os.rename(local_path_normalized, target_path)
     wait_for_idle(m)
 
     if platform.system() == "Darwin":
         # Local file stays as is, macOS treats unicode normalisations transparently.
         assert osp.exists(target_path)
-        assert osp.samefile(target_path, normalize_unicode(target_path))
+        assert osp.samefile(target_path, target_path_normalized)
     else:
         # Rename to NFC version on Dropbox servers is mirrored locally.
         assert not osp.exists(target_path)
-        assert osp.exists(normalize_unicode(target_path))
+        assert osp.exists(target_path_normalized)
 
     assert_no_errors(m)
     assert_synced(m)


### PR DESCRIPTION
Currently, file or folder moves use `shutil.move()` which tries to use `os.rename()` first and will fall back to `copy2()` followed by a delete of the original item.

This has two drawbacks for moves within the Dropbox folder:

1. Some callers implicitly rely on the move to be atomic, which is only guaranteed for a rename.
2. A `copy2` may fail with different and expected error messages where the original OSError from `os.rename()` would have been handled properly. See for example #878.

This PR switches to always using `os.rename` when moving items within the local Dropbox folder.