### PR TITLE
Preserve file metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "survey>=4.0,<6.0",
     "typing_extensions",
     "watchdog>=2.0.1",
+    "xattr",
 ]
 
 [project.readme]

--- a/src/maestral/sync.py
+++ b/src/maestral/sync.py
@@ -77,7 +77,6 @@ from .constants import (
     EXCLUDED_DIR_NAMES,
     MIGNORE_FILE,
     FILE_CACHE,
-    IS_MACOS,
 )
 from .exceptions import (
     SyncError,
@@ -3585,14 +3584,7 @@ class SyncEngine:
             # Preserve permissions of the destination file if we are only syncing an
             # update to the file content (Dropbox ID of the file remains the same).
             old_entry = self.get_index_entry(event.dbx_path_lower)
-            preserve_permissions = bool(old_entry and event.dbx_id == old_entry.dbx_id)
-
-            if preserve_permissions:
-                # Ignore FileModifiedEvent when changing permissions.
-                # Note that two FileModifiedEvents may be emitted on macOS.
-                ignore_events.append(FileModifiedEvent(event.local_path))
-                if IS_MACOS:
-                    ignore_events.append(FileModifiedEvent(event.local_path))
+            preserve_metadata = bool(old_entry and event.dbx_id == old_entry.dbx_id)
 
             if isfile(event.local_path):
                 # Ignore FileDeletedEvent when replacing old file.
@@ -3607,7 +3599,8 @@ class SyncEngine:
                     move(
                         tmp_fname,
                         event.local_path,
-                        preserve_dest_permissions=preserve_permissions,
+                        keep_target_permissions=preserve_metadata,
+                        keep_target_xattrs=preserve_metadata,
                         raise_error=True,
                     )
 

--- a/tests/linked/integration/test_sync.py
+++ b/tests/linked/integration/test_sync.py
@@ -450,10 +450,6 @@ def test_excluded_folder_cleared_on_deletion(m: Maestral) -> None:
     assert_no_errors(m)
 
 
-@pytest.mark.skipif(
-    os.chmod not in os.supports_follow_symlinks,
-    reason="chmod does not support follow_symlinks=False",
-)
 def test_unix_permissions(m: Maestral) -> None:
     """
     Tests that a newly downloaded file is created with default permissions for our


### PR DESCRIPTION
Preserve both file attributes (permissions) and extended attributes (Finder tags, etc) of local files when syncing.

Note that the extended attributes will not be synced to or from the server because this is not supported by the public Dropbox API. It _is_ supported by the proprietary client, see https://help.dropbox.com/sync/extended-attributes.

Fixes #1002.