### PR TITLE
Fix zero byte files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fixes the default systemd service name when enabling autostart on Linux. This was a
   regression in v1.7.3. Autostart entries created with `maestral autostart -Y` prior to
   v1.7.3 will continue to work.
+* Fixes an issue where data transport errors that are retried could result in zero byte
+  files being created in the cloud if the local file size is smaller than 4 MB.
 
 ## v1.7.3
 

--- a/tests/linked/unit/test_client.py
+++ b/tests/linked/unit/test_client.py
@@ -88,6 +88,22 @@ def test_upload_hash_mismatch(client: DropboxClient, monkeypatch) -> None:
     assert not client.get_metadata("/file.txt")
 
 
+def test_upload_hash_mismatch_retry(client: DropboxClient, monkeypatch) -> None:
+    """Test that upload succeeds after 3 failed attempts when starting session."""
+
+    file = resources + "/file.txt"
+
+    hasher = failing_content_hasher(0, 3)
+    monkeypatch.setattr(maestral.client, "DropboxContentHasher", hasher)
+
+    md = client.upload(file, "/file.txt")
+
+    local_hash = content_hash(file)[0]
+
+    assert md.content_hash == local_hash
+    assert client.get_metadata("/file.txt").content_hash == local_hash
+
+
 def test_upload_session_start_hash_mismatch(client: DropboxClient, monkeypatch) -> None:
     """Test that DataCorruptionError is raised after 10 failed attempts when starting
     to upload session."""


### PR DESCRIPTION
Fixes an issue where data transport errors that are retried could result in zero byte files being created in the cloud if the local file size is smaller than 4 MB. This is caused but not rewinding to the beginning of the file before retrying the upload.

Note that chunked uploads for files > 4 MB are already handled correctly.

Fixes #925 and #926. 