### PR TITLE
Test lock updates

### DIFF
--- a/tests/linked/conftest.py
+++ b/tests/linked/conftest.py
@@ -1,0 +1,52 @@
+import os
+import logging
+
+import pytest
+
+from maestral.client import DropboxClient
+from maestral.config import remove_configuration
+from maestral.exceptions import DropboxAuthError
+from maestral.keyring import CredentialStorage
+
+from .lock import DropboxTestLock
+
+
+fsevents_logger = logging.getLogger("fsevents")
+fsevents_logger.setLevel(logging.DEBUG)
+
+
+LOCK_PATH = "/test.lock"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def test_lock():
+    """
+    Returns a Dropbox client instance linked to a test account.
+
+    Acquires a lock on the account for the duration of the test session.
+    """
+    config_name = "test-lock-config"
+
+    cred_storage = CredentialStorage(config_name)
+    c = DropboxClient(config_name, cred_storage)
+
+    access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
+    refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
+    res = c.link(refresh_token=refresh_token, access_token=access_token)
+
+    if res == 1:
+        raise DropboxAuthError("Invalid token")
+    elif res == 2:
+        raise ConnectionError("Could not connect to Dropbox")
+    elif res > 0:
+        raise RuntimeError(f"[error {res}] linking failed")
+
+    lock = DropboxTestLock(c, LOCK_PATH)
+    if not lock.acquire():
+        raise TimeoutError("Could not acquire test lock")
+
+    yield lock
+
+    remove_configuration(config_name)
+    lock.release()
+    cred_storage.delete_creds()

--- a/tests/linked/integration/conftest.py
+++ b/tests/linked/integration/conftest.py
@@ -6,15 +6,12 @@ import pytest
 
 import maestral.manager
 from maestral.main import Maestral
+from maestral.client import DropboxClient
 from maestral.config import remove_configuration
 from maestral.utils.path import generate_cc_name, delete
 from maestral.utils.appdirs import get_home_dir
 from maestral.exceptions import NotFoundError, DropboxAuthError
 
-from ..lock import DropboxTestLock
-
-
-resources = os.path.dirname(os.path.dirname(__file__)) + "/resources"
 
 fsevents_logger = logging.getLogger("fsevents")
 fsevents_logger.setLevel(logging.DEBUG)
@@ -24,15 +21,44 @@ def pytest_addoption(parser):
     parser.addoption("--fs-observer", action="store", default="auto", dest="OBSERVER")
 
 
-@pytest.fixture
-def m(pytestconfig):
-    """
-    Returns a Maestral instance linked to a test account and syncing. Acquires a lock
-    on the account for the duration of the test and removes all items from the server
-    after completing the test.
-    """
+def clean_dropbox_dir(c: DropboxClient, lock_path: str) -> None:
+    for link in c.list_shared_links():
+        c.revoke_shared_link(link.url)
 
-    # Patch file event observer backend if requested.
+    res = c.list_folder("/", recursive=False)
+    for entry in res.entries:
+        if entry.path_lower == lock_path:
+            continue
+
+        try:
+            c.remove(entry.path_lower)
+        except NotFoundError:
+            pass
+
+
+def wait_for_idle(m: Maestral, cycles: int = 6) -> None:
+    """Blocks until Maestral instance is idle for at least ``cycles`` sync cycles."""
+
+    count = 0
+
+    while count < cycles:
+        if m.sync.busy():
+            # Wait until we can acquire the sync lock => we are idle.
+            m.sync.sync_lock.acquire()
+            m.sync.sync_lock.release()
+            count = 0
+        else:
+            time.sleep(1)
+            count += 1
+
+
+@pytest.fixture
+def m(pytestconfig, test_lock):
+    """
+    Returns a Maestral instance linked to a test account and syncing.
+
+    Acquires a lock on the account for the duration of the session.
+    """
     if pytestconfig.option.OBSERVER == "inotify":
         from watchdog.observers.inotify import InotifyObserver
 
@@ -50,13 +76,12 @@ def m(pytestconfig):
 
         maestral.manager.Observer = OrderedPollingObserver
 
-    # Initialize Maestral.
     config_name = "test-config"
 
     m = Maestral(config_name)
     m.log_level = logging.DEBUG
+    m.sync.max_cpu_percent = 20 * 100
 
-    # link with the given token
     access_token = os.environ.get("DROPBOX_ACCESS_TOKEN")
     refresh_token = os.environ.get("DROPBOX_REFRESH_TOKEN")
     res = m.link(refresh_token=refresh_token, access_token=access_token)
@@ -68,74 +93,20 @@ def m(pytestconfig):
     elif res > 0:
         raise RuntimeError(f"[error {res}] linking failed")
 
-    # set local Dropbox directory
     home = get_home_dir()
     local_dropbox_dir = generate_cc_name(home + "/Dropbox", suffix="test runner")
     m.create_dropbox_directory(local_dropbox_dir)
 
-    # acquire test lock and perform initial sync
-    lock = DropboxTestLock(m.client)
-    if not lock.acquire(timeout=60 * 60):
-        raise TimeoutError("Could not acquire test lock")
-
-    # clean dropbox directory
-    res = m.client.list_folder("/", recursive=False)
-    for entry in res.entries:
-        m.client.remove(entry.path_lower)
-
-    # disable throttling for tests
-    m.sync.max_cpu_percent = 20 * 100
-
-    # start syncing
+    clean_dropbox_dir(m.client, test_lock.lock_path)
     m.start_sync()
     wait_for_idle(m)
 
-    # return synced and running instance
     yield m
 
-    # stop syncing
     m.stop_sync()
+    clean_dropbox_dir(m.client, test_lock.lock_path)
     wait_for_idle(m)
+    delete(local_dropbox_dir)
 
-    # clean dropbox directory
-    res = m.client.list_folder("/", recursive=False)
-    for entry in res.entries:
-        try:
-            m.client.remove(entry.path_lower)
-        except NotFoundError:
-            pass
-
-    # remove all shared links
-    links = m.client.list_shared_links()
-
-    for link in links:
-        m.revoke_shared_link(link.url)
-
-    # remove local files and folders
-    delete(m.dropbox_path)
     remove_configuration(m.config_name)
-
-    # release lock
-    lock.release()
-
-    # remove creds from system keyring but don't unlink so that tokens remain valid
     m.cred_storage.delete_creds()
-
-
-# helper functions
-
-
-def wait_for_idle(m: Maestral, cycles: int = 6) -> None:
-    """Blocks until Maestral instance is idle for at least ``cycles`` sync cycles."""
-
-    count = 0
-
-    while count < cycles:
-        if m.sync.busy():
-            # Wait until we can acquire the sync lock => we are idle.
-            m.sync.sync_lock.acquire()
-            m.sync.sync_lock.release()
-            count = 0
-        else:
-            time.sleep(1)
-            count += 1

--- a/tests/linked/integration/conftest.py
+++ b/tests/linked/integration/conftest.py
@@ -59,6 +59,8 @@ def m(pytestconfig, test_lock):
 
     Acquires a lock on the account for the duration of the session.
     """
+    test_lock.renew()
+
     if pytestconfig.option.OBSERVER == "inotify":
         from watchdog.observers.inotify import InotifyObserver
 

--- a/tests/linked/integration/test_main.py
+++ b/tests/linked/integration/test_main.py
@@ -18,7 +18,6 @@ from maestral.exceptions import (
     InotifyError,
 )
 from maestral.constants import FileStatus, IDLE
-from maestral.utils.path import delete
 from maestral.utils.integration import get_inotify_limits
 
 
@@ -136,21 +135,15 @@ def test_move_dropbox_folder_to_itself(m: Maestral) -> None:
     assert m.running
 
 
-def test_move_dropbox_folder_to_existing(m: Maestral) -> None:
-    new_dir_short = "~/New Dropbox"
-    new_dir = osp.realpath(osp.expanduser(new_dir_short))
-    os.mkdir(new_dir)
+def test_move_dropbox_folder_to_existing(m: Maestral, tmp_path) -> None:
+    new_dir = tmp_path / "new_dbx_dir"
+    new_dir.mkdir()
 
-    try:
-        with pytest.raises(FileExistsError):
-            m.move_dropbox_directory(new_dir)
+    with pytest.raises(FileExistsError):
+        m.move_dropbox_directory(str(new_dir))
 
-        # assert that sync is still running
-        assert m.running
-
-    finally:
-        # cleanup
-        delete(new_dir)
+    # assert that sync is still running
+    assert m.running
 
 
 # API integration tests

--- a/tests/linked/lock.py
+++ b/tests/linked/lock.py
@@ -12,10 +12,10 @@ from maestral.errorhandling import convert_api_errors
 
 class DropboxTestLock:
     """
-    A lock on a Dropbox account for running sync tests. The lock will be acquired by
-    create a file at ``lock_path`` and released by deleting the file on the remote
-    Dropbox. This can be used to synchronise tests running on the same Dropbox account.
-    Lock files older than 1h are considered expired and will be discarded.
+    A lock on a Dropbox account to synchronize running tests.
+
+    The lock is acquired by creating a file at ``lock_path`` and released by deleting
+    the file on the remote Dropbox.
 
     :param client: Linked client instance.
     :param lock_path: Path for the lock folder.
@@ -26,8 +26,8 @@ class DropboxTestLock:
     def __init__(
         self,
         client: DropboxClient,
-        lock_path: str = "/test.lock",
-        expires_after: float = 15 * 60,
+        lock_path,
+        expires_after: float = 60 * 60,
     ) -> None:
         self.client = client
         self.lock_path = lock_path
@@ -47,13 +47,12 @@ class DropboxTestLock:
             If positive, blocking must be set to True.
         :returns: Whether the lock could be acquired (within timeout).
         """
-
         if not blocking and timeout > 0:
             raise ValueError("can't specify a timeout for a non-blocking call")
 
         t0 = time.time()
 
-        # we encode the expiry time in the client_modified time stamp
+        # we store the expiry time in the client_modified time stamp
         expiry_time = datetime.utcfromtimestamp(time.time() + self.expires_after)
 
         while True:
@@ -86,15 +85,12 @@ class DropboxTestLock:
 
         :returns: True if locked, False otherwise.
         """
-
         md = self.client.get_metadata(self.lock_path)
 
-        if not md:
+        if not md or not isinstance(md, FileMetadata):
             return False
 
-        elif isinstance(md, FileMetadata) and md.client_modified < datetime.now(
-            timezone.utc
-        ):
+        if md.client_modified < datetime.now(timezone.utc):
             # lock has expired, remove
             try:
                 self.client.remove(self.lock_path, parent_rev=md.rev)
@@ -103,8 +99,8 @@ class DropboxTestLock:
                 pass
 
             return False
-        else:
-            return True
+
+        return True
 
     def release(self) -> None:
         """

--- a/tests/linked/unit/conftest.py
+++ b/tests/linked/unit/conftest.py
@@ -51,6 +51,8 @@ def client(test_lock):
     """
     Returns a Dropbox client instance linked to a test account.
     """
+    test_lock.renew()
+
     config_name = "test-config"
 
     cred_storage = CredentialStorage(config_name)

--- a/tests/linked/unit/test_client.py
+++ b/tests/linked/unit/test_client.py
@@ -17,11 +17,12 @@ from maestral.exceptions import (
 from maestral.utils.path import normalize, content_hash
 from maestral.utils.hashing import DropboxContentHasher
 
-from .conftest import resources
-
 
 if not ("DROPBOX_ACCESS_TOKEN" in os.environ or "DROPBOX_REFRESH_TOKEN" in os.environ):
     pytest.skip("Requires auth token", allow_module_level=True)
+
+
+resources = os.path.dirname(os.path.dirname(__file__)) + "/resources"
 
 
 # Client API unit tests: we currently test those method calls which are not covered


### PR DESCRIPTION
* Fix an issue with the test lock being deleted in cleanup before test case.
* Simplify pytest fixtures.
* Aquire lock on per-session instead of per-test-case.
* Aquire lock for a max timeout of 10 min and renew for another 10 min for each test case.