### PR TITLE
handle FileNotFoundError when determining ACState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 * Append the username and date to the file name of a conflicting copy, for example
   `myfile (Sam's conflicting copy 2022-08-30).pdf`.
 
+#### Fixed:
+
+* Fixes an issue for systems that do not provide /sys/class/power_supply.
+  Such as Synology devices.
+
 ## v1.7.1
 
 #### Fixed:

--- a/src/maestral/utils/integration.py
+++ b/src/maestral/utils/integration.py
@@ -81,7 +81,10 @@ def get_ac_state() -> ACState:
     elif platform.system() == "Linux":
         # taken from https://github.com/giampaolo/psutil
 
-        supply_entry = list(os.scandir(LINUX_POWER_SUPPLY_PATH))
+        try:
+            supply_entry = list(os.scandir(LINUX_POWER_SUPPLY_PATH))
+        except FileNotFoundError:
+            return ACState.Undetermined
 
         ac_paths = [
             Path(entry.path)


### PR DESCRIPTION
- Added error handling for systems that do not provide `/sys/class/power_supply`. Such as Synology devices.
- Fixes  #877