### PR TITLE
Fix systemd service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## v1.7.3.dev
+## v1.8.0.dev
+
+#### Fixed:
+
+* Fixes the default systemd service name when enabling autostart on Linux. This was a
+  regression in v1.7.3. Autostart entries created with `maestral autostart -Y` prior to
+  v1.7.3 will continue to work.
+
+## v1.7.3
 
 This is the last release that supports Python 3.7 which will reach end-of-life on 27
 Jun 2023. The macOS app always ships with its own Python runtime, but custom

--- a/src/maestral/autostart.py
+++ b/src/maestral/autostart.py
@@ -345,7 +345,7 @@ class AutoStart:
             )
 
             self._impl = AutoStartSystemd(
-                service_name=f"maestral-daemon@{config_name}.service",
+                service_name="maestral-daemon@maestral.service",
                 start_cmd=" ".join(start_cmd),
                 unit_dict={"Description": "Maestral daemon for the config %i"},
                 service_dict={


### PR DESCRIPTION
Fixes a regression introduced in 87758efa5f154b75668325e581a3c1273a43947e which would result in malformed systemd file names. The file name should end with `@{DEFAULT_INSTANCE_NAME}.service` instead of `@%i.service`

Fixes #930.