### PR TITLE
be more forgiving if follow_symlinks=False is not supported

### DIFF
--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -211,9 +211,6 @@ class Maestral:
 
     @staticmethod
     def _check_system_compatibility() -> None:
-        if os.stat not in os.supports_follow_symlinks:
-            raise RuntimeError("Maestral requires lstat support")
-
         if not (IS_MACOS or IS_LINUX):
             raise RuntimeError("Only macOS and Linux are supported")
 

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -370,7 +370,9 @@ def move(
         also a folder.
     :param raise_error: Whether to raise errors or return them.
     :param preserve_dest_permissions: Whether to apply the permissions of the source
-        path to the destination path. Permissions will not be set recursively.
+        path to the destination path. Permissions will not be set recursively and may
+        will be set for symlinks if this is not supported by the platform, i.e., if
+        ``os.chmod not in os.supports_follow_symlinks``.
     :returns: Any caught exception during the move.
     """
     err: Optional[OSError] = None

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -450,6 +450,10 @@ def test_excluded_folder_cleared_on_deletion(m: Maestral) -> None:
     assert_no_errors(m)
 
 
+@pytest.mark.skipif(
+    os.chmod not in os.supports_follow_symlinks,
+    reason="chmod does not support follow_symlinks=False",
+)
 def test_unix_permissions(m: Maestral) -> None:
     """
     Tests that a newly downloaded file is created with default permissions for our


### PR DESCRIPTION
If `follow_symlinks=False` is not supported for a file system call on the platform, either fall back to `follow_symlinks=True`, or skip the call if ok. In particular:

* `stat`: Use Python's `os.lstat`, which always falls back to `os.stat`. See https://docs.python.org/3/library/os.html#os.lstat.
* `chmod`: Don't call at all if `follow_symlinks=False` is not supported.
* `open`: Don't pass O_NOFOLLOW is not available.

Fixes #890.
