### PR TITLE
[daemon] Add unitialized Start state

### DIFF
--- a/src/maestral/daemon.py
+++ b/src/maestral/daemon.py
@@ -113,6 +113,7 @@ class Start(enum.Enum):
     Ok = 0
     AlreadyRunning = 1
     Failed = 2
+    Uninitialized = 3
 
 
 # ==== error serialization =============================================================


### PR DESCRIPTION
Closes #1147 and [#33](https://github.com/samschott/maestral-qt/issues/33#issue-3765347249).

Adds an additional initialized state to the `maestral.daemon.Start` class to pass through to `maestral_qt.main.run()`.
Used prior to `maestral.daemon` startup.