### PR TITLE
No automatic reindexing

### DIFF
--- a/src/maestral/config/main.py
+++ b/src/maestral/config/main.py
@@ -39,7 +39,6 @@ DEFAULTS_CONFIG: _DefaultsType = {
     "sync": {
         "path": "",  # dropbox folder location
         "excluded_items": [],  # files and folders excluded from sync
-        "reindex_interval": 60 * 60 * 24 * 14,  # default: every fortnight
         "max_cpu_percent": 20.0,  # max CPU usage target (100% = all cores busy)
         "keep_history": 60 * 60 * 24 * 7,  # default: one week
         "upload": True,  # if download sync is enabled
@@ -89,7 +88,7 @@ for section_name, section_values in DEFAULTS_CONFIG.items():
 #    or if you want to *rename* options, then you need to do a MAJOR update in
 #    version, e.g. from 3.0 to 4.0
 # 3. You don't need to touch this value if you're just adding a new option
-CONF_VERSION = Version("19.0")
+CONF_VERSION = Version("20.0")
 
 
 # =============================================================================


### PR DESCRIPTION
Automatic reindexing every 14 days was introduced as measure to mitigate missing local file system events and potential bugs in acting on Dropbox events. Sync logic is sufficiently robust now that is no longer required.

Removing automatic reindexing will reduce the number of conflicted copies that are created by remote file edits before a file a reindexed.

See #916.