### PR TITLE
Allow passing multiple paths to `excluded add` and `excluded remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.8.1.dev:
+
+#### Changed:
+
+* Allow passing multiple paths to `maestral excluded add | remove` CLI commands.
+
 ## v1.8.0
 
 #### Changed:

--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -68,38 +68,41 @@ def excluded_list(m: Maestral) -> None:
 
 @excluded.command(
     name="add",
-    help="Add a file or folder to the excluded list and re-sync.",
+    help="Add files or folders to the excluded list and re-sync.",
 )
-@click.argument("dropbox_path", type=DropboxPath())
+@click.argument("dropbox_path", type=DropboxPath(), nargs=-1)
 @inject_proxy(fallback=True, existing_config=True)
 @convert_api_errors
-def excluded_add(m: Maestral, dropbox_path: str) -> None:
-    if dropbox_path == "/":
+def excluded_add(m: Maestral, dropbox_paths: list[str]) -> None:
+    if any(p == "/" for p in dropbox_paths):
         raise CliException("Cannot exclude the root directory.")
 
-    m.exclude_item(dropbox_path)
-    ok(f"Excluded '{dropbox_path}'.")
+    m.exclude_items(*dropbox_paths)
+    for path in dropbox_paths:
+        ok(f"Excluded '{path}'")
 
 
 @excluded.command(
     name="remove",
     help="""
-Remove a file or folder from the excluded list and re-sync.
+Remove files or folders from the excluded list and re-sync.
 
 It is safe to call this method with items which have already been included, they will
 not be downloaded again. If the given path lies inside an excluded folder, the parent
 folder will be included as well (but no other items inside it).
 """,
 )
-@click.argument("dropbox_path", type=DropboxPath())
+@click.argument("dropbox_path", type=DropboxPath(), nargs=-1)
 @inject_proxy(fallback=False, existing_config=True)
 @convert_api_errors
-def excluded_remove(m: Maestral, dropbox_path: str) -> None:
-    if dropbox_path == "/":
+def excluded_remove(m: Maestral, dropbox_paths: str) -> None:
+    if any(p == "/" for p in dropbox_paths):
         return echo("The root directory is always included")
 
-    m.include_item(dropbox_path)
-    ok(f"Included '{dropbox_path}'. Now downloading...")
+    m.include_items(*dropbox_paths)
+    for path in dropbox_paths:
+        ok(f"Included '{path}'")
+    ok("Downloading...")
 
 
 @click.group(help="Manage desktop notifications.")

--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -58,12 +58,11 @@ def excluded() -> None:
 @inject_proxy(fallback=True, existing_config=True)
 def excluded_list(m: Maestral) -> None:
     excluded_items = m.excluded_items
-    excluded_items.sort()
 
     if len(excluded_items) == 0:
         echo("No excluded files or folders.")
     else:
-        for item in excluded_items:
+        for item in sorted(excluded_items):
             echo(item)
 
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -43,7 +43,7 @@ from .core import (
     LinkAccessLevel,
     UpdateCheckResult,
 )
-from .sync import SyncDirection, SyncEngine
+from .sync import SyncDirection, SyncEngine, pf_repr
 from .manager import SyncManager
 from .models import SyncEvent, SyncErrorEntry, SyncStatus
 from .notify import MaestralDesktopNotifier
@@ -396,10 +396,15 @@ class Maestral:
     @property
     def excluded_items(self) -> set[str]:
         """
-        The list of files and folders excluded by selective sync. Any changes to this
-        list will be applied immediately if we have already performed the initial sync.
-        I.e., paths which have been added to the list will be deleted from the local
-        drive and paths which have been removed will be downloaded.
+        The list of files and folders excluded by selective sync.
+
+        Any changes to this list will be applied immediately if we have already
+        performed the initial sync. Paths which have been added to the list will be
+        deleted from the local drive and paths which have been removed will be
+        downloaded.
+
+        If the initial was not yet performed, changes will only be saved for the initial
+        sync.
 
         Use :meth:`exclude_item` and :meth:`include_item` to add or remove individual
         items from selective sync.
@@ -1075,19 +1080,19 @@ class Maestral:
         """
         Resets the sync index and state. Only call this to clean up leftover state
         information if a Dropbox was improperly unlinked (e.g., auth token has been
-        manually deleted). Otherwise leave state management to Maestral.
+        manually deleted). Otherwise, leave state management to Maestral.
 
         :raises NotLinkedError: if no Dropbox account is linked.
         """
         self._check_linked()
         self.manager.reset_sync_state()
 
-    def exclude_item(self, dbx_path: str) -> None:
+    def exclude_items(self, *dbx_paths: str) -> None:
         """
-        Excludes file or folder from sync and deletes it locally. It is safe to call
+        Excludes files or folders from sync and deletes it locally. It is safe to call
         this method with items which have already been excluded.
 
-        :param dbx_path: Dropbox path of item to exclude.
+        :param dbx_paths: Dropbox paths of items to exclude.
         :raises NotFoundError: if there is nothing at the given path.
         :raises ConnectionError: if the connection to Dropbox fails.
         :raises DropboxAuthError: in case of an invalid access token.
@@ -1099,38 +1104,34 @@ class Maestral:
         self._check_linked()
         self._check_dropbox_dir()
 
-        dbx_path_lower = normalize(dbx_path.rstrip("/"))
+        dbx_paths_lower = {normalize(p.rstrip("/")) for p in dbx_paths}
 
-        # ---- input validation --------------------------------------------------------
+        # ---- input cleanup -----------------------------------------------------------
+        excluded_items_old = self.sync.excluded_items
+        excluded_items_new = self.sync.clean_excluded_items_list(
+            excluded_items_old | dbx_paths_lower
+        )
 
-        md = self.client.get_metadata(dbx_path_lower)
+        excluded_items_added = excluded_items_new - excluded_items_old
 
-        if not md:
-            raise NotFoundError(
-                "Cannot exclude item", f'"{dbx_path_lower}" does not exist on Dropbox'
-            )
-
-        if self.sync.is_excluded_by_user(dbx_path_lower):
+        if len(excluded_items_added) == 0:
             return
 
+        # ---- apply changes -----------------------------------------------------------
         if self.sync.sync_lock.acquire(blocking=False):
             try:
-                # ---- update excluded items list --------------------------------------
-                excluded_items = self.sync.excluded_items
-                excluded_items.add(dbx_path_lower)
+                self.sync.excluded_items = excluded_items_new
 
-                self.sync.excluded_items = excluded_items
+                for dbx_path_lower in excluded_items_added:
+                    self._remove_after_excluded(dbx_path_lower)
+                    self._logger.info("Excluded %s", dbx_path_lower)
 
-                # ---- remove item from local Dropbox ----------------------------------
-                self._remove_after_excluded(dbx_path_lower)
-
-                self._logger.info("Excluded %s", dbx_path_lower)
                 self._logger.info(IDLE)
             finally:
                 self.sync.sync_lock.release()
 
         else:
-            raise BusyError("Cannot exclude item", "Please try again when idle.")
+            raise BusyError("Cannot add excluded items", "Please try again when idle.")
 
     def _remove_after_excluded(self, dbx_path_lower: str) -> None:
         # Perform housekeeping.
@@ -1149,9 +1150,9 @@ class Maestral:
         with self.manager.sync.fs_events.ignore(event_cls(local_path)):
             delete(local_path)
 
-    def include_item(self, dbx_path: str) -> None:
+    def include_items(self, *dbx_paths: str) -> None:
         """
-        Includes a file or folder in sync and downloads it in the background. It is safe
+        Includes files or folders in sync and downloads it in the background. It is safe
         to call this method with items which have already been included, they will not
         be downloaded again.
 
@@ -1163,7 +1164,7 @@ class Maestral:
         Any downloads will be carried out by the sync threads. Errors during the
         download can be accessed through :attr:`sync_errors` or :attr:`maestral_errors`.
 
-        :param dbx_path: Dropbox path of item to include.
+        :param dbx_paths: Dropbox paths of items to include.
         :raises NotFoundError: if there is nothing at the given path.
         :raises DropboxAuthError: in case of an invalid access token.
         :raises DropboxServerError: for internal Dropbox errors.
@@ -1174,56 +1175,46 @@ class Maestral:
         self._check_linked()
         self._check_dropbox_dir()
 
-        dbx_path_lower = normalize(dbx_path.rstrip("/"))
+        dbx_paths_lower = {normalize(p.rstrip("/")) for p in dbx_paths}
 
         # ---- input validation --------------------------------------------------------
-        md = self.client.get_metadata(dbx_path_lower)
-
-        if not md:
-            raise NotFoundError(
-                "Cannot include item",
-                f"'{dbx_path_lower}' does not exist on Dropbox",
-            )
-
-        if not self.sync.is_excluded_by_user(dbx_path_lower):
+        excluded_items = self.sync.excluded_items
+        newly_included_items = {
+            p for p in dbx_paths_lower if self.sync.is_excluded_by_user(p)
+        }
+        if len(newly_included_items) == 0:
             return
 
         # ---- update excluded items list ----------------------------------------------
-        excluded_items = self.sync.excluded_items
+        excluded_items.difference_update(newly_included_items)
 
-        # Remove dbx_path from list.
-        excluded_items.discard(dbx_path_lower)
+        # Find parent folders that should also be newly included.
+        for dbx_path_lower in newly_included_items.copy():
+            for folder in excluded_items.copy():
+                # Include all parents which are required to download dbx_path_lower.
+                if is_child(dbx_path_lower, folder):
+                    # Remove parent folder from excluded list.
+                    excluded_items.discard(folder)
+                    # Re-add their children (except parents of dbx_path_lower).
+                    for res in self.client.list_folder_iterator(folder):
+                        for entry in res.entries:
+                            if not is_equal_or_child(dbx_path_lower, entry.path_lower):
+                                excluded_items.add(entry.path_lower)
 
-        excluded_parent: str | None = None
+                    # Add the parent to the download list.
+                    newly_included_items.add(folder)
 
-        for folder in excluded_items.copy():
-            # Include all parents which are required to download dbx_path.
-            if is_child(dbx_path_lower, folder):
-                # Remove parent folders from excluded list.
-                excluded_items.remove(folder)
-                # Re-add their children (except parents of dbx_path).
-                for res in self.client.list_folder_iterator(folder):
-                    for entry in res.entries:
-                        if not is_equal_or_child(dbx_path_lower, entry.path_lower):
-                            excluded_items.add(entry.path_lower)
+                # Include all children of dbx_path_lower.
+                if is_child(folder, dbx_path_lower):
+                    excluded_items.discard(folder)
 
-                excluded_parent = folder
-
-            # Include all children of dbx_path.
-            if is_child(folder, dbx_path_lower):
-                excluded_items.remove(folder)
-
+        # ---- download items from Dropbox ---------------------------------------------
         if self.sync.sync_lock.acquire(blocking=False):
+            self._logger.debug("Excluded items old: %s", pf_repr(self.excluded_items))
+            self._logger.debug("Excluded items new: %s", pf_repr(excluded_items))
             try:
                 self.sync.excluded_items = excluded_items
-
-                # ---- download item from Dropbox --------------------------------------
-                if excluded_parent:
-                    self._logger.info(
-                        "Included '%s' and parent directories", dbx_path_lower
-                    )
-                    self.manager.download_queue.put(excluded_parent)
-                else:
+                for dbx_path_lower in newly_included_items:
                     self._logger.info("Included '%s'", dbx_path_lower)
                     self.manager.download_queue.put(dbx_path_lower)
             finally:

--- a/src/maestral/manager.py
+++ b/src/maestral/manager.py
@@ -487,10 +487,9 @@ class SyncManager:
 
                 # Migrate all excluded items.
                 self._logger.debug("Migrating excluded items")
-                new_excluded = [
+                self.sync.excluded_items = {
                     new_user_home_path + path for path in self.sync.excluded_items
-                ]
-                self.sync.excluded_items = new_excluded
+                }
 
             elif new_root_type == "user" and current_root_type == "team":
                 # User left a team.
@@ -533,13 +532,11 @@ class SyncManager:
                 # prefix from excluded items. If the user folder itself is
                 # excluded, keep it excluded.
                 self._logger.debug("Migrating excluded items")
-                new_excluded = [
+                self.sync.excluded_items = {
                     removeprefix(path, current_user_home_path_lower)
                     for path in self.sync.excluded_items
                     if is_child(path, current_user_home_path_lower)
-                ]
-
-                self.sync.excluded_items = new_excluded
+                }
 
             elif new_root_type == "team" and current_root_type == "team":
                 # User switched between different teams.
@@ -559,12 +556,11 @@ class SyncManager:
                 # Prune all teams folders from excluded list. If the user folder
                 # itself is excluded, keep it excluded.
                 self._logger.debug("Migrating excluded items")
-                new_excluded = [
+                self.sync.excluded_items = {
                     path
                     for path in self.sync.excluded_items
                     if is_equal_or_child(path, current_user_home_path_lower)
-                ]
-                self.sync.excluded_items = new_excluded
+                }
 
             # Update path root of client.
             self.sync.client.update_path_root(root_info)

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -148,6 +148,7 @@ __all__ = [
     "SyncEngine",
     "ActivityNode",
     "ActivityTree",
+    "pf_repr",
 ]
 
 umask = os.umask(0o22)
@@ -687,7 +688,7 @@ class SyncEngine:
         removed from the list. If only children are given but not the parent folder, any
         new items added to the parent will be synced. Change this property *before*
         downloading newly included items or deleting excluded items."""
-        return self._excluded_items
+        return self._excluded_items.copy()
 
     @excluded_items.setter
     def excluded_items(self, dbx_paths: Collection[str]) -> None:

--- a/tests/linked/integration/test_main.py
+++ b/tests/linked/integration/test_main.py
@@ -141,12 +141,11 @@ def test_move_dropbox_folder_to_existing(m: Maestral) -> None:
 # API integration tests
 
 
-def test_selective_sync(m: Maestral) -> None:
+def test_exclude_items(m: Maestral) -> None:
     """
     Tests :meth:`Maestral.exclude_item`, :meth:`MaestralMaestral.include_item`,
     :meth:`Maestral.excluded_status` and :meth:`Maestral.excluded_items`.
     """
-
     dbx_dirs = [
         "/selective_sync_test_folder",
         "/independent_folder",
@@ -163,16 +162,17 @@ def test_selective_sync(m: Maestral) -> None:
     wait_for_idle(m)
 
     # exclude "/selective_sync_test_folder" from sync
-    m.exclude_item("/selective_sync_test_folder")
+    m.exclude_items(
+        "/selective_sync_test_folder",
+        "/selective_sync_test_folder/subfolder_0",
+    )
     wait_for_idle(m)
 
     # check that local items have been deleted
     assert not osp.exists(m.to_local_path("/selective_sync_test_folder"))
 
     # check that `Maestral.excluded_items` only contains top-level folder
-    assert "/selective_sync_test_folder" in m.excluded_items
-    assert "/selective_sync_test_folder/subfolder_0" not in m.excluded_items
-    assert "/selective_sync_test_folder/subfolder_1" not in m.excluded_items
+    assert m.excluded_items == {"/selective_sync_test_folder"}
 
     # check that `Maestral.excluded_status` returns the correct values
     assert m.excluded_status("") == "partially excluded"
@@ -182,8 +182,24 @@ def test_selective_sync(m: Maestral) -> None:
         if dbx_path != "/independent_folder":
             assert m.excluded_status(dbx_path) == "excluded"
 
+
+def test_include_items(m: Maestral) -> None:
+    # create remote folder structure and exclude from sync
+    m.exclude_items("/selective_sync_test_folder")
+    dbx_dirs = [
+        "/selective_sync_test_folder",
+        "/independent_folder",
+        "/selective_sync_test_folder/subfolder_0",
+        "/selective_sync_test_folder/subfolder_1",
+    ]
+
+    for path in dbx_dirs:
+        m.sync.client.make_dir(path)
+
+    wait_for_idle(m)
+
     # include folder in sync, check that it worked
-    m.include_item("/selective_sync_test_folder")
+    m.include_items("/selective_sync_test_folder")
     wait_for_idle(m)
 
     assert osp.exists(m.to_local_path("/selective_sync_test_folder"))
@@ -192,9 +208,36 @@ def test_selective_sync(m: Maestral) -> None:
     for dbx_path in dbx_dirs:
         assert m.excluded_status(dbx_path) == "included"
 
-    # test excluding a non-existent folder
-    with pytest.raises(NotFoundError):
-        m.exclude_item("/bogus_folder")
+    # check for fatal errors
+    assert not m.fatal_errors
+
+
+def test_include_items_nested(m: Maestral) -> None:
+    """Tests special cases of nested selected sync changes."""
+    # create remote folder structure and exclude from sync
+    m.exclude_items("/selective_sync_test_folder")
+    dbx_dirs = [
+        "/selective_sync_test_folder",
+        "/independent_folder",
+        "/selective_sync_test_folder/subfolder_0",
+        "/selective_sync_test_folder/subfolder_1",
+    ]
+
+    for path in dbx_dirs:
+        m.sync.client.make_dir(path)
+
+    wait_for_idle(m)
+
+    # test including a folder inside "/selective_sync_test_folder",
+    # "/selective_sync_test_folder" should become included itself but
+    # its other children will still be excluded
+    m.include_items("/selective_sync_test_folder/subfolder_0")
+    wait_for_idle(m)
+
+    assert "/selective_sync_test_folder" not in m.excluded_items
+    assert "/selective_sync_test_folder/subfolder_1" in m.excluded_items
+    assert osp.exists(m.to_local_path("/selective_sync_test_folder/subfolder_0"))
+    assert not osp.exists(m.to_local_path("/selective_sync_test_folder/subfolder_1"))
 
     # check for fatal errors
     assert not m.fatal_errors
@@ -202,7 +245,6 @@ def test_selective_sync(m: Maestral) -> None:
 
 def test_selective_sync_global(m: Maestral) -> None:
     """Test :meth:`Maestral.exclude_items` to change all items at once."""
-
     dbx_dirs = [
         "/selective_sync_test_folder",
         "/independent_folder",
@@ -238,40 +280,6 @@ def test_selective_sync_global(m: Maestral) -> None:
     assert osp.exists(m.to_local_path("/selective_sync_test_folder"))
     assert osp.exists(m.to_local_path("/selective_sync_test_folder/subfolder_1"))
     assert m.excluded_items == {"/selective_sync_test_folder/subfolder_0"}
-
-    # check for fatal errors
-    assert not m.fatal_errors
-
-
-def test_selective_sync_nested(m: Maestral) -> None:
-    """Tests special cases of nested selected sync changes."""
-
-    dbx_dirs = [
-        "/selective_sync_test_folder",
-        "/independent_folder",
-        "/selective_sync_test_folder/subfolder_0",
-        "/selective_sync_test_folder/subfolder_1",
-    ]
-
-    local_dirs = [m.to_local_path(dbx_path) for dbx_path in dbx_dirs]
-
-    # create folder structure
-    for path in local_dirs:
-        os.mkdir(path)
-
-    wait_for_idle(m)
-
-    # exclude "/selective_sync_test_folder" from sync
-    m.exclude_item("/selective_sync_test_folder")
-    wait_for_idle(m)
-
-    # test including a folder inside "/selective_sync_test_folder",
-    # "/selective_sync_test_folder" should become included itself but
-    # its other children will still be excluded
-    m.include_item("/selective_sync_test_folder/subfolder_0")
-
-    assert "/selective_sync_test_folder" not in m.excluded_items
-    assert "/selective_sync_test_folder/subfolder_1" in m.excluded_items
 
     # check for fatal errors
     assert not m.fatal_errors

--- a/tests/linked/integration/test_main.py
+++ b/tests/linked/integration/test_main.py
@@ -219,25 +219,25 @@ def test_selective_sync_global(m: Maestral) -> None:
     wait_for_idle(m)
 
     # exclude "/selective_sync_test_folder" and one child from sync
-    m.excluded_items = [
+    m.excluded_items = {
         "/selective_sync_test_folder",
         "/selective_sync_test_folder/subfolder_0",
-    ]
+    }
     wait_for_idle(m)
 
     # check that local items have been deleted
     assert not osp.exists(m.to_local_path("/selective_sync_test_folder"))
 
     # check that `Maestral.excluded_items` has been updated correctly
-    assert m.excluded_items == ["/selective_sync_test_folder"]
+    assert m.excluded_items == {"/selective_sync_test_folder"}
 
     # exclude only child folder from sync, check that it worked
-    m.excluded_items = ["/selective_sync_test_folder/subfolder_0"]
+    m.excluded_items = {"/selective_sync_test_folder/subfolder_0"}
     wait_for_idle(m)
 
     assert osp.exists(m.to_local_path("/selective_sync_test_folder"))
     assert osp.exists(m.to_local_path("/selective_sync_test_folder/subfolder_1"))
-    assert m.excluded_items == ["/selective_sync_test_folder/subfolder_0"]
+    assert m.excluded_items == {"/selective_sync_test_folder/subfolder_0"}
 
     # check for fatal errors
     assert not m.fatal_errors

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -415,7 +415,7 @@ def test_excluded_folder_cleared_on_deletion(m: Maestral) -> None:
     wait_for_idle(m)
 
     # Exclude the folder from sync.
-    m.exclude_item(dbx_path)
+    m.exclude_items(dbx_path)
     wait_for_idle(m)
 
     assert normalize(dbx_path) in m.excluded_items
@@ -793,7 +793,7 @@ def test_selective_sync_conflict(m: Maestral) -> None:
     wait_for_idle(m)
 
     # exclude 'folder' from sync
-    m.exclude_item("/folder")
+    m.exclude_items("/folder")
     wait_for_idle(m)
 
     assert_synced(m, {})


### PR DESCRIPTION
This PR contains the following changes:

* Replace `Maestral.include_item()` and `Maestral.exclude_item()` with new APIs `Maestral.include_items()` and `Maestral.exclude_items()` that accept multiple paths.
* Update `Maestral.excluded_items` API to accept and return a set instead of a list. This better represents the semantics of excluded items, where the order is not important.
* Return a copy of excluded items from `Maestral.excluded_items` to prevent modifying the set in place. 
* Update CLI commands `excluded add` and `excluded remove` to accept multiple paths. See #958 for why this is useful.
* Split large selective sync tests into more specific test cases.