### PR TITLE
Index local case changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   applies to autostart entries created with `maestral autostart -Y` and not using the
   "Start on login" checkbox in the GUI.
 * The `filestatus` now is case-sensitive when checking on a case-sensitive file system.
+* Fixes an issue where renaming a file by changing the casing only would not be picked
+  up if Maestral was not running during the rename.
 
 ## v1.7.2
 

--- a/src/maestral/database/orm.py
+++ b/src/maestral/database/orm.py
@@ -262,8 +262,9 @@ class Manager(Generic[M]):
 
         for column in self.model.__columns__:
             if column.index:
-                idx_name = f"idx_{self.table_name}_{column.name}"
-                sql = f"CREATE INDEX {idx_name} ON {self.table_name} ({column.name});"
+                table_name_stripped = self.table_name.strip("'\"")
+                idx_name = f"idx_{table_name_stripped}_{column.name}"
+                sql = f"CREATE INDEX IF NOT EXISTS {idx_name} ON {self.table_name} ({column.name});"
                 self.db.executescript(sql)
 
     def clear_cache(self) -> None:

--- a/src/maestral/models.py
+++ b/src/maestral/models.py
@@ -465,7 +465,7 @@ class IndexEntry(Model):
     Corresponds to the path_lower field of Dropbox metadata.
     """
 
-    dbx_path_cased = NonNullColumn(SqlPath())
+    dbx_path_cased = NonNullColumn(SqlPath(), index=True)
     """
     Dropbox path of the item, correctly cased. Corresponds to the path_display field of
     Dropbox metadata.

--- a/src/maestral/utils/__init__.py
+++ b/src/maestral/utils/__init__.py
@@ -8,6 +8,8 @@ from typing import Iterator, TypeVar, Optional, Iterable, Tuple, Type
 
 from packaging.version import Version
 
+from .path import normalize
+
 
 _N = TypeVar("_N", float, int)
 _T = TypeVar("_T")
@@ -21,7 +23,7 @@ def natural_size(num: float, unit: str = "B", sep: bool = True) -> str:
     :param float num: Value in given unit.
     :param unit: Unit suffix.
     :param sep: Whether to separate unit and value with a space.
-    :returns: Human readable string with decimal prefixes.
+    :returns: Human-readable string with decimal prefixes.
     """
     sep_char = " " if sep else ""
 
@@ -86,7 +88,7 @@ def get_newer_version(version: str, releases: Iterable[str]) -> Optional[str]:
     return latest_release if Version(version) < Version(latest_release) else None
 
 
-def removeprefix(string: str, prefix: str) -> str:
+def removeprefix(string: str, prefix: str, case_sensitive: bool = True) -> str:
     """
     Removes the given prefix from a string. Only the first instance of the prefix is
     removed. The original string is returned if it does not start with the given prefix.
@@ -95,12 +97,20 @@ def removeprefix(string: str, prefix: str) -> str:
 
     :param string: Original string.
     :param prefix: Prefix to remove.
+    :param case_sensitive: Whether to do case-sensitive prefix removal.
     :returns: String without prefix.
     """
-    if string.startswith(prefix):
+    if case_sensitive:
+        string_lower = string
+        prefix_lower = prefix
+    else:
+        string_lower = normalize(string)
+        prefix_lower = normalize(prefix)
+
+    if string_lower.startswith(prefix_lower):
         return string[len(prefix) :]
     else:
-        return string[:]
+        raise ValueError(f'"{string}" does not start with "{prefix}"')
 
 
 def sanitize_string(string: str) -> str:

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -30,31 +30,41 @@ _AnyPath = Union[str, bytes, "os.PathLike[str]", "os.PathLike[bytes]"]
 # ==== path relationships ==============================================================
 
 
-def is_child(path: str, parent: str) -> bool:
+def is_child(path: str, parent: str, case_sensitive: bool = True) -> bool:
     """
     Checks if ``path`` semantically is inside ``parent``. Neither path needs to
     refer to an actual item on the drive. This function is case-sensitive.
 
     :param path: Item path.
     :param parent: Parent path.
+    :param case_sensitive: Whether to do case-sensitive checks.
     :returns: Whether ``path`` semantically lies inside ``parent``.
     """
+    if not case_sensitive:
+        path = normalize(path)
+        parent = normalize(parent)
+
     parent = parent.rstrip(osp.sep) + osp.sep
     path = path.rstrip(osp.sep)
 
     return path.startswith(parent)
 
 
-def is_equal_or_child(path: str, parent: str) -> bool:
+def is_equal_or_child(path: str, parent: str, case_sensitive: bool = True) -> bool:
     """
     Checks if ``path`` semantically is inside ``parent`` or equals ``parent``. Neither
     path needs to refer to an actual item on the drive. This function is case-sensitive.
 
     :param path: Item path.
     :param parent: Parent path.
+    :param case_sensitive: Whether to do case-sensitive checks.
     :returns: ``True`` if ``path`` semantically lies inside ``parent`` or
         ``path == parent``.
     """
+    if not case_sensitive:
+        path = normalize(path)
+        parent = normalize(parent)
+
     return is_child(path, parent) or path == parent
 
 

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -229,6 +229,10 @@ def to_existing_unnormalized_path(
     This is similar to :func:`get_existing_equivalent_paths` but returns only the first
     candidate or raises a :class:`FileNotFoundError` if no candidates can be found.
 
+    If the file system is not case-sensitive but case-preserving, this function
+    effectively returns the "displayed" version of a path, as used for example in file
+    managers.
+
     On macOS, we use fcntl F_GETPATH for a more efficient implementation.
 
     :param path: Original path relative to ``root``.


### PR DESCRIPTION
We currently correctly handle local case changes while Maestral is running. However, if a local item was renamed in case only while Maestral was stopped, indexing on startup won't flag the item as changed because the comparison to our index is case-insensitive. This PR fixes this issue by enforcing case-sensitive comparison.