### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pytest --cov=maestral --cov-report=xml tests/offline
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: pytest
@@ -113,7 +113,7 @@ jobs:
           pytest -v --cov=maestral --cov-report=xml tests/linked/unit
 
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: pytest
@@ -186,7 +186,7 @@ jobs:
           pytest --verbose --cov=maestral --cov-report=xml tests/linked/integration --fs-observer ${{ matrix.observer }}
 
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: pytest


### PR DESCRIPTION
Reverts samschott/maestral#983. codecov-action v4 is still in beta, see https://github.com/codecov/codecov-action/issues/1089.