### PR TITLE
Fix `excluded add | remove` CLI argument names

### DIFF
--- a/src/maestral/cli/cli_settings.py
+++ b/src/maestral/cli/cli_settings.py
@@ -70,7 +70,7 @@ def excluded_list(m: Maestral) -> None:
     name="add",
     help="Add files or folders to the excluded list and re-sync.",
 )
-@click.argument("dropbox_path", type=DropboxPath(), nargs=-1)
+@click.argument("dropbox_paths", type=DropboxPath(), nargs=-1)
 @inject_proxy(fallback=True, existing_config=True)
 @convert_api_errors
 def excluded_add(m: Maestral, dropbox_paths: list[str]) -> None:
@@ -92,7 +92,7 @@ not be downloaded again. If the given path lies inside an excluded folder, the p
 folder will be included as well (but no other items inside it).
 """,
 )
-@click.argument("dropbox_path", type=DropboxPath(), nargs=-1)
+@click.argument("dropbox_paths", type=DropboxPath(), nargs=-1)
 @inject_proxy(fallback=False, existing_config=True)
 @convert_api_errors
 def excluded_remove(m: Maestral, dropbox_paths: str) -> None:

--- a/src/maestral/cli/common.py
+++ b/src/maestral/cli/common.py
@@ -105,7 +105,7 @@ def inject_proxy(
                 proxy = ctx.with_resource(MaestralProxy(config_name, fallback=fallback))
             except CommunicationError:
                 click.echo("Maestral daemon is not running.")
-                ctx.exit(0)
+                ctx.exit(1)
             else:
                 return ctx.invoke(f, proxy, *args, **kwargs)
 

--- a/src/maestral/main.py
+++ b/src/maestral/main.py
@@ -1135,7 +1135,7 @@ class Maestral:
         self.sync.remove_node_from_index(dbx_path_lower)
         self.sync.clear_sync_errors_for_path(dbx_path_lower, recursive=True)
 
-        # Remove folder from local drive.
+        # Remove item from local drive.
         local_path_uncased = f"{self.dropbox_path}{dbx_path_lower}"
 
         try:

--- a/src/maestral/utils/path.py
+++ b/src/maestral/utils/path.py
@@ -217,8 +217,8 @@ def get_existing_equivalent_paths(
 
 def _macos_get_canonically_cased_path(path: str) -> str:
     # Use fcntl to get FS path, there can only be one.
-    fd = open(path, "a", opener=opener_no_symlink)
-    fs_path = fcntl.fcntl(fd.fileno(), F_GETPATH, b"\x00" * 1024)
+    with open(path, opener=opener_no_symlink) as fd:
+        fs_path = fcntl.fcntl(fd.fileno(), F_GETPATH, b"\x00" * 1024)
     return os.fsdecode(fs_path.strip(b"\x00"))
 
 

--- a/tests/offline/test_cli.py
+++ b/tests/offline/test_cli.py
@@ -147,6 +147,22 @@ def test_excluded_list(m: Maestral) -> None:
     assert result.output == "No excluded files or folders.\n"
 
 
+def test_excluded_add_raises_not_linked_error(m: Maestral) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["excluded", "add", "test", "-c", m.config_name])
+
+    assert result.exit_code == 1
+    assert "No Dropbox account linked" in result.output
+
+
+def test_excluded_remove_raises_not_running_error(m: Maestral) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["excluded", "remove", "test", "-c", m.config_name])
+
+    assert result.exit_code == 1
+    assert "Maestral daemon is not running" in result.output
+
+
 def test_notify_level(config_name: str) -> None:
     start_maestral_daemon_process(config_name, timeout=TEST_TIMEOUT)
     m = MaestralProxy(config_name)


### PR DESCRIPTION
Change CLI signature to `excluded add | remove [DROPBOX_PATHS]`, to match the implementing function's argument name.

Also add tests to prevent regressions and fix triggering fake sync events when adding excluded items on macOS.

Fixes #1030.